### PR TITLE
Fix minor issues in manpages

### DIFF
--- a/man/pkg.m4.7
+++ b/man/pkg.m4.7
@@ -87,7 +87,7 @@ be changed by passing the
 .Nm DIRECTORY
 parameter.
 .Pp
-This value can be overriden with the
+This value can be overridden with the
 .Fl -with-pkgconfigdir
 configure parameter.
 .Ss "PKG_NOARCH_INSTALLDIR(DIRECTORY)"
@@ -99,7 +99,7 @@ be changed by passing the
 .Nm DIRECTORY
 parameter.
 .Pp
-This value can be overriden with the
+This value can be overridden with the
 .Fl -with-noarch-pkgconfigdir
 configure parameter.
 .Ss "PKG_CHECK_VAR(VARIABLE, MODULE, CONFIG-VARIABLE, [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])"

--- a/man/pkgconf-personality.5
+++ b/man/pkgconf-personality.5
@@ -72,6 +72,7 @@ A list of directories that are included by default in the search path for
 libraries.
 (mandatory; fragment list)
 .\"
+.El
 .Sh EXAMPLES
 An example .personality file:
 .Bd -literal


### PR DESCRIPTION
- [x] Spelling in `pkg.m4(7)`;
- [x] troff markup in `pkgconf-personality(5)`.