### PR TITLE
libpkgconf: parser: fix out of boundary access

### DIFF
--- a/libpkgconf/parser.c
+++ b/libpkgconf/parser.c
@@ -66,8 +66,11 @@ pkgconf_parser_parse(FILE *f, void *data, const pkgconf_parser_operand_func_t *o
 		}
 
 		op = *p;
-		*p = '\0';
-		p++;
+		if (*p != '\0')
+		{
+			*p = '\0';
+			p++;
+		}
 
 		while (*p && isspace((unsigned int)*p))
 			p++;


### PR DESCRIPTION
It is possible to trigger an out of boundary access with specially
crafted files. If a line consist of only a key and spaces, then
op will point to '\0'-ending of the buffer. Since p is iterated by
one byte right past this ending '\0', the next read access to p is
effectively out of bounds.

Theoretically this can also lead to out of boundary writes if spaces
are encountered.

Proof of concept (I recommend to compile with address sanitizer):

$ echo -n a > poc.pc
$ dd if=/dev/zero bs=1 count=65533 | tr '\0' ' ' >> poc.pc
$ pkgconf poc.pc