### PR TITLE
new configure --with-pkg-config-dir

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -5,6 +5,7 @@ libdir		= @libdir@
 datarootdir	= @datarootdir@
 datadir		= @datadir@
 includedir	= @includedir@
+pkgconfigdir	= @PKGCONFIGDIR@
 
 CC		= @CC@
 PROG		= pkgconf@EXEEXT@
@@ -12,7 +13,7 @@ SRCS		= main.c pkg.c bsdstubs.c getopt_long.c fragment.c argvsplit.c fileio.c tu
 OBJS		= ${SRCS:.c=.o}
 CFLAGS		= @CFLAGS@
 LDFLAGS		= @LDFLAGS@
-CFLAGS		+= -DLIBDIR=\"${libdir}\" -DINCLUDEDIR=\"${includedir}\" -DPKG_DEFAULT_PATH=\"${libdir}/pkgconfig:${datadir}/pkgconfig\" -Wall -Wextra -Wformat=2 -std=gnu99 -D_FORTIFY_SOURCE=2
+CFLAGS		+= -DLIBDIR=\"${libdir}\" -DINCLUDEDIR=\"${includedir}\" -DPKG_DEFAULT_PATH=\"${pkgconfigdir}\" -Wall -Wextra -Wformat=2 -std=gnu99 -D_FORTIFY_SOURCE=2
 
 all: build
 build: ${PROG}

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,7 @@ AC_CONFIG_SRCDIR([pkg.c])
 AC_CONFIG_HEADERS([config.h])
 AC_CHECK_FUNCS([strlcpy strlcat strndup])
 
+
 AC_ARG_ENABLE([strict],
 	      [AC_HELP_STRING([--enable-strict],
 			     [enable POSIX-strict argument checking and disable some workarounds])],
@@ -33,6 +34,13 @@ else
 fi
 
 AC_SUBST([STRICT_MODE])
+
+AC_ARG_WITH([pkg-config-dir],[AC_HELP_STRING([--with-pkg-config-dir],[specify
+	     the place where pc files will be found])],PKGCONFIGDIR="$withval",
+	     PKGCONFIGDIR="${libdir}/pkgconfig:${datadir}/pkgconfig")
+
+AC_SUBST([PKGCONFIGDIR])
+
 
 AC_PROG_CPP
 AC_PROG_CC


### PR DESCRIPTION
Allow one to configure the place where pc files are store, it default on
${libdir}/pkgconfig:${datadir}/pkgconfig

--with-pkg-config-dir is modeled over what can be found in some other configure scripts
