### PR TITLE
use correct autoconf macro name

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,7 @@ dnl from the use of this software.
 AC_PREREQ([2.68])
 AC_INIT([pkgconf], [1.6.3], [https://todo.sr.ht/~kaniini/pkgconf])
 AC_CONFIG_SRCDIR([cli/main.c])
-AC_CONFIG_MACRO_DIRS([m4])
+AC_CONFIG_MACRO_DIR([m4])
 AX_CHECK_COMPILE_FLAG([-Wall], [CFLAGS="$CFLAGS -Wall"])
 AX_CHECK_COMPILE_FLAG([-Wextra], [CFLAGS="$CFLAGS -Wextra"])
 AX_CHECK_COMPILE_FLAG([-Wformat=2], [CFLAGS="$CFLAGS -Wformat=2"])


### PR DESCRIPTION
AC_CONFIG_MACRO_DIR without trailing S is known by autoconf since 2.58.
AC_CONFIG_MACRO_DIR with trailing S is known by autoconf newer than 2.69.

This fixes libtool after 'autoreconf -fi'.

Fixes commit a8a65c7f6c6b6463bbdee119c0ff71536925e455
Related to issue #145

Signed-off-by: Olaf Hering <olaf@aepfle.de>