### PR TITLE
Zero lists when freeing them

### DIFF
--- a/libpkgconf/iter.h
+++ b/libpkgconf/iter.h
@@ -35,6 +35,14 @@ typedef struct {
 #define PKGCONF_LIST_INITIALIZER		{ NULL, NULL, 0 }
 
 static inline void
+pkgconf_list_zero(pkgconf_list_t *list)
+{
+	list->head = NULL;
+	list->tail = NULL;
+	list->length = 0;
+}
+
+static inline void
 pkgconf_node_insert(pkgconf_node_t *node, void *data, pkgconf_list_t *list)
 {
 	pkgconf_node_t *tnode;

--- a/libpkgconf/path.c
+++ b/libpkgconf/path.c
@@ -268,6 +268,8 @@ pkgconf_path_free(pkgconf_list_t *dirlist)
 		free(pnode->path);
 		free(pnode);
 	}
+
+	pkgconf_list_zero(dirlist);
 }
 
 static char *

--- a/libpkgconf/tuple.c
+++ b/libpkgconf/tuple.c
@@ -390,4 +390,6 @@ pkgconf_tuple_free(pkgconf_list_t *list)
 
 	PKGCONF_FOREACH_LIST_ENTRY_SAFE(list->head, next, node)
 		pkgconf_tuple_free_entry(node->data, list);
+
+	pkgconf_list_zero(list);
 }


### PR DESCRIPTION
Otherwise, the list pointer is left in a state that it cannot safely be re-initialized. This is particularly problematic for static members using lists, as once they are de-inited they cannot be re-iniited