### PR TITLE
libpkgconf: add support for Haiku

### DIFF
--- a/libpkgconf/client.c
+++ b/libpkgconf/client.c
@@ -78,7 +78,11 @@ pkgconf_client_init(pkgconf_client_t *client, pkgconf_error_handler_func_t error
 	pkgconf_path_build_from_environ("PKG_CONFIG_SYSTEM_INCLUDE_PATH", SYSTEM_INCLUDEDIR, &client->filter_includedirs, false);
 
 	/* GCC uses these environment variables to define system include paths, so we should check them. */
+#ifdef __HAIKU__
+	pkgconf_path_build_from_environ("BELIBRARIES", NULL, &client->filter_libdirs, false);
+#else
 	pkgconf_path_build_from_environ("LIBRARY_PATH", NULL, &client->filter_libdirs, false);
+#endif
 	pkgconf_path_build_from_environ("CPATH", NULL, &client->filter_includedirs, false);
 	pkgconf_path_build_from_environ("C_INCLUDE_PATH", NULL, &client->filter_includedirs, false);
 	pkgconf_path_build_from_environ("CPLUS_INCLUDE_PATH", NULL, &client->filter_includedirs, false);

--- a/libpkgconf/stdinc.h
+++ b/libpkgconf/stdinc.h
@@ -53,6 +53,9 @@
 #else
 # define PATH_DEV_NULL	"/dev/null"
 # define SIZE_FMT_SPECIFIER	"%zu"
+# ifdef __HAIKU__
+#  include <FindDirectory.h>
+# endif
 # include <dirent.h>
 # include <unistd.h>
 # include <limits.h>

--- a/tests/regress.sh
+++ b/tests/regress.sh
@@ -79,7 +79,8 @@ variable_body()
 
 keep_system_libs_body()
 {
-	export PKG_CONFIG_PATH="${selfdir}/lib1" LIBRARY_PATH="/test/local/lib"
+	export PKG_CONFIG_PATH="${selfdir}/lib1"
+	eval export "$LIBRARY_PATH_ENV"="/test/local/lib"
 	atf_check \
 		-o inline:"\n" \
 		pkgconf --libs-only-L cflags-libs-only

--- a/tests/test_env.sh.in
+++ b/tests/test_env.sh.in
@@ -22,10 +22,12 @@ done
 #--- end kludge ---
 
 selfdir="@abs_top_srcdir@/tests"
+LIBRARY_PATH_ENV="LIBRARY_PATH"
 PATH_SEP=":"
 SYSROOT_DIR="${selfdir}/test"
 case "$(uname -s)" in
 Msys|CYGWIN*) PATH_SEP=";";;
+Haiku) LIBRARY_PATH_ENV="BELIBRARIES";;
 esac
 
 prefix="@prefix@"


### PR DESCRIPTION
This patch add support for [Haiku]. The associated port can be found at https://github.com/haikuports/haikuports/pull/2026

[Haiku]: https://www.haiku-os.org/