### PR TITLE
Don't prepend sysroot_dir if pkg-config file lies outside of sysroot_dir

### DIFF
--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -434,7 +434,9 @@ pkgconf_pkg_new_from_file(pkgconf_client_t *client, const char *filename, FILE *
 	 * See https://github.com/pkgconf/pkgconf/issues/213
 	 */
 	if (client->sysroot_dir && strncmp(pkg->pc_filedir, client->sysroot_dir, strlen(client->sysroot_dir)))
-		pkgconf_tuple_add(client, &pkg->vars, "pc_sysrootdir", "", false, pkg->flags);
+	{
+		pkgconf_client_set_sysroot_dir(client, "");
+	}
 
 	/* make module id */
 	if ((idptr = strrchr(pkg->filename, PKG_DIR_SEP_S)) != NULL)


### PR DESCRIPTION
Proposal to fix again issue https://github.com/pkgconf/pkgconf/issues/213 (the fix from Pull Request https://github.com/pkgconf/pkgconf/pull/226 is broken meanwhile)