### PR TITLE
man: Silence more mandoc warnings

### DIFF
--- a/man/pc.5
+++ b/man/pc.5
@@ -14,8 +14,9 @@
 .Nm file.pc
 .Nd pkg-config file format
 .Sh DESCRIPTION
-pkg-config files provide a useful mechanism for storing various information 
-about libraries and packages on a given system.  Information stored by
+pkg-config files provide a useful mechanism for storing various information
+about libraries and packages on a given system.
+Information stored by
 .Nm .pc
 files include compiler and linker flags necessary to use a given library, as
 well as any other relevant metadata.
@@ -31,8 +32,9 @@ is an implementation.
 .Ss FILE SYNTAX
 The
 .Nm .pc
-file follows a format inspired by RFC822.  Comments are prefixed by a pound sign,
-hash sign or octothorpe (#), and variable assignment is similar to POSIX shell.
+file follows a format inspired by RFC822.
+Comments are prefixed by a pound sign, hash sign or octothorpe (#), and variable
+assignment is similar to POSIX shell.
 Properties are defined using RFC822-style stanzas.
 .\"
 .Ss VARIABLES
@@ -40,18 +42,18 @@ Properties are defined using RFC822-style stanzas.
 Variable definitions start with an alphanumeric string, followed by an equal sign,
 and then the value the variable should contain.
 .Pp
-Variable references are always written as "${variable}".  It is possible to escape
-literal "${" as "$${".
+Variable references are always written as "${variable}".
+It is possible to escape literal "${" as "$${".
 .\"
 .Ss PROPERTIES
 .\"
 Properties are set using RFC822-style stanzas which consist of a keyword, followed
-by a colon (:) and then the value the property should be set to.  Variable
-substitution is always performed regardless of property type.
+by a colon (:) and then the value the property should be set to.
+Variable substitution is always performed regardless of property type.
 .Pp
 There are three types of property:
 .\"
-.Bl -tag
+.Bl -tag -width indent
 .\"
 .It Literal
 The property will be set to the text of the value.
@@ -75,53 +77,64 @@ shell without any shell expansions after variable substitution has been done.
 .\"
 .El
 .Ss PROPERTY KEYWORDS
-.Bl -tag
+.Bl -tag -width indent
 .\"
 .It Name
-The displayed name of the package.  (mandatory; literal)
+The displayed name of the package.
+(mandatory; literal)
 .It Version
-The version of the package.  (mandatory; literal)
+The version of the package.
+(mandatory; literal)
 .It Description
-A description of the package.  (mandatory; literal)
+A description of the package.
+(mandatory; literal)
 .It URL
-A URL to a webpage for the package.  This is used to recommend where newer
-versions of the package can be acquired.  (mandatory; literal)
+A URL to a webpage for the package.
+This is used to recommend where newer versions of the package can be acquired.
+(mandatory; literal)
 .It Cflags
-Required compiler flags.  These flags are always used, regardless of whether
-static compilation is requested.  (optional; fragment list)
+Required compiler flags.
+These flags are always used, regardless of whether static compilation is requested.
+(optional; fragment list)
 .It Cflags.private
 Required compiler flags for static compilation.
 (optional; fragment list; pkgconf extension)
 .It Libs
 Required linking flags for this package.
 Libraries this package depends on for linking against it, which are not
-described as dependencies should be specified here.  (optional; fragment list)
+described as dependencies should be specified here.
+(optional; fragment list)
 .It Libs.private
 Required linking flags for this package that are only required when linking
 statically.
 Libraries this package depends on for linking against it statically, which are
-not described as dependencies should be specified here.  (optional; fragment list)
+not described as dependencies should be specified here.
+(optional; fragment list)
 .It Requires
 Required dependencies that must be met for the package to be usable.
 All dependencies must be satisfied or the pkg-config implementation must not use
-the package.  (optional; dependency list)
+the package.
+(optional; dependency list)
 .It Requires.private
 Required dependencies that must be met for the package to be usable for static linking.
 All dependencies must be satisfied or the pkg-config implementation must not use
-the package for static linking.  (optional; dependency list)
+the package for static linking.
+(optional; dependency list)
 .It Conflicts
-Dependencies that must not be met for the package to be usable.  If any package in the
-proposed dependency solution match any dependency in the Conflicts list, the package
-being considered is not usable.  (optional; dependency list)
+Dependencies that must not be met for the package to be usable.
+If any package in the proposed dependency solution match any dependency in the
+Conflicts list, the package being considered is not usable.
+(optional; dependency list)
 .It Provides
-Dependencies that may be provided by an alternate package.  If a package cannot be
-found, the entire package collection is scanned for providers which can match the
-requested dependency.  (optional; dependency list; pkgconf extension)
+Dependencies that may be provided by an alternate package.
+If a package cannot be found, the entire package collection is scanned for
+providers which can match the requested dependency.
+(optional; dependency list; pkgconf extension)
 .El
 .Ss EXTENSIONS
 Features that have been marked as a pkgconf extension are only guaranteed to work
-with the pkgconf implementation of pkg-config.  Other implementations may or may
-not support the extensions.
+with the pkgconf implementation of pkg-config.
+Other implementations may or may not support the extensions.
 .Pp
 Accordingly, it is suggested that
 .Nm .pc

--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -111,12 +111,12 @@ of a solution.
 .El
 .Sh QUERY-SPECIFIC OPTIONS
 .Bl -tag -width indent
-.It Fl -cflags Ns , Fl -cflags-only-I Ns , Fl -cflags-only-other
+.It Fl -cflags , Fl -cflags-only-I , Fl -cflags-only-other
 Display either all CFLAGS, only
 .Fl I
 CFLAGS or only CFLAGS that are not
 .Fl I .
-.It Fl -libs Ns , Fl -libs-only-L Ns , Fl -libs-only-l Ns , Fl -libs-only-other
+.It Fl -libs , Fl -libs-only-L , Fl -libs-only-l , Fl -libs-only-other
 Display either all linker flags, only
 .Fl L
 linker flags, only
@@ -125,7 +125,7 @@ linker flags or only linker flags that are not
 .Fl L
 or
 .Fl l .
-.It Fl -keep-system-cflags Ns , Fl -keep-system-libs
+.It Fl -keep-system-cflags , Fl -keep-system-libs
 Keep CFLAGS or linker flag fragments that would be filtered due to being
 included by default in the compiler.
 .It Fl -define-variable Ns = Ns Ar VARNAME Ns = Ns Ar VALUE
@@ -144,7 +144,7 @@ entries for a module to the output channel.
 .It Fl -variable Ns = Ns Ar VARNAME
 Print the value of
 .Va VARNAME .
-.It Fl -print-requires Ns , Fl -print-requires-private
+.It Fl -print-requires , Fl -print-requires-private
 Print the modules included in either the
 .Va Requires
 field or the
@@ -213,5 +213,5 @@ Displaying the CFLAGS of a package:
 .Dl $ pkgconf --cflags foo
 .Dl -fPIC -I/usr/include/foo
 .Sh SEE ALSO
-.Xr pkg.m4 7 ,
-.Xr pc 5
+.Xr pc 5 ,
+.Xr pkg.m4 7


### PR DESCRIPTION
Here are the remaining fixes for `mandoc(1)` lint warnings for the `pkgconf.1` and `pc.5` manuals.
```
man -Tlint pkgconf
```
```
skipping no-space macro
  (mdoc) An input line begins with an Ns macro, or the next argument
  after an Ns macro is an isolated closing delimiter. The macro is
  ignored.
```
```
unusual Xr order
  (mdoc) In the SEE ALSO section, an Xr macro with a lower section
  number follows one with a higher number, or two Xr macros referring
  to the same section are out of alphabetical order.
```
```
man: pkgconf.1:114:16: WARNING: skipping no-space macro
man: pkgconf.1:114:39: WARNING: skipping no-space macro
man: pkgconf.1:119:14: WARNING: skipping no-space macro
man: pkgconf.1:119:35: WARNING: skipping no-space macro
man: pkgconf.1:119:56: WARNING: skipping no-space macro
man: pkgconf.1:128:28: WARNING: skipping no-space macro
man: pkgconf.1:147:24: WARNING: skipping no-space macro
man: pkgconf.1:217:2: WARNING: unusual Xr order: pc(5) after pkg.m4(7)
```
```
man -Tlint pc
```
```
whitespace at end of input line
  (mdoc, man, roff) Whitespace at the end of input lines is almost
  never semantically significant -- but in the odd case where it
  might be, it is extremely confusing when reviewing and maintaining
  documents.
```
```
new sentence, new line
  (mdoc) A new sentence starts in the middle of a text line. Start it
  on a new input line to help formatters produce correct spacing.
```
```
missing -width in -tag list, using 8n
  (mdoc) Every Bl macro having the -tag argument requires -width, too.
```
```
man: pc.5:17:76: STYLE: whitespace at end of input line
man: pc.5:18:50: WARNING: new sentence, new line
man: pc.5:49:67: WARNING: new sentence, new line
man: pc.5:87:38: WARNING: new sentence, new line
man: pc.5:90:27: WARNING: new sentence, new line
man: pc.5:113:66: WARNING: new sentence, new line
man: pc.5:117:61: WARNING: new sentence, new line
man: pc.5:123:49: WARNING: new sentence, new line
man: pc.5:56:2: WARNING: missing -width in -tag list, using 6n: Bl -tag
man: pc.5:80:2: WARNING: missing -width in -tag list, using 6n: Bl -tag
```
https://man.openbsd.org/mandoc.1

The only diff with the rendered manuals here is.
```
--- pkgconf.1.orig      2018-04-09 09:24:07.282871191 -0700
+++ pkgconf.1   2018-04-09 09:47:29.207856489 -0700
@@ -204,6 +204,6 @@
            -fPIC -I/usr/include/foo
 
 SEE ALSO
-     pkg.m4(7), pc(5)
+     pc(5), pkg.m4(7)
 
 Slackware Linux                November 15, 2016               Slackware Linux
```