### PR TITLE
Feature Request: Add Cflags.private fragment

### DIFF
--- a/pkg.h
+++ b/pkg.h
@@ -95,6 +95,7 @@ struct pkg_ {
 	pkg_list_t libs;
 	pkg_list_t libs_private;
 	pkg_list_t cflags;
+	pkg_list_t cflags_private;
 
 	pkg_list_t requires;
 	pkg_list_t requires_private;

--- a/tests/lib1/foo.pc
+++ b/tests/lib1/foo.pc
@@ -8,3 +8,4 @@ Description: A testing pkg-config file
 Version: 1.2.3
 Libs: -L${libdir} -lfoo
 Cflags: -fPIC -I${includedir}/foo
+Cflags.private: -DFOO_STATIC

--- a/tests/run.sh.in
+++ b/tests/run.sh.in
@@ -114,6 +114,8 @@ run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --static --libs baz" \
 	'-lfoo' '-lbaz' '-lzee'
 run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --static --libs argv-parse-2" \
 	'-pthread '
+run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --static --cflags baz" \
+	'-fPIC' '-I/usr/include/foo' '-DFOO_STATIC'
 
 # 4) tests for parser bugs
 run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --libs dos-lineendings" \


### PR DESCRIPTION
Hi,

This is [copied from the freedesktop request](https://bugs.freedesktop.org/show_bug.cgi?id=47996).

The Libs.private setting is a very handy way to handle static as well as shared library builds.

However, when (cross-)compiling for the Windows platform, this is not always sufficient. The libraries need extra "dllexport" declarations in the headers when building a shared library. Those can usually be suppressed (for static linking) by something like -DTHISLIBRARY_STATIC. It would avoid lots of nasty code if "pkg-config --cflags --static" could take care of that. It might be as simple as:

Cflags.private: -DTHISLIBRARY_STATIC

These changes are a naive implementation of the required behaviour - it basically mimics that of Libs.private.

``` sh
pkgconf --cflags baz
-fPIC -I/usr/include/foo

pkgconf --cflags --static baz
-fPIC -I/usr/include/foo -DFOO_STATIC
```

I understand there is a [spec in progress](http://dev.gentoo.org/~mgorny/pkg-config-spec.html), but this functionality would be very handy at the moment.

Thanks,

Tony
