### PR TITLE
Fix --exists description in man page

### DIFF
--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -96,7 +96,7 @@ Exit with error if a module's version is not exactly the specified version.
 .It Fl -max-version Ns = Ns Ar VERSION
 Exit with error if a module's version is greater than the specified version.
 .It Fl -exists
-Exit with a non-zero result if the dependency resolver was able to find all of
+Exit with a non-zero result if the dependency resolver was unable to find all of
 the requested modules.
 .It Fl -uninstalled
 Exit with a non-zero result if the dependency resolver uses an


### PR DESCRIPTION
pkgconf exists with 0 if all modules exist and not the other way around.