### PR TITLE
libpkgconf: fragment: fix out of boundary write

### DIFF
--- a/libpkgconf/fragment.c
+++ b/libpkgconf/fragment.c
@@ -442,8 +442,10 @@ fragment_quote(const pkgconf_fragment_t *frag)
 
 		if ((ptrdiff_t)(dst - out) + 2 > outlen)
 		{
+			ptrdiff_t offset = dst - out;
 			outlen *= 2;
 			out = realloc(out, outlen);
+			dst = out + offset;
 		}
 	}
 


### PR DESCRIPTION
fragment_quote adds quotation to fragments if needed. It allocates a
buffer and grows it as needed.

Unfortunately the dst pointer is not updated after a realloc, which
means that dst still points into the old memory area. Further writing
characters into that area leads to out of boundy writes.

Proof of concept:

$ cat > poc.pc << EOF
Name: poc
Description: poc
Version: 1
CFlags: -Ia
CFlags: -I%%%%%%%%%%%%%%%%%%%%b
CFlags: -I%%%%%%%%%%%%%%%%%%%%c
CFlags: -Id
EOF
$ pkgconf --cflags poc.pc

Most reliable attempt is to compile pkgconf with address sanitizer,
but this file should lead to an abort on a glibc system due to modified
chunk pointers (tested with Linux on amd64).

But since this is undefined behaviour, it depends on system details.