### PR TITLE
Add support for being used as a meson subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -78,6 +78,12 @@ dep_libpkgconf = declare_dependency(
   include_directories : include_directories('.'),
 )
 
+# If we have a new enough meson override the dependency so that only
+# `dependency('libpkgconf')` is required from the consumer
+if meson.version().version_compare('>= 0.54.0')
+  meson.override_dependency('libpkgconf', dep_libpkgconf)
+endif
+
 pkg = import('pkgconfig')
 pkg.generate(libpkgconf,
   name : 'libpkgconf',

--- a/meson.build
+++ b/meson.build
@@ -72,6 +72,12 @@ libpkgconf = library('pkgconf',
   soversion : '3',
 )
 
+# For other projects using libpkgconfig as a subproject
+dep_libpkgconf = declare_dependency(
+  link_with : libpkgconf,
+  include_directories : include_directories('.'),
+)
+
 pkg = import('pkgconfig')
 pkg.generate(libpkgconf,
   name : 'libpkgconf',


### PR DESCRIPTION
Meson allows dependencies to be compiled and built as part of the parent projects build process using a subproject systems and "wraps". This is useful for situations where dependencies are difficult to install (such as windows and macos), or where a newer version is needed, or static linking is required.

Included are two patches to allow libpkgconf to be used as a subproject dependency. There is an immediate consumer for this in [muon](https://git.sr.ht/~lattis/muon), and I will be using this functionality in [meson++](https://github.com/dcbaker/meson-plus-plus), especially since support windows and macOS is a goal for meson++.