### PR TITLE
Support .pc file without a trailing newline

### DIFF
--- a/fileio.c
+++ b/fileio.c
@@ -83,10 +83,18 @@ pkg_fgetline(char *line, size_t size, FILE *stream)
 
 	}
 
-	*s = '\0';
-
 	if (c == EOF && (s == line || ferror(stream)))
 		return NULL;
+
+	*s = '\0';
+
+	/* Remove newline character. */
+	if (s > line && *(--s) == '\n') {
+		*s = '\0';
+
+		if (s > line && *(--s) == '\r')
+			*s = '\0';
+	}
 
 	return line;
 }

--- a/pkg.c
+++ b/pkg.c
@@ -212,8 +212,6 @@ pkg_new_from_file(const char *filename, FILE *f, unsigned int flags)
 	{
 		char op, *p, *key, *value;
 
-		readbuf[strlen(readbuf) - 1] = '\0';
-
 		p = readbuf;
 		while (*p && (isalpha(*p) || isdigit(*p) || *p == '_' || *p == '.'))
 			p++;

--- a/tests/lib1/no-trailing-newline.pc
+++ b/tests/lib1/no-trailing-newline.pc
@@ -1,0 +1,10 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: no-trailing-newline
+Description: A testing pkg-config file
+Version: 1.2.3
+Libs: -L${libdir}/no-trailing-newline -lno-trailing-newline
+Cflags: -I${includedir}/no-trailing-newline

--- a/tests/run.sh.in
+++ b/tests/run.sh.in
@@ -122,6 +122,8 @@ run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --static --libs-only-l private-
 # 4) tests for parser bugs
 run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --libs dos-lineendings" \
 	'-L/usr/lib/dos-lineendings -ldos-lineendings'
+run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --cflags no-trailing-newline" \
+	'-I/usr/include/no-trailing-newline'
 run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --libs argv-parse" \
 	'-llib-2 -lpthread'
 run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --exists -foo; echo \$?" \


### PR DESCRIPTION
Some editors write text files without a newline character at the end of the last line.

Before this change, the main loop in `pkg_new_from_file()` expected a newline character at the end of the line and overwrote it with a NUL character. In the case of the last line in a non-newline-terminated file, this ate the last character of that line.

Now, the `pkg_fgetline()` function takes care of returning a line without the newline character (or the `\r\n` sequence in case of a DOS file format).

This happens with `cppunit.pc` from the [CppUnit](http://sourceforge.net/projects/cppunit/) project.
