### PR TITLE
cli: add environment variable PKG_CONFIG_DONT_DEFINE_PREFIX

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1062,7 +1062,7 @@ main(int argc, char *argv[])
 	if ((want_flags & PKG_NO_PROVIDES) == PKG_NO_PROVIDES)
 		want_client_flags |= PKGCONF_PKG_PKGF_SKIP_PROVIDES;
 
-	if ((want_flags & PKG_DONT_DEFINE_PREFIX) == PKG_DONT_DEFINE_PREFIX)
+	if ((want_flags & PKG_DONT_DEFINE_PREFIX) == PKG_DONT_DEFINE_PREFIX  || getenv("PKG_CONFIG_DONT_DEFINE_PREFIX") != NULL)
 		want_client_flags &= ~PKGCONF_PKG_PKGF_REDEFINE_PREFIX;
 
 	if ((want_flags & PKG_INTERNAL_CFLAGS) == PKG_INTERNAL_CFLAGS)


### PR DESCRIPTION
On Windows, pkgconf redefines the prefix by default.
This gives the user the option to disable this behavior via an environment variable.
The benefit of an environment variable is the user can change this behavior when
using a build system such as cmake or meson, which may not expose this
parameter to the user.