### PR TITLE
tests: minor cleanups

### DIFF
--- a/tests/run.sh.in
+++ b/tests/run.sh.in
@@ -41,7 +41,7 @@ run_test() {
 	done=$(( done + 1 ))
 }
 
-selfdir=@abs_srcdir@
+selfdir="@abs_srcdir@"
 
 PATH_SEP=":"
 SYSROOT_DIR="${selfdir}/test"

--- a/tests/run.sh.in
+++ b/tests/run.sh.in
@@ -34,7 +34,7 @@ run_test() {
 	done
 
 	if [ ${t_ret} -eq 0 ]; then
-		echo -n "."
+		printf "."
 	else
 		failed=$(( failed + 1 ))
 	fi


### PR DESCRIPTION
Please also checkout what happens when module contains space at one of its components, it seems like pkgconf does not support that, maybe standard does not support this case.

```
./pkgconf --modversion '/tmp/pkgconf a/tests/lib1/foo.pc'
Package /tmp/pkgconf was not found in the pkg-config search path.
````