### PR TITLE
pkg: make pkgconf_compare_version consistent

### DIFF
--- a/doc/libpkgconf-pkg.rst
+++ b/doc/libpkgconf-pkg.rst
@@ -76,7 +76,7 @@ routines.
 
    :param char* a: The first version to compare in the pair.
    :param char* b: The second version to compare in the pair.
-   :return: -1 if the first version is greater, 0 if both versions are equal, 1 if the second version is greater.
+   :return: -1 if the first version is less than, 0 if both versions are equal, 1 if the second version is less than.
    :rtype: int
 
 .. c:function:: pkgconf_pkg_t *pkgconf_builtin_pkg_get(const char *name)

--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -826,7 +826,7 @@ out:
  *
  *    :param char* a: The first version to compare in the pair.
  *    :param char* b: The second version to compare in the pair.
- *    :return: -1 if the first version is greater, 0 if both versions are equal, 1 if the second version is greater.
+ *    :return: -1 if the first version is less than, 0 if both versions are equal, 1 if the second version is less than.
  *    :rtype: int
  */
 int
@@ -841,10 +841,10 @@ pkgconf_compare_version(const char *a, const char *b)
 
 	/* optimization: if version matches then it's the same version. */
 	if (a == NULL)
-		return 1;
+		return -1;
 
 	if (b == NULL)
-		return -1;
+		return 1;
 
 	if (!strcasecmp(a, b))
 		return 0;
@@ -865,9 +865,9 @@ pkgconf_compare_version(const char *a, const char *b)
 		if (*one == '~' || *two == '~')
 		{
 			if (*one != '~')
-				return -1;
-			if (*two != '~')
 				return 1;
+			if (*two != '~')
+				return -1;
 
 			one++;
 			two++;


### PR DESCRIPTION
The code taken from rpmvercmp in pkg-config returns -1 if a is less than 
b, 0 if a is equal to b, and 1 if a is greater than b. This matches the  
expectations of the comparison operators that use this function.         
However, the tilde handling, the NULL handling, and the docstring all do 
the opposite.                                                            
                                                                         
This fixes the tilde handling, the NULL handling, and the docstring to   
match the behavior of the rpmvercmp code and the expectations of the     
comparison operators.

The tilde handling fix is basically a revert of 22d7625

Before: https://godbolt.org/z/GfafdffY7

After: https://godbolt.org/z/Ysf7xjvTK

dpkg behavior for comparison:
```
$ dpkg --compare-versions '1.0.0~rc1' '<<' '1.0.0' && echo true || echo false
true
```