### PR TITLE
stdinc.h: fix build with mingw

### DIFF
--- a/libpkgconf/stdinc.h
+++ b/libpkgconf/stdinc.h
@@ -33,10 +33,18 @@
 # include <malloc.h>
 # define PATH_DEV_NULL	"nul"
 # ifndef ssize_t
+# ifndef __MINGW32__
 #  include <BaseTsd.h>
+# else
+#  include <basetsd.h>
+# endif
 #  define ssize_t SSIZE_T
 # endif
-# include "win-dirent.h"
+# ifndef __MINGW32__
+#  include "win-dirent.h"
+# else
+# include <dirent.h>
+# endif
 #else
 # define PATH_DEV_NULL	"/dev/null"
 # include <dirent.h>


### PR DESCRIPTION
Fixes this build error with mingw:
...
| compilation terminated.
| In file included from ../pkgconf-1.3.7/libpkgconf/libpkgconf.h:19:0,
| from ../pkgconf-1.3.7/libpkgconf/audit.c:16:
| ../pkgconf-1.3.7/libpkgconf/stdinc.h:36:12: fatal error: BaseTsd.h: No
such file or directory
| # include <BaseTsd.h>

Signed-off-by: Maxin B. John <maxin.john@intel.com>