### PR TITLE
use pkgconf_strlcpy

### DIFF
--- a/libpkgconf/personality.c
+++ b/libpkgconf/personality.c
@@ -192,7 +192,7 @@ load_personality_with_path(const char *path, const char *triplet)
 	if (triplet != NULL)
 		snprintf(pathbuf, sizeof pathbuf, "%s/%s.personality", path, triplet);
 	else
-		strlcpy(pathbuf, path, sizeof pathbuf);
+		pkgconf_strlcpy(pathbuf, path, sizeof pathbuf);
 
 	f = fopen(pathbuf, "r");
 	if (f == NULL)


### PR DESCRIPTION
On Debian/Ubuntu I get:

```
  CC       libpkgconf/personality.lo
  libpkgconf/personality.c: In function ‘load_personality_with_path’:
  libpkgconf/personality.c:195:3: warning: implicit declaration of function ‘strlcpy’ [-Wimplicit-function-declaration]
  strlcpy(pathbuf, path, sizeof pathbuf);
        ^~~~~~~
  CC       libpkgconf/parser.lo
  CCLD     libpkgconf.la
  ar: `u' modifier ignored since `D' is the default (see `U')
  CC       cli/pkgconf-main.o
  CC       cli/pkgconf-getopt_long.o
  CC       cli/pkgconf-renderer-msvc.o
  CCLD     pkgconf
  ./.libs/libpkgconf.so: undefined reference to `strlcpy'
```

strlcpy seems to be in `<bsd/string.h>` + `-lbsd` on Debian with `libbsd-dev` installed.  But this seems to work with or without that package installed.