### PR TITLE
pass client and user data to error handler

### DIFF
--- a/libpkgconf/client.c
+++ b/libpkgconf/client.c
@@ -38,11 +38,13 @@
  *
  *    :param pkgconf_client_t* client: The client to initialise.
  *    :param pkgconf_error_handler_func_t error_handler: An optional error handler to use for logging errors.
+ *    :param void * error_handler_data: user data passed to optional error handler
  *    :return: nothing
  */
 void
-pkgconf_client_init(pkgconf_client_t *client, pkgconf_error_handler_func_t error_handler)
+pkgconf_client_init(pkgconf_client_t *client, pkgconf_error_handler_func_t error_handler, void *error_handler_data)
 {
+	client->error_handler_data = error_handler_data;
 	client->error_handler = error_handler;
 	client->auditf = NULL;
 
@@ -58,14 +60,15 @@ pkgconf_client_init(pkgconf_client_t *client, pkgconf_error_handler_func_t error
  *    Allocate and initialise a pkgconf client object.
  *
  *    :param pkgconf_error_handler_func_t error_handler: An optional error handler to use for logging errors.
+ *    :param void * error_handler_data: user data passed to optional error handler
  *    :return: A pkgconf client object.
  *    :rtype: pkgconf_client_t*
  */
 pkgconf_client_t *
-pkgconf_client_new(pkgconf_error_handler_func_t error_handler)
+pkgconf_client_new(pkgconf_error_handler_func_t error_handler, void *error_handler_data)
 {
 	pkgconf_client_t *out = calloc(sizeof(pkgconf_client_t), 1);
-	pkgconf_client_init(out, error_handler);
+	pkgconf_client_init(out, error_handler, error_handler_data);
 	return out;
 }
 

--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -131,7 +131,7 @@ struct pkgconf_pkg_ {
 typedef bool (*pkgconf_pkg_iteration_func_t)(const pkgconf_pkg_t *pkg, void *data);
 typedef void (*pkgconf_pkg_traverse_func_t)(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *data, unsigned int flags);
 typedef bool (*pkgconf_queue_apply_func_t)(pkgconf_client_t *client, pkgconf_pkg_t *world, void *data, int maxdepth, unsigned int flags);
-typedef bool (*pkgconf_error_handler_func_t)(const char *msg);
+typedef bool (*pkgconf_error_handler_func_t)(const char *msg, const pkgconf_client_t *client, const void *data);
 
 struct pkgconf_client_ {
 	pkgconf_list_t dir_list;
@@ -144,6 +144,7 @@ struct pkgconf_client_ {
 
 	pkgconf_list_t global_vars;
 
+	void *error_handler_data;
 	pkgconf_error_handler_func_t error_handler;
 
 	FILE *auditf;
@@ -153,8 +154,8 @@ struct pkgconf_client_ {
 };
 
 /* client.c */
-void pkgconf_client_init(pkgconf_client_t *client, pkgconf_error_handler_func_t error_handler);
-pkgconf_client_t *pkgconf_client_new(pkgconf_error_handler_func_t error_handler);
+void pkgconf_client_init(pkgconf_client_t *client, pkgconf_error_handler_func_t error_handler, void *error_handler_data);
+pkgconf_client_t *pkgconf_client_new(pkgconf_error_handler_func_t error_handler, void *error_handler_data);
 void pkgconf_client_deinit(pkgconf_client_t *client);
 void pkgconf_client_free(pkgconf_client_t *client);
 const char *pkgconf_client_get_sysroot_dir(const pkgconf_client_t *client);
@@ -195,7 +196,7 @@ void pkgconf_client_set_buildroot_dir(pkgconf_client_t *client, const char *buil
 #endif /* defined(__INTEL_COMPILER) || defined(__GNUC__) */
 
 bool pkgconf_error(const pkgconf_client_t *client, const char *format, ...) PRINTFLIKE(2, 3);
-bool pkgconf_default_error_handler(const char *msg);
+bool pkgconf_default_error_handler(const char *msg, const pkgconf_client_t *client, const void *data);
 
 pkgconf_pkg_t *pkgconf_pkg_ref(const pkgconf_client_t *client, pkgconf_pkg_t *pkg);
 void pkgconf_pkg_unref(pkgconf_client_t *client, pkgconf_pkg_t *pkg);

--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -25,13 +25,15 @@ pkgconf_error(const pkgconf_client_t *client, const char *format, ...)
 	vsnprintf(errbuf, sizeof errbuf, format, va);
 	va_end(va);
 
-	return client->error_handler(errbuf);
+	return client->error_handler(errbuf, client, client->error_handler_data);
 }
 
 bool
-pkgconf_default_error_handler(const char *msg)
+pkgconf_default_error_handler(const char *msg, const pkgconf_client_t *client, const void *data)
 {
 	(void) msg;
+	(void) client;
+	(void) data;
 
 	return true;
 }

--- a/main.c
+++ b/main.c
@@ -66,8 +66,10 @@ FILE *error_msgout = NULL;
 FILE *logfile_out = NULL;
 
 static bool
-error_handler(const char *msg)
+error_handler(const char *msg, const pkgconf_client_t *client, const void *data)
 {
+	(void) client;
+	(void) data;
 	fprintf(error_msgout, "%s", msg);
 	return true;
 }
@@ -682,7 +684,7 @@ main(int argc, char *argv[])
 		{ NULL, 0, NULL, 0 }
 	};
 
-	pkgconf_client_init(&pkg_client, error_handler);
+	pkgconf_client_init(&pkg_client, error_handler, NULL);
 	pkgconf_path_build_from_environ("PKG_CONFIG_SYSTEM_LIBRARY_PATH", SYSTEM_LIBDIR, &filter_libdirs);
 	pkgconf_path_build_from_environ("PKG_CONFIG_SYSTEM_INCLUDE_PATH", SYSTEM_INCLUDEDIR, &filter_includedirs);
 


### PR DESCRIPTION
Would it be possible to pass in the client object and some user data into the error handler?  This will help me route errors to the appropriate client object.