### PR TITLE
libpkgconf: fileio: prevent buffer overflow.

### DIFF
--- a/libpkgconf/fileio.c
+++ b/libpkgconf/fileio.c
@@ -20,7 +20,7 @@ char *
 pkgconf_fgetline(char *line, size_t size, FILE *stream)
 {
 	char *s = line;
-	char *end = line + size - 1;
+	char *end = line + size - 2;
 	bool quoted = false;
 	int c = '\0', c2;
 


### PR DESCRIPTION
pkgconf_fgetline is called with a user-defined buffer, its size, and
a FILE stream to read input from.

If the buffer is almost completely filled and the file stream contains
an escaped character, then it is possible to trigger an off-by-one
buffer overflow with a '\0' character.

Easiest example to trigger this:

char buf[2];
pkgconf_fgetline(buf, sizeof(buf), stdin);

Enter "\\" (two backslashes) and press enter. If the library and the
program are compiled with address sanitizer, you will see the program
crashing. Otherwise it depends on your architecture what happens.

Since nobody should be using a buffer of only size 1 or 2, keep enough
space for a possibly escaped character in while loop by subtracting one
more byte for this situation, not just for '\0'.