### PR TITLE
man: Silence pkgconf-personality.5 warning.

### DIFF
--- a/man/pkgconf-personality.5
+++ b/man/pkgconf-personality.5
@@ -93,5 +93,5 @@ SystemLibraryPaths: /home/kaniini/sysroot/x86_64-pc-linux-gnu/lib
 .Ed
 .Sh SEE ALSO
 .Xr pkgconf 1 ,
-.Xr pkg.m4 7 ,
-.Xr pc 5
+.Xr pc 5 ,
+.Xr pkg.m4 7


### PR DESCRIPTION
```
man: ./pkgconf-personality.5:97:2: WARNING: unusual Xr order: pc(5) after pkg.m4(7)
```
Reproduced with `mandoc-1.14.5`.
```
man -Tlint -l ./pkgconf-personality.5
```