### PR TITLE
meson: remove useless command that isn't needed

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -19,5 +19,4 @@ tests = [
 # yuck
 foreach test : tests
   test_file = configure_file(input: test + '.sh', output: test, copy: true)
-  run_command('chmod', '755', test_file, check : true)
 endforeach


### PR DESCRIPTION
The tests/*.sh are executable in the source tree, and don't need to be chmodded after being copied to the build tree.