### PR TITLE
pkg.m4: PKG_CHECK_MODULES provides modversion

### DIFF
--- a/pkg.m4
+++ b/pkg.m4
@@ -146,6 +146,7 @@ AC_MSG_CHECKING([for $1])
 
 _PKG_CONFIG([$1][_CFLAGS], [cflags], [$2])
 _PKG_CONFIG([$1][_LIBS], [libs], [$2])
+_PKG_CONFIG([$1][_VERSION], [modversion], [$2])
 
 m4_define([_PKG_TEXT], [Alternatively, you may set the environment variables $1[]_CFLAGS
 and $1[]_LIBS to avoid the need to call pkg-config.
@@ -186,6 +187,7 @@ To get pkg-config, see <http://pkg-config.freedesktop.org/>.])[]dnl
 else
         $1[]_CFLAGS=$pkg_cv_[]$1[]_CFLAGS
         $1[]_LIBS=$pkg_cv_[]$1[]_LIBS
+        $1[]_VERSION=$pkg_cv_[]$1[]_VERSION
         AC_MSG_RESULT([yes])
         $3
 fi[]dnl


### PR DESCRIPTION
Projects using PKG_CHECK_MODULES wants to add dependency versions to
their binaries. Currently, the projects have to resolve dependency
versions themselves when using pkgconf.
    
With this patch PKG_CHECK_MODULES now defines a $PKG_VERSION variable
that represents `--modversion`.
