### PR TITLE
Add test for multiple dependencies on base package

### DIFF
--- a/tests/lib1/private-libs-duplication.pc
+++ b/tests/lib1/private-libs-duplication.pc
@@ -1,6 +1,6 @@
 Name: private-libs-duplication
 Version: 1.0
-Requires: bar
+Requires: baz bar
 Libs: -lprivate
 Libs.private: -lfoo
 

--- a/tests/run.sh.in
+++ b/tests/run.sh.in
@@ -117,7 +117,7 @@ run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --static --libs argv-parse-2" \
 run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --static --cflags baz" \
 	'-fPIC' '-I/usr/include/foo' '-DFOO_STATIC'
 run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --static --libs-only-l private-libs-duplication" \
-	'-lprivate -lbar -lfoo'
+	'-lprivate -lbaz -lzee -lbar -lfoo'
 
 # 4) tests for parser bugs
 run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --libs dos-lineendings" \


### PR DESCRIPTION
This is just a demonstration following on from #51. When there are multiple dependencies on the same lib:

private-libs-duplication --> baz bar
baz --> foo
bar --> foo

`foo` should be moved along to the end.

Current output is:

```
-lprivate -lbaz -lfoo -lbar -lzee
```

expected is:

```
-lprivate -lbaz -lzee -lbar -lfoo
```
