### PR TITLE
meson.build: fix warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -58,6 +58,10 @@ cdata.set_quoted('PACKAGE_VERSION', meson.project_version())
 cdata.set_quoted('PACKAGE_BUGREPORT', 'https://todo.sr.ht/~kaniini/pkgconf')
 cdata.set('abs_top_srcdir', meson.current_source_dir())
 cdata.set('abs_top_builddir', meson.current_build_dir())
+# required by tests/test_env.sh.in (autoconf)
+cdata.set_quoted('prefix', get_option('prefix'))
+cdata.set_quoted('exec_prefix', get_option('prefix'))
+cdata.set_quoted('datarootdir', join_paths(get_option('prefix'), 'share'))
 
 
 subdir('libpkgconf')


### PR DESCRIPTION
fix this warning:
  tests/meson.build:2: WARNING: The variable(s) 'datarootdir', 'exec_prefix', 'prefix' in the input file 'tests/test_env.sh.in' are not present in the given configuration data.

muon errors out:
  tests/test_env.sh.in:32:10: error key not found in configuration data
    32 | prefix="@prefix@"