### PR TITLE
Test failure with default prefix and parsing of keep-system-* args

### DIFF
--- a/main.c
+++ b/main.c
@@ -62,10 +62,10 @@ fragment_has_system_dir(pkg_fragment_t *frag)
 	switch (frag->type)
 	{
 	case 'L':
-		if ((want_flags & PKG_KEEP_SYSTEM_CFLAGS) == 0 && !strcasecmp(SYSTEM_LIBDIR, frag->data))
+		if ((want_flags & PKG_KEEP_SYSTEM_LIBS) == 0 && !strcasecmp(SYSTEM_LIBDIR, frag->data))
 			return true;
 	case 'I':
-		if ((want_flags & PKG_KEEP_SYSTEM_LIBS) == 0 && !strcasecmp(SYSTEM_INCLUDEDIR, frag->data))
+		if ((want_flags & PKG_KEEP_SYSTEM_CFLAGS) == 0 && !strcasecmp(SYSTEM_INCLUDEDIR, frag->data))
 			return true;
 	default:
 		break;

--- a/tests/run.sh.in
+++ b/tests/run.sh.in
@@ -136,7 +136,7 @@ run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --cflags tilde-quoting" \
 # 5) tests for other regressions
 run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --variable=includedir foo" \
 	'/usr/include'
-run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --libs-only-L cflags-libs-only" \
+run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --libs-only-L --keep-system-libs cflags-libs-only" \
 	'-L/usr/local/lib'
 run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --libs-only-L --libs-only-l cflags-libs-only" \
 	'-lfoo'


### PR DESCRIPTION
Hi,

I was seeing a test failure when configured with the default `--prefix=/usr/local`. The test was supposed to return `-L/usr/local/lib`, but was returning nothing without specifying the (counter-intuitive) `--keep-system-cflags`. It looks like the parsing of these options was transposed.

Cheers,

Tony
