### PR TITLE
libpkgconf: path: supply buffer to realpath

### DIFF
--- a/libpkgconf/path.c
+++ b/libpkgconf/path.c
@@ -92,15 +92,11 @@ pkgconf_path_add(const char *text, pkgconf_list_t *dirlist, bool filter)
 			return;
 		if (S_ISLNK(st.st_mode))
 		{
-			char *linkdest = realpath(path, NULL);
+			char pathbuf[PATH_MAX];
+			char *linkdest = realpath(path, pathbuf);
 
 			if (linkdest != NULL && stat(linkdest, &st) == -1)
-			{
-				free(linkdest);
 				return;
-			}
-
-			free(linkdest);
 		}
 		if (path_list_contains_entry(path, dirlist, &st))
 			return;


### PR DESCRIPTION
To avoid a crash on some platforms (like Darwin 9) provide a buffer to
realpath(3).

Darwin 9 (last PPC target) documents realpath needs to be given a buffer
to the resolved_path argument large enough to hold PATH_MAX bytes.
With NULL argument it crashes.  Solaris makes no mention of
resolved_path to be allowed NULL, yet recent versions accept it and
malloc(3) accordingly.

Because the documentation explicitly mentions PATH_MAX being the limit
to what realpath(3) would write in resolved_path, switching to a static
buffer here doesn't limit resolution compared to dynamically allocating
a buffer by realpath(3).

While this change requires a bit more space on the stack, it avoids a
malloc/free sequence, and allows successful operation on (older)
platforms that lack support for dynamically allocating a return buffer
in realpath(3).

Signed-off-by: Fabian Groffen <grobian@gentoo.org>