### PR TITLE
Fix crash when specified filename has no path separators

### DIFF
--- a/pkg.c
+++ b/pkg.c
@@ -131,8 +131,8 @@ pkg_get_parent_dir(pkg_t *pkg)
 	char *pathbuf;
 
 	strlcpy(buf, pkg->filename, sizeof buf);
-	pathbuf = strrchr(buf, PKG_DIR_SEP_S);
-	pathbuf[0] = '\0';
+	if ((pathbuf = strrchr(buf, PKG_DIR_SEP_S)) != NULL)
+		pathbuf[0] = '\0';
 
 	return buf;
 }
@@ -154,8 +154,10 @@ pkg_new_from_file(const char *filename, FILE *f)
 	pkg->vars = pkg_tuple_add(pkg->vars, "pcfiledir", pkg_get_parent_dir(pkg));
 
 	/* make module id */
-	idptr = strrchr(pkg->filename, PKG_DIR_SEP_S);
-	idptr++;
+	if ((idptr = strrchr(pkg->filename, PKG_DIR_SEP_S)) != NULL)
+		idptr++;
+	else
+		idptr = pkg->filename;
 
 	pkg->id = strdup(idptr);
 	idptr = strrchr(pkg->id, '.');


### PR DESCRIPTION
When running `pkgconf` without any path separators, a crash occurs. This happens when compiling Unreal3.2 with libtre:
## tre.pc

<pre>

prefix=/usr/home/bryan/Unreal3.2/extras/regexp
exec_prefix=${prefix}
libdir=${exec_prefix}/lib
includedir=${prefix}/include

Name: TRE
Description: TRE regexp matching library
Version: 0.8.0
Libs: -L${libdir} -ltre
Cflags: -I${includedir}
</pre>


<pre>
$ pkgconf tre.pc
Segmentation fault: 11 (core dumped)
</pre>
