### PR TITLE
pkgconf:  Handle spaces correctly when expanding variables

### DIFF
--- a/libpkgconf/argvsplit.c
+++ b/libpkgconf/argvsplit.c
@@ -80,7 +80,7 @@ pkgconf_argv_split(const char *src, int *argc, char ***argv)
 		if (escaped)
 		{
 			/* POSIX: only \CHAR is special inside a double quote if CHAR is {$, `, ", \, newline}. */
-			if (quote == '\"')
+			if (quote)
 			{
 				if (!(*src_iter == '$' || *src_iter == '`' || *src_iter == '"' || *src_iter == '\\'))
 					*dst_iter++ = '\\';
@@ -88,8 +88,15 @@ pkgconf_argv_split(const char *src, int *argc, char ***argv)
 				*dst_iter++ = *src_iter;
 			}
 			else
-				*dst_iter++ = *src_iter;
+			{
+				/* If we are outside a quoted string/char, an escaped space is usually used to
+				   preserve spaces in file names. */
+				if (*src_iter != ' ')
+					*dst_iter++ = '\\';
 
+				*dst_iter++ = *src_iter;
+			}
+            
 			escaped = false;
 		}
 		else if (quote)
@@ -118,11 +125,9 @@ pkgconf_argv_split(const char *src, int *argc, char ***argv)
 		}
 		else switch(*src_iter)
 		{
-#ifndef _WIN32
 			case '\\':
 				escaped = true;
 				break;
-#endif
 
 			case '\"':
 			case '\'':

--- a/tests/lib1/spaces-in-paths.pc
+++ b/tests/lib1/spaces-in-paths.pc
@@ -1,0 +1,7 @@
+prefix=/test\ with\ spaces
+includedir=${prefix}/include
+
+Name: spaces-in-paths
+Version: 1
+Description: test package for properly expanding spaces in variables
+Cflags: -I${includedir} -I${includedir}/subdir


### PR DESCRIPTION
Given the following .pc fragment:

includedir=/mingw64/include
Cflags: -I${includedir} -I${includedir}/taglib

Should includedir be assigned the value 'C:/Program\ Files/Git/mingw64/include', the expansion of ${includedir} will be chopped off after the first space:

Cflags: -IC:/Program\

With this patch, the expansion is corrected:

Cflags: -IC:/Program\ Files/Git/mingw64/include -IC:/Program\ Files/Git/mingw64/include/taglib

Create spaces-in-paths.pc