### PR TITLE
Remove needless / after $(DESTDIR)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -25,10 +25,10 @@ clean:
 	rm $(PROG)
 
 install:
-	mkdir -p $(DESTDIR)/$(bindir)
-	install -c -m755 $(PROG) $(DESTDIR)/$(bindir)/$(PROG)
-	mkdir -p $(DESTDIR)/$(datarootdir)/aclocal
-	install -c -m644 pkg.m4 $(DESTDIR)/$(datarootdir)/aclocal/pkg.m4
+	mkdir -p $(DESTDIR)$(bindir)
+	install -c -m755 $(PROG) $(DESTDIR)$(bindir)/$(PROG)
+	mkdir -p $(DESTDIR)$(datarootdir)/aclocal
+	install -c -m644 pkg.m4 $(DESTDIR)$(datarootdir)/aclocal/pkg.m4
 
 check: $(PROG)
 	$(SHELL) tests/run.sh ./$(PROG)


### PR DESCRIPTION
Makefile.in has / after $(DESTDIR) and this fails installing on MSYS(MinGW),
because it tries to install to //usr/local/bin and // has a special meaning on MinGW.

Please remove / after $(DESTDIR).
