### PR TITLE
libpkgconf: fix memory leak

### DIFF
--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -1417,7 +1417,7 @@ pkgconf_pkg_verify_dependency(pkgconf_client_t *client, pkgconf_dependency_t *pk
 			pkgdep->match = pkgconf_pkg_ref(client, pkg);
 	}
 
-	if (pkg != NULL)
+	if (pkg != NULL && pkg->why == NULL)
 		pkg->why = strdup(pkgdep->package);
 
 	return pkg;


### PR DESCRIPTION
Passing all tests (with asan).

This section can receive the same package instance multiple times. From what I've seen `pkgdep->package` is always the same, so I've elected to only set the `why` field the first time.