### PR TITLE
cli: fix --modversion not showing version in various cases

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -306,7 +306,7 @@ apply_modversion(pkgconf_client_t *client, pkgconf_pkg_t *world, void *data, int
 			pkgconf_dependency_t *dep = world_iter->data;
 			pkgconf_pkg_t *pkg = dep->match;
 
-			if (strncmp(pkg->id, queue_node->package, strlen(pkg->id)))
+			if (strcmp(pkg->why, queue_node->package))
 				continue;
 
 			if (pkg->version != NULL) {
@@ -315,6 +315,8 @@ apply_modversion(pkgconf_client_t *client, pkgconf_pkg_t *world, void *data, int
 
 				printf("%s\n", pkg->version);
 			}
+
+			break;
 		}
 	}
 

--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -149,6 +149,7 @@ struct pkgconf_pkg_ {
 	char *license;
 	char *maintainer;
 	char *copyright;
+	char *why;
 
 	pkgconf_list_t libs;
 	pkgconf_list_t libs_private;

--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -546,6 +546,9 @@ pkgconf_pkg_free(pkgconf_client_t *client, pkgconf_pkg_t *pkg)
 	if (pkg->copyright != NULL)
 		free(pkg->copyright);
 
+	if (pkg->why != NULL)
+		free(pkg->why);
+
 	free(pkg);
 }
 
@@ -1398,19 +1401,24 @@ pkgconf_pkg_verify_dependency(pkgconf_client_t *client, pkgconf_dependency_t *pk
 			return NULL;
 		}
 
-		return pkgconf_pkg_scan_providers(client, pkgdep, eflags);
-	}
-
-	if (pkg->id == NULL)
-		pkg->id = strdup(pkgdep->package);
-
-	if (pkgconf_pkg_comparator_impls[pkgdep->compare](pkg->version, pkgdep->version) != true)
-	{
-		if (eflags != NULL)
-			*eflags |= PKGCONF_PKG_ERRF_PACKAGE_VER_MISMATCH;
+		pkg = pkgconf_pkg_scan_providers(client, pkgdep, eflags);
 	}
 	else
-		pkgdep->match = pkgconf_pkg_ref(client, pkg);
+	{
+		if (pkg->id == NULL)
+			pkg->id = strdup(pkgdep->package);
+
+		if (pkgconf_pkg_comparator_impls[pkgdep->compare](pkg->version, pkgdep->version) != true)
+		{
+			if (eflags != NULL)
+				*eflags |= PKGCONF_PKG_ERRF_PACKAGE_VER_MISMATCH;
+		}
+		else
+			pkgdep->match = pkgconf_pkg_ref(client, pkg);
+	}
+
+	if (pkg != NULL)
+		pkg->why = strdup(pkgdep->package);
 
 	return pkg;
 }

--- a/tests/lib1/foobar.pc
+++ b/tests/lib1/foobar.pc
@@ -1,0 +1,12 @@
+prefix=/test
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: foobar
+Description: A testing pkg-config file
+Version: 3.2.1
+Libs: -L${libdir} -lfoobar
+Cflags: -fPIC -I${includedir}/foobar
+Cflags.private: -DFOOBAR_STATIC
+License: ISC

--- a/tests/lib1/unavailable-provider.pc
+++ b/tests/lib1/unavailable-provider.pc
@@ -1,0 +1,11 @@
+prefix=/test
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: unavailable_provider
+Description: Provides an otherwise unavailable package
+Version: 1.2.3
+Provides: unavailable = 1.2.3
+Libs: -lunavailable
+Cflags:

--- a/tests/regress.sh
+++ b/tests/regress.sh
@@ -23,6 +23,9 @@ tests_init \
 	idirafter_munge_order \
 	idirafter_munge_sysroot \
 	idirafter_ordering \
+	modversion_common_prefix \
+	modversion_fullpath \
+	modversion_provides \
 	modversion_uninstalled \
 	pcpath \
 	virtual_variable \
@@ -273,6 +276,24 @@ billion_laughs_body()
 {
 	atf_check -o inline:"warning: truncating very long variable to 64KB\nwarning: truncating very long variable to 64KB\nwarning: truncating very long variable to 64KB\nwarning: truncating very long variable to 64KB\nwarning: truncating very long variable to 64KB\n" \
 		pkgconf --with-path="${selfdir}/lib1" --validate billion-laughs
+}
+
+modversion_common_prefix_body()
+{
+	atf_check -o inline:"foo: 1.2.3\nfoobar: 3.2.1\n" \
+		pkgconf --with-path="${selfdir}/lib1" --modversion --verbose foo foobar
+}
+
+modversion_fullpath_body()
+{
+	atf_check -o inline:"1.2.3\n" \
+		pkgconf --modversion "${selfdir}/lib1/foo.pc"
+}
+
+modversion_provides_body()
+{
+	atf_check -o inline:"1.2.3\n" \
+		pkgconf --with-path="${selfdir}/lib1" --modversion unavailable
 }
 
 modversion_uninstalled_body()


### PR DESCRIPTION
There are numerous edge cases where version is wrong or missing when matching the dependency queue to resolved packages. This adds the dependency name as it appears in the dependency queue to each package as it is resolved, allowing for a simple and correct comparison when printing.

This is an alternative approach to  #311

This should resolve these current issues;

- duplicate and/or incorrect versions shown in cases like libev libevdev
- no version shown for complete paths (#312)
- no version shown when package is matched by provides. sdl  -> sdl12_compat
- no version shown when package is matched by -uninstalled