### PR TITLE
cli: fix --modversion not working with provided deps

### DIFF
--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -607,6 +607,9 @@ pkgconf_pkg_try_specific_path(pkgconf_client_t *client, const char *path, const 
 	{
 		PKGCONF_TRACE(client, "found (uninstalled): %s", uninst_locbuf);
 		pkg = pkgconf_pkg_new_from_file(client, uninst_locbuf, f, PKGCONF_PKG_PROPF_UNINSTALLED);
+
+		pkgconf_dependency_t *provides_dep = pkgconf_dependency_add(client, &pkg->provides, strdup(name), pkg->version, PKGCONF_CMP_EQUAL, 0);
+		pkgconf_dependency_unref(provides_dep->owner, provides_dep);
 	}
 	else if ((f = fopen(locbuf, "r")) != NULL)
 	{


### PR DESCRIPTION
If a dep is resolved via the provides property the package id will be different to the requested dep. This matches the requested dep against provided dep names instead.

I ran into this issue when building a package depending on sdl, which is provided by sdl12_compat on my system. I'm not familiar enough with pkgconf to say this change couldn't have other unintended side effects, but it has worked for me in this case.