### PR TITLE
small memory leak fix

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -802,6 +802,7 @@ main(int argc, char *argv[])
 	char *want_env_prefix = NULL;
 	unsigned int want_client_flags = PKGCONF_PKG_PKGF_NONE;
 	pkgconf_cross_personality_t *personality;
+	bool opened_error_msgout = false;
 
 	want_flags = 0;
 
@@ -1027,8 +1028,10 @@ main(int argc, char *argv[])
 	error_msgout = stderr;
 	if ((want_flags & PKG_ERRORS_ON_STDOUT) == PKG_ERRORS_ON_STDOUT)
 		error_msgout = stdout;
-	if ((want_flags & PKG_SILENCE_ERRORS) == PKG_SILENCE_ERRORS)
+	if ((want_flags & PKG_SILENCE_ERRORS) == PKG_SILENCE_ERRORS) {
 		error_msgout = fopen(PATH_DEV_NULL, "w");
+		opened_error_msgout = true;
+	}
 
 	if ((want_flags & PKG_IGNORE_CONFLICTS) == PKG_IGNORE_CONFLICTS || getenv("PKG_CONFIG_IGNORE_CONFLICTS") != NULL)
 		want_client_flags |= PKGCONF_PKG_PKGF_SKIP_CONFLICTS;
@@ -1459,6 +1462,8 @@ out:
 
 	if (logfile_out != NULL)
 		fclose(logfile_out);
+	if (opened_error_msgout)
+		fclose(error_msgout);
 
 	return ret;
 }

--- a/cli/main.c
+++ b/cli/main.c
@@ -1454,6 +1454,7 @@ out_println:
 		printf("\n");
 
 out:
+	pkgconf_cross_personality_deinit(personality);
 	pkgconf_client_deinit(&pkg_client);
 
 	if (logfile_out != NULL)

--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -231,6 +231,7 @@ PKGCONF_API void pkgconf_client_dir_list_build(pkgconf_client_t *client, const p
 /* personality.c */
 PKGCONF_API pkgconf_cross_personality_t *pkgconf_cross_personality_default(void);
 PKGCONF_API pkgconf_cross_personality_t *pkgconf_cross_personality_find(const char *triplet);
+PKGCONF_API void pkgconf_cross_personality_deinit(pkgconf_cross_personality_t *personality);
 
 #define PKGCONF_IS_MODULE_SEPARATOR(c) ((c) == ',' || isspace ((unsigned int)(c)))
 #define PKGCONF_IS_OPERATOR_CHAR(c) ((c) == '<' || (c) == '>' || (c) == '!' || (c) == '=')

--- a/libpkgconf/personality.c
+++ b/libpkgconf/personality.c
@@ -103,6 +103,14 @@ pkgconf_cross_personality_default(void)
 	return &default_personality;
 }
 
+void
+pkgconf_cross_personality_deinit(pkgconf_cross_personality_t *personality)
+{
+	pkgconf_path_free(&personality->dir_list);
+	pkgconf_path_free(&personality->filter_libdirs);
+	pkgconf_path_free(&personality->filter_includedirs);
+}
+
 #ifndef PKGCONF_LITE
 static bool
 valid_triplet(const char *triplet)


### PR DESCRIPTION
Hello, I was using integrating `libpkgconf` into my project and noticed some memory wasn't being cleaned up with the help of valgrind.  I was already suspicious that there was no `_deinit` function for personality, so it was pretty easy to track down.  I'm not entirely sure this is the correct fix, because I haven't been able to determine if personality owns these resources, or if client is supposed to.  If the latter is the case, let me know and I will move my clean up code to the client deinit function.

I also added some code to close `error_msgout` if it got opened, because that was making valgrind upset too.

Since the memory was still referenced, this is not that big of an issue, but I thought I might as well make a PR.