### PR TITLE
Use the -l:lib syntax when pkgconf is called with --static

### DIFF
--- a/libpkgconf/fragment.c
+++ b/libpkgconf/fragment.c
@@ -146,8 +146,27 @@ pkgconf_fragment_add(const pkgconf_client_t *client, pkgconf_list_t *list, const
 		frag = calloc(sizeof(pkgconf_fragment_t), 1);
 
 		frag->type = *(string + 1);
-		frag->data = pkgconf_fragment_copy_munged(client, string + 2, flags);
 
+		if ((client->flags & PKGCONF_PKG_PKGF_MERGE_PRIVATE_FRAGMENTS) &&
+		    (frag->type == 'l') && (*(string + 2) != ':'))
+		{
+			size_t len;
+			char *newdata;
+
+			len = strlen(string + 2) + strlen(":lib") + strlen(".a") + 3;
+			newdata = malloc(len);
+
+			pkgconf_strlcpy(newdata, ":lib", len);
+			pkgconf_strlcat(newdata, string + 2, len);
+			pkgconf_strlcat(newdata, ".a", len);
+
+			frag->data = pkgconf_fragment_copy_munged(client, newdata, flags);
+
+			free(newdata);
+		}
+		else
+			frag->data = pkgconf_fragment_copy_munged(client, string + 2, flags);
+ 
 		PKGCONF_TRACE(client, "added fragment {%c, '%s'} to list @%p", frag->type, frag->data, list);
 	}
 	else


### PR DESCRIPTION
Libraries from Requires.private and Libs.private will only be included when static linking. So, for static linking, pkgconf is used with the --static option.

cc \`pkgconf --static --cflags --libs name\` -o myapp myapp.c

We expect that the static version of the libraries are used during the link of myapp (libname.a as well as the .a libraries from Requires.private and Libs.private). But if both versions of the libraries (static and dynamic) are available, the dynamic version (.so) is preferred by the linker.

This change proposes to replace the -l part for libraries using the -l:lib syntax when pkgconf is called with the --static option (-lname is replaced by -l:libname.a). So a static link is done as expected, even if a dynamic version of the libraries is available.

The current implementation of this change may not be perfect, it focuses on the principle of the proposal.