### PR TITLE
man: Silence mandoc warnings for pkg.m4.7

### DIFF
--- a/man/pkg.m4.7
+++ b/man/pkg.m4.7
@@ -27,23 +27,21 @@
 .Sh DESCRIPTION
 .Nm
 is a collection of autoconf macros which help to configure compiler and linker
-flags for development libraries. This allows build systems to detect other
-dependencies and use them with the system toolchain.
+flags for development libraries.
+This allows build systems to detect other dependencies and use them with the
+system toolchain.
 .Sh "AUTOCONF MACROS"
-.Pp
 .Ss "PKG_PREREQ(MIN-VERSION)"
 Checks that the version of the
 .Nm
-autoconf macros in use is at
-least MIN-VERSION. This can be used to ensure a particular
+autoconf macros in use is at least MIN-VERSION.
+This can be used to ensure a particular
 .Nm
 macro will be available.
-.Pp
 .Ss "PKG_PROG_PKG_CONFIG([MIN-VERSION])"
 Checks for an implementation of
 .Nm pkg-config
 which is at least MIN-VERSION or newer.
-.Pp
 .Ss "PKG_CHECK_MODULES(VARIABLE-PREFIX, MODULES [,ACTION-IF-FOUND [,ACTION-IF-NOT-FOUND]])"
 .Ss "PKG_CHECK_MODULES_STATIC(VARIABLE-PREFIX, MODULES [,ACTION-IF-FOUND [,ACTION-IF-NOT-FOUND]])"
 Checks whether a given module set exists, and if so, defines
@@ -131,7 +129,7 @@ in a single macro.
 Convenience macro to trigger
 .Nm AM_CONDITIONAL
 after a
-.Nm PKG_WITH_MODULES check.
+.Nm PKG_WITH_MODULES check.\&
 .Nm VARIABLE-PREFIX
 is exported as a make variable.
 .Ss "PKG_HAVE_DEFINE_WITH_MODULES(VARIABLE-PREFIX, MODULES, [DESCRIPTION], [DEFAULT])"
@@ -140,6 +138,6 @@ Convenience macro to trigger
 and
 .Nm AC_DEFINE
 after a
-.Nm PKG_WITH_MODULES check.
+.Nm PKG_WITH_MODULES check.\&
 .Nm VARIABLE-PREFIX
 is exported as a make variable.


### PR DESCRIPTION
These should be the last `mandoc(1)` lint warnings for pkgconf. I silenced the last two warnings by adding a zero-width space at the end so the trailing delimiters are no longer trailing.
```
man -Tlint pkg.m4
```
```
new sentence, new line
  (mdoc) A new sentence starts in the middle of a text line. Start it
  on a new input line to help formatters produce correct spacing.
```
```
skipping paragraph macro
  In mdoc(7) documents, this happens

    - at the beginning and end of sections and subsections
    - right before non-compact lists and displays
    - at the end of items in non-column, non-compact lists
    - and for multiple consecutive paragraph macros.

  In man(7) documents, it happens

    - for empty P, PP, and LP macros
    - for IP macros having neither head nor body arguments
    - for br or sp right after SH or SS
```
```
no blank before trailing delimiter
  (mdoc) The last argument of a macro that supports trailing
  delimiter arguments is longer than one byte and ends with a
  trailing delimiter. Consider inserting a blank such that the
  delimiter becomes a separate argument, thus moving it out of
  the scope of the macro.
```
```
man: pkg.m4.7:30:34: WARNING: new sentence, new line
man: pkg.m4.7:38:20: WARNING: new sentence, new line
man: pkg.m4.7:33:2: WARNING: skipping paragraph macro: Pp after Sh
man: pkg.m4.7:41:2: WARNING: skipping paragraph macro: Pp at the end of Ss
man: pkg.m4.7:46:2: WARNING: skipping paragraph macro: Pp at the end of Ss
man: pkg.m4.7:134:27: STYLE: no blank before trailing delimiter: Nm ... check.
man: pkg.m4.7:143:27: STYLE: no blank before trailing delimiter: Nm ... check.
```
https://man.openbsd.org/mandoc.1

See this diff for the rendered manual.
```
--- pkg.m4.orig 2018-04-09 21:36:52.887489533 -0700
+++ pkg.m4      2018-04-09 21:49:59.918383767 -0700
@@ -17,15 +17,15 @@
 
 DESCRIPTION
      pkg.m4 is a collection of autoconf macros which help to configure
-     compiler and linker flags for development libraries. This allows build
+     compiler and linker flags for development libraries.  This allows build
      systems to detect other dependencies and use them with the system
      toolchain.
 
 AUTOCONF MACROS
    PKG_PREREQ(MIN-VERSION)
      Checks that the version of the pkg.m4 autoconf macros in use is at least
-     MIN-VERSION. This can be used to ensure a particular pkg.m4 macro will be
-     available.
+     MIN-VERSION.  This can be used to ensure a particular pkg.m4 macro will
+     be available.
 
    PKG_PROG_PKG_CONFIG([MIN-VERSION])
      Checks for an implementation of pkg-config which is at least MIN-VERSION
```