### PR TITLE
meson: Add with-system options

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -49,8 +49,18 @@ foreach f : ['libdir', 'datadir']
   personality_path += [join_paths(get_option('prefix'), get_option(f), 'pkgconfig', 'personality.d')]
 endforeach
 
-cdata.set_quoted('SYSTEM_LIBDIR', join_paths(get_option('prefix'), get_option('libdir')))
-cdata.set_quoted('SYSTEM_INCLUDEDIR', join_paths(get_option('prefix'), get_option('includedir')))
+SYSTEM_LIBDIR = get_option('with-system-libdir')
+if SYSTEM_LIBDIR != ''
+  cdata.set_quoted('SYSTEM_LIBDIR', SYSTEM_LIBDIR)
+else
+  cdata.set_quoted('SYSTEM_LIBDIR', join_paths(get_option('prefix'), get_option('libdir')))
+endif
+SYSTEM_INCLUDEDIR = get_option('with-system-includedir')
+if SYSTEM_INCLUDEDIR != ''
+  cdata.set_quoted('SYSTEM_INCLUDEDIR', SYSTEM_INCLUDEDIR)
+else
+  cdata.set_quoted('SYSTEM_INCLUDEDIR', join_paths(get_option('prefix'), get_option('includedir')))
+endif
 cdata.set_quoted('PKG_DEFAULT_PATH', ':'.join(default_path))
 cdata.set_quoted('PERSONALITY_PATH', ':'.join(personality_path))
 cdata.set_quoted('PACKAGE_NAME', meson.project_name())

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,3 +3,17 @@ option(
   type: 'feature',
   description: 'Build tests which depends upon the kyua framework',
 )
+
+option(
+  'with-system-libdir',
+  type: 'string',
+  value: '',
+  description: 'Specify the system library directory (default {prefix}/{libdir})'
+)
+
+option(
+  'with-system-includedir',
+  type: 'string',
+  value: '',
+  description: 'Specify the system include directory (default {prefix}/{includedir})'
+)


### PR DESCRIPTION
Hi @kaniini,

This PR is to allow the Meson build system to override the system include and/or lib folder like Autotools.

Fixes #283