### PR TITLE
Do a better job of freeing memory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,30 @@ jobs:
         run: |
           meson test -v -C _build
 
+  debian-meson-asan:
+    runs-on: ubuntu-latest
+    container:
+      image: debian:testing
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Update system and add dependencies
+        run: |
+          apt-get update
+          apt-get install -y kyua atf-sh build-essential meson
+
+      - name: Build
+        run: |
+          meson _build -Db_sanitize=address
+          meson compile -C _build
+
+      - name: Run tests
+        run: |
+          meson test -v -C _build
+        env:
+          ASAN_OPTIONS: "exitcode=7"
+
   debian-autotools:
     runs-on: ubuntu-latest
     container:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -12,6 +12,21 @@ pipeline:
         IMAGE: debian
         BUILD: meson
 
+  debian-meson-asan:
+    image: debian:testing
+    environment:
+      - ASAN_OPTIONS="exitcode=7"
+    commands:
+      - apt-get update
+      - apt-get install -y kyua atf-sh build-essential meson
+      - meson _build -Db_sanitize=address
+      - meson compile -C _build
+      - meson test -v -C _build
+    when:
+      matrix:
+        IMAGE: debian
+        BUILD: meson
+
   debian-autotools:
     image: debian:testing
     commands:

--- a/cli/main.c
+++ b/cli/main.c
@@ -1183,17 +1183,19 @@ main(int argc, char *argv[])
 					pkgconf_error(&pkg_client, "Package '%s' was not found\n", pkgiter->package);
 
 				ret = EXIT_FAILURE;
-				goto out;
+				goto cleanup;
 			}
 
 			if (pkgconf_compare_version(pkg->version, required_module_version) >= 0)
 			{
 				ret = EXIT_SUCCESS;
-				goto out;
+				goto cleanup;
 			}
 		}
 
 		ret = EXIT_FAILURE;
+cleanup:
+		pkgconf_dependency_free(&deplist);
 		goto out;
 	}
 	else if (required_exact_module_version != NULL)
@@ -1219,17 +1221,19 @@ main(int argc, char *argv[])
 					pkgconf_error(&pkg_client, "Package '%s' was not found\n", pkgiter->package);
 
 				ret = EXIT_FAILURE;
-				goto out;
+				goto cleanup2;
 			}
 
 			if (pkgconf_compare_version(pkg->version, required_exact_module_version) == 0)
 			{
 				ret = EXIT_SUCCESS;
-				goto out;
+				goto cleanup2;
 			}
 		}
 
 		ret = EXIT_FAILURE;
+cleanup2:
+		pkgconf_dependency_free(&deplist);
 		goto out;
 	}
 	else if (required_max_module_version != NULL)
@@ -1255,17 +1259,19 @@ main(int argc, char *argv[])
 					pkgconf_error(&pkg_client, "Package '%s' was not found\n", pkgiter->package);
 
 				ret = EXIT_FAILURE;
-				goto out;
+				goto cleanup3;
 			}
 
 			if (pkgconf_compare_version(pkg->version, required_max_module_version) <= 0)
 			{
 				ret = EXIT_SUCCESS;
-				goto out;
+				goto cleanup3;
 			}
 		}
 
 		ret = EXIT_FAILURE;
+cleanup3:
+		pkgconf_dependency_free(&deplist);
 		goto out;
 	}
 

--- a/cli/main.c
+++ b/cli/main.c
@@ -1337,7 +1337,7 @@ main(int argc, char *argv[])
 	}
 
 	if ((want_flags & PKG_VALIDATE) == PKG_VALIDATE)
-		return 0;
+		goto out;
 
 	if ((want_flags & PKG_UNINSTALLED) == PKG_UNINSTALLED)
 	{

--- a/libpkgconf/cache.c
+++ b/libpkgconf/cache.c
@@ -167,6 +167,7 @@ pkgconf_cache_remove(pkgconf_client_t *client, pkgconf_pkg_t *pkg)
 	if (slot == NULL)
 		return;
 
+	pkg->flags &= ~PKGCONF_PKG_PROPF_CACHED;
 	*slot = NULL;
 
 	qsort(client->cache_table, client->cache_count,

--- a/libpkgconf/cache.c
+++ b/libpkgconf/cache.c
@@ -186,18 +186,6 @@ pkgconf_cache_remove(pkgconf_client_t *client, pkgconf_pkg_t *pkg)
 		client->cache_count, sizeof(void *));
 }
 
-static inline void
-clear_dependency_matches(pkgconf_list_t *list)
-{
-	pkgconf_node_t *iter;
-
-	PKGCONF_FOREACH_LIST_ENTRY(list->head, iter)
-	{
-		pkgconf_dependency_t *dep = iter->data;
-		dep->match = NULL;
-	}
-}
-
 /*
  * !doc
  *
@@ -224,18 +212,12 @@ pkgconf_cache_free(pkgconf_client_t *client)
 	{
 		pkgconf_pkg_t *pkg = cache_table[i];
 
-		clear_dependency_matches(&pkg->required);
-		clear_dependency_matches(&pkg->requires_private);
-		clear_dependency_matches(&pkg->provides);
-		clear_dependency_matches(&pkg->conflicts);
+		pkgconf_dependency_free(&pkg->required);
+		pkgconf_dependency_free(&pkg->requires_private);
+		pkgconf_dependency_free(&pkg->provides);
+		pkgconf_dependency_free(&pkg->conflicts);
 	}
 
-	/* now forcibly free everything */
-	for (i = 0, count = client->cache_count; i < count; i++)
-	{
-		pkgconf_pkg_t *pkg = cache_table[i];
-		pkgconf_pkg_unref(client, pkg);
-	}
 	free(cache_table);
 
 	PKGCONF_TRACE(client, "cleared package cache");

--- a/libpkgconf/cache.c
+++ b/libpkgconf/cache.c
@@ -235,6 +235,7 @@ pkgconf_cache_free(pkgconf_client_t *client)
 		pkgconf_pkg_t *pkg = cache_table[i];
 		pkgconf_pkg_free(client, pkg);
 	}
+	free(cache_table);
 
 	PKGCONF_TRACE(client, "cleared package cache");
 }

--- a/libpkgconf/cache.c
+++ b/libpkgconf/cache.c
@@ -233,7 +233,7 @@ pkgconf_cache_free(pkgconf_client_t *client)
 	for (i = 0, count = client->cache_count; i < count; i++)
 	{
 		pkgconf_pkg_t *pkg = cache_table[i];
-		pkgconf_pkg_free(client, pkg);
+		pkgconf_pkg_unref(client, pkg);
 	}
 	free(cache_table);
 

--- a/libpkgconf/dependency.c
+++ b/libpkgconf/dependency.c
@@ -197,6 +197,9 @@ pkgconf_dependency_free_one(pkgconf_dependency_t *dep)
 	if (dep->match != NULL)
 		pkgconf_pkg_unref(dep->match->owner, dep->match);
 
+	if (dep->parent != NULL)
+		pkgconf_pkg_unref(dep->match->owner, dep->parent);
+
 	if (dep->package != NULL)
 		free(dep->package);
 

--- a/libpkgconf/dependency.c
+++ b/libpkgconf/dependency.c
@@ -113,7 +113,7 @@ add_or_replace_dependency_node(pkgconf_client_t *client, pkgconf_dependency_t *d
 	}
 
 	PKGCONF_TRACE(client, "added dependency [%s] to list @%p; flags=%x", dependency_to_str(dep, depbuf, sizeof depbuf), list, dep->flags);
-	pkgconf_node_insert_tail(&dep->iter, dep, list);
+	pkgconf_node_insert_tail(&dep->iter, pkgconf_dependency_ref(dep->owner, dep), list);
 
 	return pkgconf_dependency_ref(dep->owner, dep);
 }
@@ -357,7 +357,8 @@ pkgconf_dependency_parse_str(pkgconf_client_t *client, pkgconf_list_t *deplist_h
 
 			if (state == OUTSIDE_MODULE)
 			{
-				pkgconf_dependency_addraw(client, deplist_head, package, package_sz, NULL, 0, compare, flags);
+				pkgconf_dependency_t *dep = pkgconf_dependency_addraw(client, deplist_head, package, package_sz, NULL, 0, compare, flags);
+				pkgconf_dependency_unref(dep->owner, dep);
 
 				compare = PKGCONF_CMP_ANY;
 				package_sz = 0;
@@ -401,7 +402,8 @@ pkgconf_dependency_parse_str(pkgconf_client_t *client, pkgconf_list_t *deplist_h
 				version_sz = ptr - vstart;
 				state = OUTSIDE_MODULE;
 
-				pkgconf_dependency_addraw(client, deplist_head, package, package_sz, version, version_sz, compare, flags);
+				pkgconf_dependency_t *dep = pkgconf_dependency_addraw(client, deplist_head, package, package_sz, version, version_sz, compare, flags);
+				pkgconf_dependency_unref(dep->owner, dep);
 
 				compare = PKGCONF_CMP_ANY;
 				cnameptr = cmpname;

--- a/libpkgconf/dependency.c
+++ b/libpkgconf/dependency.c
@@ -222,6 +222,7 @@ pkgconf_dependency_ref(pkgconf_client_t *client, pkgconf_dependency_t *dep)
 		return NULL;
 
 	dep->refcount++;
+	PKGCONF_TRACE(client, "%s: refcount@%p: %d", dep->package, dep, dep->refcount);
 	return dep;
 }
 
@@ -242,7 +243,9 @@ pkgconf_dependency_unref(pkgconf_client_t *client, pkgconf_dependency_t *dep)
 	if (client != dep->owner)
 		return;
 
-	if (--dep->refcount <= 0)
+	dep->refcount--;
+	PKGCONF_TRACE(client, "%s: refcount@%p: %d", dep->package, dep, dep->refcount);
+	if (dep->refcount <= 0)
 		pkgconf_dependency_free_one(dep);
 }
 

--- a/libpkgconf/dependency.c
+++ b/libpkgconf/dependency.c
@@ -16,6 +16,8 @@
 #include <libpkgconf/stdinc.h>
 #include <libpkgconf/libpkgconf.h>
 
+#include <assert.h>
+
 /*
  * !doc
  *
@@ -244,8 +246,9 @@ pkgconf_dependency_unref(pkgconf_client_t *client, pkgconf_dependency_t *dep)
 		return;
 
 	dep->refcount--;
+	assert(dep->refcount >= 0);
 	PKGCONF_TRACE(client, "%s: refcount@%p: %d", dep->package, dep, dep->refcount);
-	if (dep->refcount <= 0)
+	if (dep->refcount == 0)
 		pkgconf_dependency_free_one(dep);
 }
 

--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -17,6 +17,8 @@
 #include <libpkgconf/stdinc.h>
 #include <libpkgconf/libpkgconf.h>
 
+#include <assert.h>
+
 /*
  * !doc
  *
@@ -514,6 +516,8 @@ pkgconf_pkg_free(pkgconf_client_t *client, pkgconf_pkg_t *pkg)
 	if (pkg->pc_filedir != NULL)
 		free(pkg->pc_filedir);
 
+	/* We shouldn't be trying to free this if someone is still holding a reference to it */
+	assert(pkg->refcount == 0);
 	free(pkg);
 }
 

--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -1466,6 +1466,8 @@ pkgconf_pkg_walk_list(pkgconf_client_t *client,
 		if (eflags_local != PKGCONF_PKG_ERRF_OK && !(client->flags & PKGCONF_PKG_PKGF_SKIP_ERRORS))
 		{
 			pkgconf_pkg_report_graph_error(client, parent, pkgdep, depnode, eflags_local);
+			if (pkgdep != NULL)
+				pkgconf_pkg_unref(client, pkgdep);
 			continue;
 		}
 		if (pkgdep == NULL)

--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -536,7 +536,7 @@ pkgconf_pkg_ref(pkgconf_client_t *client, pkgconf_pkg_t *pkg)
 		PKGCONF_TRACE(client, "WTF: client %p refers to package %p owned by other client %p", client, pkg, pkg->owner);
 
 	pkg->refcount++;
-	PKGCONF_TRACE(client, "refcount@%p: %d", pkg, pkg->refcount);
+	PKGCONF_TRACE(client, "%s: refcount@%p: %d", pkg->id, pkg, pkg->refcount);
 
 	return pkg;
 }
@@ -559,7 +559,7 @@ pkgconf_pkg_unref(pkgconf_client_t *client, pkgconf_pkg_t *pkg)
 		PKGCONF_TRACE(client, "WTF: client %p unrefs package %p owned by other client %p", client, pkg, pkg->owner);
 
 	pkg->refcount--;
-	PKGCONF_TRACE(pkg->owner, "refcount@%p: %d", pkg, pkg->refcount);
+	PKGCONF_TRACE(pkg->owner, "%s: refcount@%p: %d", pkg->id, pkg, pkg->refcount);
 
 	if (pkg->refcount <= 0)
 		pkgconf_pkg_free(pkg->owner, pkg);

--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -453,7 +453,8 @@ pkgconf_pkg_new_from_file(pkgconf_client_t *client, const char *filename, FILE *
 		return NULL;
 	}
 
-	pkgconf_dependency_add(client, &pkg->provides, pkg->id, pkg->version, PKGCONF_CMP_EQUAL, 0);
+	pkgconf_dependency_t *dep = pkgconf_dependency_add(client, &pkg->provides, pkg->id, pkg->version, PKGCONF_CMP_EQUAL, 0);
+	pkgconf_dependency_unref(dep->owner, dep);
 
 	return pkgconf_pkg_ref(client, pkg);
 }

--- a/libpkgconf/queue.c
+++ b/libpkgconf/queue.c
@@ -116,22 +116,26 @@ pkgconf_queue_collect_dependents(pkgconf_client_t *client, pkgconf_pkg_t *pkg, v
 	if (pkg == world)
 		return;
 
-	PKGCONF_FOREACH_LIST_ENTRY(pkg->required.head, node)
-	{
-		pkgconf_dependency_t *flattened_dep;
+	if ((pkg->flags & PKGCONF_PKG_PROPF_STATIC) == PKGCONF_PKG_PROPF_STATIC) {
+		PKGCONF_FOREACH_LIST_ENTRY(pkg->requires_private.head, node)
+		{
+			pkgconf_dependency_t *flattened_dep;
 
-		flattened_dep = pkgconf_dependency_copy(client, node->data);
+			flattened_dep = pkgconf_dependency_copy(client, node->data);
 
-		pkgconf_node_insert(&flattened_dep->iter, flattened_dep, &world->required);
+			pkgconf_node_insert(&flattened_dep->iter, flattened_dep, &world->requires_private);
+		}
 	}
-
-	PKGCONF_FOREACH_LIST_ENTRY(pkg->requires_private.head, node)
+	else
 	{
-		pkgconf_dependency_t *flattened_dep;
+		PKGCONF_FOREACH_LIST_ENTRY(pkg->required.head, node)
+		{
+			pkgconf_dependency_t *flattened_dep;
 
-		flattened_dep = pkgconf_dependency_copy(client, node->data);
+			flattened_dep = pkgconf_dependency_copy(client, node->data);
 
-		pkgconf_node_insert(&flattened_dep->iter, flattened_dep, &world->requires_private);
+			pkgconf_node_insert(&flattened_dep->iter, flattened_dep, &world->required);
+		}
 	}
 }
 

--- a/libpkgconf/queue.c
+++ b/libpkgconf/queue.c
@@ -160,7 +160,9 @@ flatten_dependency_set(pkgconf_client_t *client, pkgconf_list_t *list)
 			continue;
 
 		if (pkg->serial == client->serial)
-			continue;
+		{
+			goto next;
+		}
 
 		if (dep->match == NULL)
 		{
@@ -191,7 +193,8 @@ flatten_dependency_set(pkgconf_client_t *client, pkgconf_list_t *list)
 
 		PKGCONF_TRACE(client, "added %s to dep table", dep->package);
 
-next:;
+next:
+		pkgconf_pkg_unref(client, pkg);
 	}
 
 	qsort(deps, dep_count, sizeof (void *), dep_sort_cmp);

--- a/libpkgconf/queue.c
+++ b/libpkgconf/queue.c
@@ -272,24 +272,28 @@ pkgconf_queue_apply(pkgconf_client_t *client, pkgconf_list_t *list, pkgconf_queu
 		.realname = "virtual world package",
 		.flags = PKGCONF_PKG_PROPF_STATIC | PKGCONF_PKG_PROPF_VIRTUAL,
 	};
+	bool ret = false;
 
 	/* if maxdepth is one, then we will not traverse deeper than our virtual package. */
 	if (!maxdepth)
 		maxdepth = -1;
 
 	if (pkgconf_queue_verify(client, &world, list, maxdepth) != PKGCONF_PKG_ERRF_OK)
-		return false;
+	{
+		goto out;
+	}
 
 	/* the world dependency set is flattened after it is returned from pkgconf_queue_verify */
 	if (!func(client, &world, data, maxdepth))
 	{
-		pkgconf_pkg_free(client, &world);
-		return false;
+		goto out;
 	}
 
-	pkgconf_pkg_free(client, &world);
 
-	return true;
+	ret = true;
+out:
+	pkgconf_pkg_free(client, &world);
+	return ret;
 }
 
 /*


### PR DESCRIPTION
This sorts out all of the memory leaks found my the address sanitizer in the test suite. As a result of getting them all sorted out, I've enabled the address sanitizer in one test in the CI, to help keep that working.