### PR TITLE
libpkgconf: personality: fix out of boundary access

### DIFF
--- a/libpkgconf/personality.c
+++ b/libpkgconf/personality.c
@@ -168,7 +168,7 @@ personality_keyword_set(pkgconf_cross_personality_t *p, const size_t lineno, con
 	pair->func(p, keyword, lineno, pair->offset, value);
 }
 
-static const pkgconf_parser_operand_func_t personality_parser_ops[] = {
+static const pkgconf_parser_operand_func_t personality_parser_ops[256] = {
 	[':'] = (pkgconf_parser_operand_func_t) personality_keyword_set
 };
 


### PR DESCRIPTION
It is possible to set the instruction pointer to undefined values by
using an operator larger than ':' in ASCII.

Since the personality function array does not have 256 entries, an
invalid operator can overflow the array.

Proof of concept:

$ echo "a _ b" > poc
$ ln -s $(which pkgconf) poc-pkgconf
$ ./poc-pkgconf