### PR TITLE
Fix search order

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1019,7 +1019,7 @@ main(int argc, char *argv[])
 	pkgconf_client_init(&pkg_client, error_handler, NULL, personality);
 
 	/* user-supplied dirs come first */
-	pkgconf_client_dir_list_add(&pkg_client, &prepended_dir_list);
+	pkgconf_path_copy_list(&pkg_client.dir_list, &prepended_dir_list);
 	pkgconf_path_free(&prepended_dir_list);
 
 #ifndef PKGCONF_LITE

--- a/cli/main.c
+++ b/cli/main.c
@@ -827,7 +827,7 @@ main(int argc, char *argv[])
 {
 	int ret;
 	pkgconf_list_t pkgq = PKGCONF_LIST_INITIALIZER;
-	pkgconf_list_t dir_list = PKGCONF_LIST_INITIALIZER;
+	pkgconf_list_t prependend_dir_list = PKGCONF_LIST_INITIALIZER;
 	char *builddir;
 	char *sysroot_dir;
 	char *env_traverse_depth;
@@ -967,7 +967,7 @@ main(int argc, char *argv[])
 			logfile_arg = pkg_optarg;
 			break;
 		case 42:
-			pkgconf_path_add(pkg_optarg, &dir_list, true);
+			pkgconf_path_add(pkg_optarg, &prependend_dir_list, true);
 			break;
 		case 43:
 			pkgconf_client_set_prefix_varname(&pkg_client, pkg_optarg);
@@ -1006,19 +1006,21 @@ main(int argc, char *argv[])
 #endif
 	}
 
-	pkgconf_path_copy_list(&personality->dir_list, &dir_list);
-	pkgconf_path_free(&dir_list);
-
 #ifndef PKGCONF_LITE
 	if ((want_flags & PKG_DUMP_PERSONALITY) == PKG_DUMP_PERSONALITY)
 	{
 		dump_personality(personality);
+		pkgconf_path_free(&prependend_dir_list);
 		return EXIT_SUCCESS;
 	}
 #endif
 
 	/* now, bring up the client.  settings are preserved since the client is prealloced */
 	pkgconf_client_init(&pkg_client, error_handler, NULL, personality);
+
+	/* user-supplied dirs come first */
+	pkgconf_client_dir_list_add(&pkg_client, &prependend_dir_list);
+	pkgconf_path_free(&prependend_dir_list);
 
 #ifndef PKGCONF_LITE
 	if ((want_flags & PKG_MSVC_SYNTAX) == PKG_MSVC_SYNTAX || getenv("PKG_CONFIG_MSVC_SYNTAX") != NULL)

--- a/cli/main.c
+++ b/cli/main.c
@@ -827,7 +827,7 @@ main(int argc, char *argv[])
 {
 	int ret;
 	pkgconf_list_t pkgq = PKGCONF_LIST_INITIALIZER;
-	pkgconf_list_t prependend_dir_list = PKGCONF_LIST_INITIALIZER;
+	pkgconf_list_t prepended_dir_list = PKGCONF_LIST_INITIALIZER;
 	char *builddir;
 	char *sysroot_dir;
 	char *env_traverse_depth;
@@ -967,7 +967,7 @@ main(int argc, char *argv[])
 			logfile_arg = pkg_optarg;
 			break;
 		case 42:
-			pkgconf_path_add(pkg_optarg, &prependend_dir_list, true);
+			pkgconf_path_add(pkg_optarg, &prepended_dir_list, true);
 			break;
 		case 43:
 			pkgconf_client_set_prefix_varname(&pkg_client, pkg_optarg);
@@ -1010,7 +1010,7 @@ main(int argc, char *argv[])
 	if ((want_flags & PKG_DUMP_PERSONALITY) == PKG_DUMP_PERSONALITY)
 	{
 		dump_personality(personality);
-		pkgconf_path_free(&prependend_dir_list);
+		pkgconf_path_free(&prepended_dir_list);
 		return EXIT_SUCCESS;
 	}
 #endif
@@ -1019,8 +1019,8 @@ main(int argc, char *argv[])
 	pkgconf_client_init(&pkg_client, error_handler, NULL, personality);
 
 	/* user-supplied dirs come first */
-	pkgconf_client_dir_list_add(&pkg_client, &prependend_dir_list);
-	pkgconf_path_free(&prependend_dir_list);
+	pkgconf_client_dir_list_add(&pkg_client, &prepended_dir_list);
+	pkgconf_path_free(&prepended_dir_list);
 
 #ifndef PKGCONF_LITE
 	if ((want_flags & PKG_MSVC_SYNTAX) == PKG_MSVC_SYNTAX || getenv("PKG_CONFIG_MSVC_SYNTAX") != NULL)

--- a/libpkgconf/client.c
+++ b/libpkgconf/client.c
@@ -65,13 +65,14 @@ pkgconf_client_dir_list_add(pkgconf_client_t *client, const pkgconf_list_t *dir_
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_client_dir_list_build(pkgconf_client_t *client)
+ * .. c:function:: void pkgconf_client_dir_list_build(pkgconf_client_t *client, const pkgconf_cross_personality_t *personality)
  *
  *    Bootstraps the package search paths.  If the ``PKGCONF_PKG_PKGF_ENV_ONLY`` `flag` is set on the client,
  *    then only the ``PKG_CONFIG_PATH`` environment variable will be used, otherwise both the
  *    ``PKG_CONFIG_PATH`` and ``PKG_CONFIG_LIBDIR`` environment variables will be used.
  *
  *    :param pkgconf_client_t* client: The pkgconf client object to bootstrap.
+ *    :param pkgconf_cross_personality_t* personality: the cross-compile personality to use
  *    :return: nothing
  */
 void

--- a/libpkgconf/client.c
+++ b/libpkgconf/client.c
@@ -48,6 +48,23 @@ trace_path_list(const pkgconf_client_t *client, const char *desc, pkgconf_list_t
 /*
  * !doc
  *
+ * .. c:function:: void pkgconf_client_dir_list_add(pkgconf_client_t *client, const pkgconf_list_t *dir_list)
+ *
+ *    Add to package search paths.
+ *
+ *    :param pkgconf_client_t* client: The pkgconf client object to bootstrap.
+ *    :param const pkgconf_list_t *dir_list: The list of directories to be added.
+ *    :return: nothing
+ */
+void
+pkgconf_client_dir_list_add(pkgconf_client_t *client, const pkgconf_list_t *dir_list)
+{
+	pkgconf_path_copy_list(&client->dir_list, dir_list);
+}
+
+/*
+ * !doc
+ *
  * .. c:function:: void pkgconf_client_dir_list_build(pkgconf_client_t *client)
  *
  *    Bootstraps the package search paths.  If the ``PKGCONF_PKG_PKGF_ENV_ONLY`` `flag` is set on the client,

--- a/libpkgconf/client.c
+++ b/libpkgconf/client.c
@@ -48,23 +48,6 @@ trace_path_list(const pkgconf_client_t *client, const char *desc, pkgconf_list_t
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_client_dir_list_add(pkgconf_client_t *client, const pkgconf_list_t *dir_list)
- *
- *    Add to package search paths.
- *
- *    :param pkgconf_client_t* client: The pkgconf client object to bootstrap.
- *    :param const pkgconf_list_t *dir_list: The list of directories to be added.
- *    :return: nothing
- */
-void
-pkgconf_client_dir_list_add(pkgconf_client_t *client, const pkgconf_list_t *dir_list)
-{
-	pkgconf_path_copy_list(&client->dir_list, dir_list);
-}
-
-/*
- * !doc
- *
  * .. c:function:: void pkgconf_client_dir_list_build(pkgconf_client_t *client, const pkgconf_cross_personality_t *personality)
  *
  *    Bootstraps the package search paths.  If the ``PKGCONF_PKG_PKGF_ENV_ONLY`` `flag` is set on the client,

--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -250,6 +250,7 @@ PKGCONF_API pkgconf_error_handler_func_t pkgconf_client_get_error_handler(const 
 PKGCONF_API void pkgconf_client_set_error_handler(pkgconf_client_t *client, pkgconf_error_handler_func_t error_handler, void *error_handler_data);
 PKGCONF_API pkgconf_error_handler_func_t pkgconf_client_get_trace_handler(const pkgconf_client_t *client);
 PKGCONF_API void pkgconf_client_set_trace_handler(pkgconf_client_t *client, pkgconf_error_handler_func_t trace_handler, void *trace_handler_data);
+PKGCONF_API void pkgconf_client_dir_list_add(pkgconf_client_t *client, const pkgconf_list_t *dir_list);
 PKGCONF_API void pkgconf_client_dir_list_build(pkgconf_client_t *client, const pkgconf_cross_personality_t *personality);
 
 /* personality.c */

--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -250,7 +250,6 @@ PKGCONF_API pkgconf_error_handler_func_t pkgconf_client_get_error_handler(const 
 PKGCONF_API void pkgconf_client_set_error_handler(pkgconf_client_t *client, pkgconf_error_handler_func_t error_handler, void *error_handler_data);
 PKGCONF_API pkgconf_error_handler_func_t pkgconf_client_get_trace_handler(const pkgconf_client_t *client);
 PKGCONF_API void pkgconf_client_set_trace_handler(pkgconf_client_t *client, pkgconf_error_handler_func_t trace_handler, void *trace_handler_data);
-PKGCONF_API void pkgconf_client_dir_list_add(pkgconf_client_t *client, const pkgconf_list_t *dir_list);
 PKGCONF_API void pkgconf_client_dir_list_build(pkgconf_client_t *client, const pkgconf_cross_personality_t *personality);
 
 /* personality.c */

--- a/libpkgconf/path.c
+++ b/libpkgconf/path.c
@@ -112,7 +112,7 @@ pkgconf_path_add(const char *text, pkgconf_list_t *dirlist, bool filter)
 	}
 #endif
 
-	pkgconf_node_insert(&node->lnode, node, dirlist);
+	pkgconf_node_insert_tail(&node->lnode, node, dirlist);
 }
 
 /*

--- a/tests/basic.sh
+++ b/tests/basic.sh
@@ -29,16 +29,16 @@ tests_init \
 	libs_circular_directpc \
 	libs_static \
 	libs_static_ordering \
-	license_isc \
-	license_noassertion \
-	modversion_noflatten \
 	pkg_config_path \
+	with_path \
 	nolibs \
 	nocflags \
 	arbitary_path \
-	with_path \
 	relocatable \
-	single_depth_selectors
+	single_depth_selectors \
+	license_isc \
+	license_noassertion \
+	modversion_noflatten
 
 noargs_body()
 {

--- a/tests/basic.sh
+++ b/tests/basic.sh
@@ -31,6 +31,7 @@ tests_init \
 	libs_static_ordering \
 	pkg_config_path \
 	with_path \
+	pkg_config_path_and_with_path \
 	nolibs \
 	nocflags \
 	arbitary_path \
@@ -278,6 +279,17 @@ with_path_body()
 	atf_check \
 		-o inline:"-fPIC -I/test/include/foo\n" \
 		pkgconf --with-path=${selfdir}/lib2 --with-path=${selfdir}/lib1 --cflags --static foo
+}
+
+pkg_config_path_and_with_path_body()
+{
+	export PKG_CONFIG_PATH="${selfdir}/lib2"
+	atf_check \
+		-o inline:"-fPIC -I/test/include/foo\n" \
+		pkgconf --cflags --static foo
+	atf_check \
+		-o inline:"-fPIC -I/test/include/foo -DFOO_STATIC\n" \
+		pkgconf --with-path=${selfdir}/lib1 --cflags --static foo
 }
 
 nolibs_body()

--- a/tests/basic.sh
+++ b/tests/basic.sh
@@ -272,6 +272,12 @@ with_path_body()
 	atf_check \
 		-o inline:"-L/test/lib -lbar -lfoo\n" \
 		pkgconf --with-path=${selfdir}/lib1 --with-path=${selfdir}/lib2 --libs bar
+	atf_check \
+		-o inline:"-fPIC -I/test/include/foo -DFOO_STATIC\n" \
+		pkgconf --with-path=${selfdir}/lib1 --with-path=${selfdir}/lib2 --cflags --static foo
+	atf_check \
+		-o inline:"-fPIC -I/test/include/foo\n" \
+		pkgconf --with-path=${selfdir}/lib2 --with-path=${selfdir}/lib1 --cflags --static foo
 }
 
 nolibs_body()

--- a/tests/basic.sh
+++ b/tests/basic.sh
@@ -259,6 +259,9 @@ pkg_config_path_body()
 	atf_check \
 		-o inline:"-L/test/lib -lbar -lfoo\n" \
 		pkgconf --libs bar
+	atf_check \
+		-o inline:"-fPIC -I/test/include/foo -DFOO_STATIC\n" \
+		pkgconf --cflags --static foo
 }
 
 with_path_body()


### PR DESCRIPTION
Revert https://github.com/pkgconf/pkgconf/commit/384ade5f316367f15da9dbf09853e06fe29bf2bf. (Credits: @1480c1.)
Always insert `--with-path` dirs (command line) before anything else (environment, defaults).
Add tests.

Fixes #326.