### PR TITLE
argvsplit: fix some quoting rules

### DIFF
--- a/libpkgconf/argvsplit.c
+++ b/libpkgconf/argvsplit.c
@@ -89,11 +89,6 @@ pkgconf_argv_split(const char *src, int *argc, char ***argv)
 			}
 			else
 			{
-				/* If we are outside a quoted string/char, an escaped space is usually used to
-				   preserve spaces in file names. */
-				if (!(*src_iter == '$' || *src_iter == '`' || *src_iter == '"' || *src_iter == '\\' || *src_iter == ' '))
-					*dst_iter++ = '\\';
-
 				*dst_iter++ = *src_iter;
 			}
 

--- a/tests/lib1/quotes.pc
+++ b/tests/lib1/quotes.pc
@@ -7,4 +7,4 @@ Name: quotes
 Description: A testing pkg-config file
 Version: 1.2.3
 Libs: -L${libdir} -lfoo
-Cflags: -DQUOTED=\"bla\"
+Cflags: -DQUOTED=\"bla\" -DA=\"escaped\ string\'\ \literal\" -DB="\1\$" -DC='bla'

--- a/tests/parser.sh
+++ b/tests/parser.sh
@@ -142,7 +142,7 @@ quoted_body()
 {
 	export PKG_CONFIG_PATH="${selfdir}/lib1"
 	atf_check \
-		-o inline:"-DQUOTED=\\\"bla\\\"\n" \
+		-o inline:"-DQUOTED=\\\"bla\\\" -DA=\\\"escaped\\ string\\\'\\ literal\\\" -DB=\\\\\\1\$ -DC=bla\n" \
 		pkgconf --cflags quotes
 }
 


### PR DESCRIPTION
- Fix the issue：#287 
I built some test cases, which can cover all conditions, and it can be successfully executed under my Linux.