### PR TITLE
libpkgconf: fragment: fix out of boundary read

### DIFF
--- a/libpkgconf/fragment.c
+++ b/libpkgconf/fragment.c
@@ -137,7 +137,7 @@ pkgconf_fragment_add(const pkgconf_client_t *client, pkgconf_list_t *list, const
 	if (*string == '\0')
 		return;
 
-	if (!pkgconf_fragment_is_special(string))
+	if (strlen(string) > 1 && !pkgconf_fragment_is_special(string))
 	{
 		frag = calloc(sizeof(pkgconf_fragment_t), 1);
 


### PR DESCRIPTION
Parsing a fragment which consists only of a single dash leads to
an out of boundary read. It duplicates the following entry which
is not expected behaviour if another fragment follows.

Proof of concept:

$ cat > poc.pc << "EOF"
Name: poc
Description: poc
Version: 1
Cflags: - -I/somewhere
EOF
$ PKG_CONFIG_PATH=. pkgconf --cflags poc
-I/somewhere -I/somewhere

If - is the last entry, it leads to an out of boundary read, which is
easy to see if pkgconf is compiled with address sanitizer.