### PR TITLE
Fix tests when SHELL=bash

### DIFF
--- a/tests/run.sh.in
+++ b/tests/run.sh.in
@@ -18,7 +18,7 @@ run_test() {
 		shift
 
 		case "${res}" in
-			*${1}*)
+			*"${1}"*)
 				;;
 			*)
 				echo


### PR DESCRIPTION
The QUOTED test was failing to properly recognize
the expected output.

<pre>

/bin/bash tests/run.sh ./pkgconf
...................................................
***********************
!!! Test 51 failed.
!!! $ PKG_CONFIG_PATH=/root/git/pkgconf/tests/lib1 ./pkgconf --cflags quotes
!!! -DQUOTED=\"bla\"
!!! expected '-DQUOTED=\"bla\"' in output
***********************
.....
1 of 57 tests failed. See output for details.
*** Error code 1

Stop in /root/git/pkgconf.
</pre>


Tested patch with sh, bash and zsh:

<pre>
# zsh tests/run.sh ./pkgconf
.........................................................
57 tests done. All succeeded.

# sh tests/run.sh ./pkgconf
.........................................................
57 tests done. All succeeded.

# bash tests/run.sh ./pkgconf
.........................................................
57 tests done. All succeeded.
</pre>
