### PR TITLE
Preserve double and single quotes in library / framework names

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -72,5 +72,10 @@ noinst_HEADERS   = getopt_long.h
 
 dist_doc_DATA = README.md AUTHORS
 
-check: pkgconf
+EXTRA_PROGRAMS = unit_tests
+unit_tests_SOURCES = libpkgconf/tests/argvsplit-test.c
+unit_tests_LDADD   = libpkgconf.la
+
+check: pkgconf unit_tests
+	./unit_tests
 	$(SHELL) tests/run.sh ./pkgconf

--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ EXTRA_DIST =	\
 		tests/lib1/prefix-foo2.pc \
 		tests/lib1/bar.pc \
 		tests/lib1/framework-2.pc \
+		tests/lib1/framework-3.pc \
 		tests/lib1/private-libs-duplication.pc \
 		tests/lib1/baz.pc \
 		tests/lib1/incomplete.pc \
@@ -75,6 +76,8 @@ dist_doc_DATA = README.md AUTHORS
 EXTRA_PROGRAMS = unit_tests
 unit_tests_SOURCES = libpkgconf/tests/argvsplit-test.c
 unit_tests_LDADD   = libpkgconf.la
+
+CLEANFILES = $(EXTRA_PROGRAMS)
 
 check: pkgconf unit_tests
 	./unit_tests

--- a/libpkgconf/argvsplit.c
+++ b/libpkgconf/argvsplit.c
@@ -42,8 +42,10 @@ pkgconf_argv_split(const char *src, int *argc, char ***argv)
 
 	while (*src_iter)
 	{
-		if (quote == *src_iter)
+		if (quote == *src_iter) {
 			quote = 0;
+			*dst_iter++ = *src_iter;
+		}
 		else if (quote)
 		{
 			if (*src_iter == '\\')
@@ -81,6 +83,7 @@ pkgconf_argv_split(const char *src, int *argc, char ***argv)
 			case '"':
 			case '\'':
 				quote = *src_iter;
+				*dst_iter++ = *src_iter;
 				break;
 
 			case '\\':

--- a/libpkgconf/tests/argvsplit-test.c
+++ b/libpkgconf/tests/argvsplit-test.c
@@ -1,0 +1,34 @@
+#include <stdio.h>
+#include <assert.h>
+
+#include "../libpkgconf.h"
+
+void test_simple()
+{
+	int argc;
+	char **argv;
+
+	pkgconf_argv_split("A B", &argc, &argv);
+	assert(argc == 2);
+	assert(!strcmp(argv[0], "A"));
+	assert(!strcmp(argv[1], "B"));
+	pkgconf_argv_free(argv);
+}
+
+void test_escaped()
+{
+	int argc;
+	char **argv;
+
+	pkgconf_argv_split("A\\ B", &argc, &argv);
+	assert(argc == 1);
+	assert(!strcmp(argv[0], "A\\ B"));
+	pkgconf_argv_free(argv);
+}
+
+int main(int argc, char **argv)
+{
+	(void) argc; (void) argv;
+	test_simple();
+	test_escaped();
+}

--- a/libpkgconf/tests/argvsplit-test.c
+++ b/libpkgconf/tests/argvsplit-test.c
@@ -26,9 +26,21 @@ void test_escaped()
 	pkgconf_argv_free(argv);
 }
 
+void test_quoted()
+{
+	int argc;
+	char **argv;
+
+	pkgconf_argv_split("\"A B\"", &argc, &argv);
+	assert(argc == 1);
+	assert(!strcmp(argv[0], "\"A B\""));
+	pkgconf_argv_free(argv);
+}
+
 int main(int argc, char **argv)
 {
 	(void) argc; (void) argv;
 	test_simple();
 	test_escaped();
+	test_quoted();
 }

--- a/tests/lib1/framework-3.pc
+++ b/tests/lib1/framework-3.pc
@@ -1,0 +1,9 @@
+prefix=/test
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: framework-3
+Description: pkg-config with space in framework name
+Version: 1.3
+Libs: -F${libdir} -framework "Spacey Framework"

--- a/tests/lib1/quotes.pc
+++ b/tests/lib1/quotes.pc
@@ -6,5 +6,5 @@ includedir=${prefix}/include
 Name: quotes
 Description: A testing pkg-config file
 Version: 1.2.3
-Libs: -L${libdir} -lfoo\ bar
+Libs: -L${libdir} -lfoo\ bar "-lfoobie bletch"
 Cflags: -DQUOTED=\"bla\"

--- a/tests/lib1/quotes.pc
+++ b/tests/lib1/quotes.pc
@@ -6,5 +6,5 @@ includedir=${prefix}/include
 Name: quotes
 Description: A testing pkg-config file
 Version: 1.2.3
-Libs: -L${libdir} -lfoo
+Libs: -L${libdir} -lfoo\ bar
 Cflags: -DQUOTED=\"bla\"

--- a/tests/run.sh.in
+++ b/tests/run.sh.in
@@ -221,7 +221,7 @@ run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --list-all | grep -q 'multiline
 run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --cflags quotes" \
 	"-DQUOTED=\\\"bla\\\""
 run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --libs quotes" \
-	'-lfoo\ bar'
+	'-lfoo\ bar "-lfoobie bletch"'
 
 run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --libs nolib; echo \$?" \
 	'0'
@@ -241,6 +241,8 @@ run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --libs framework-2" \
 	"-F/test/lib -framework framework-2 -framework framework-1"
 run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --libs framework-1 framework-2" \
 	"-F/test/lib -framework framework-1 -framework framework-2"
+run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --libs framework-3" \
+	'-F/test/lib -framework "Spacey Framework"'
 
 run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --exists --print-errors 'foo > 0.6.0 foo < 0.8.0'; echo \$?" \
 	'1'

--- a/tests/run.sh.in
+++ b/tests/run.sh.in
@@ -220,6 +220,8 @@ run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --list-all | grep -q 'multiline
 # test quoted #35
 run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --cflags quotes" \
 	"-DQUOTED=\\\"bla\\\""
+run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --libs quotes" \
+	'-lfoo\ bar'
 
 run_test "PKG_CONFIG_PATH='${selfdir}/lib1' ${1} --libs nolib; echo \$?" \
 	'0'


### PR DESCRIPTION
pkg-config supports .pc files containing e.g.
```
Libs: -F${libdir}/cefclient.app/Contents/Frameworks -framework 'Chromium Embedded Framework'
```
and preserves the quotes.  pkgconf should do the same.

And what the heck, a unit test for argvsplit to check its behavior in this area seemed like a good idea.