### PR TITLE
libpkgconf: fix -Walloc-size

### DIFF
--- a/libpkgconf/argvsplit.c
+++ b/libpkgconf/argvsplit.c
@@ -72,7 +72,7 @@ pkgconf_argv_split(const char *src, int *argc, char ***argv)
 
 	memset(buf, 0, strlen(src) + 1);
 
-	*argv = calloc(sizeof (void *), argv_size);
+	*argv = calloc(argv_size, sizeof (void *));
 	(*argv)[argc_count] = dst_iter;
 
 	while (*src_iter)

--- a/libpkgconf/client.c
+++ b/libpkgconf/client.c
@@ -161,7 +161,7 @@ pkgconf_client_init(pkgconf_client_t *client, pkgconf_error_handler_func_t error
 pkgconf_client_t *
 pkgconf_client_new(pkgconf_error_handler_func_t error_handler, void *error_handler_data, const pkgconf_cross_personality_t *personality)
 {
-	pkgconf_client_t *out = calloc(sizeof(pkgconf_client_t), 1);
+	pkgconf_client_t *out = calloc(1, sizeof(pkgconf_client_t));
 	pkgconf_client_init(out, error_handler, error_handler_data, personality);
 	return out;
 }

--- a/libpkgconf/dependency.c
+++ b/libpkgconf/dependency.c
@@ -130,7 +130,7 @@ pkgconf_dependency_addraw(pkgconf_client_t *client, pkgconf_list_t *list, const 
 {
 	pkgconf_dependency_t *dep;
 
-	dep = calloc(sizeof(pkgconf_dependency_t), 1);
+	dep = calloc(1, sizeof(pkgconf_dependency_t));
 	dep->package = pkgconf_strndup(package, package_sz);
 
 	if (version_sz != 0)
@@ -469,7 +469,7 @@ pkgconf_dependency_copy(pkgconf_client_t *client, const pkgconf_dependency_t *de
 {
 	pkgconf_dependency_t *new_dep;
 
-	new_dep = calloc(sizeof(pkgconf_dependency_t), 1);
+	new_dep = calloc(1, sizeof(pkgconf_dependency_t));
 	new_dep->package = strdup(dep->package);
 
 	if (dep->version != NULL)

--- a/libpkgconf/fragment.c
+++ b/libpkgconf/fragment.c
@@ -143,7 +143,7 @@ pkgconf_fragment_add(const pkgconf_client_t *client, pkgconf_list_t *list, const
 
 	if (strlen(string) > 1 && !pkgconf_fragment_is_special(string))
 	{
-		frag = calloc(sizeof(pkgconf_fragment_t), 1);
+		frag = calloc(1, sizeof(pkgconf_fragment_t));
 
 		frag->type = *(string + 1);
 		frag->data = pkgconf_fragment_copy_munged(client, string + 2, flags);
@@ -192,7 +192,7 @@ pkgconf_fragment_add(const pkgconf_client_t *client, pkgconf_list_t *list, const
 			}
 		}
 
-		frag = calloc(sizeof(pkgconf_fragment_t), 1);
+		frag = calloc(1, sizeof(pkgconf_fragment_t));
 
 		frag->type = 0;
 		frag->data = strdup(string);
@@ -353,7 +353,7 @@ pkgconf_fragment_copy(const pkgconf_client_t *client, pkgconf_list_t *list, cons
 	else if (!is_private && !pkgconf_fragment_can_merge_back(base, client->flags, is_private) && (pkgconf_fragment_lookup(list, base) != NULL))
 		return;
 
-	frag = calloc(sizeof(pkgconf_fragment_t), 1);
+	frag = calloc(1, sizeof(pkgconf_fragment_t));
 
 	frag->type = base->type;
 	frag->merged = base->merged;
@@ -427,7 +427,7 @@ fragment_quote(const pkgconf_fragment_t *frag)
 	if (frag->data == NULL)
 		return NULL;
 
-	out = dst = calloc(outlen, 1);
+	out = dst = calloc(1, outlen);
 
 	for (; *src; src++)
 	{

--- a/libpkgconf/path.c
+++ b/libpkgconf/path.c
@@ -90,7 +90,7 @@ prepare_path_node(const char *text, pkgconf_list_t *dirlist, bool filter)
 		return NULL;
 #endif
 
-	node = calloc(sizeof(pkgconf_path_t), 1);
+	node = calloc(1, sizeof(pkgconf_path_t));
 	node->path = strdup(path);
 
 #ifdef PKGCONF_CACHE_INODES
@@ -266,7 +266,7 @@ pkgconf_path_copy_list(pkgconf_list_t *dst, const pkgconf_list_t *src)
 	{
 		pkgconf_path_t *srcpath = n->data, *path;
 
-		path = calloc(sizeof(pkgconf_path_t), 1);
+		path = calloc(1, sizeof(pkgconf_path_t));
 		path->path = strdup(srcpath->path);
 
 #ifdef PKGCONF_CACHE_INODES

--- a/libpkgconf/personality.c
+++ b/libpkgconf/personality.c
@@ -257,7 +257,7 @@ load_personality_with_path(const char *path, const char *triplet)
 	if (f == NULL)
 		return NULL;
 
-	p = calloc(sizeof(pkgconf_cross_personality_t), 1);
+	p = calloc(1, sizeof(pkgconf_cross_personality_t));
 	if (triplet != NULL)
 		p->name = strdup(triplet);
 	pkgconf_parser_parse(f, p, personality_parser_ops, personality_warn_func, pathbuf);

--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -250,7 +250,7 @@ determine_prefix(const pkgconf_pkg_t *pkg, char *buf, size_t buflen)
 static char *
 convert_path_to_value(const char *path)
 {
-	char *buf = calloc((strlen(path) + 1) * 2, 1);
+	char *buf = calloc(1, (strlen(path) + 1) * 2);
 	char *bptr = buf;
 	const char *i;
 
@@ -419,7 +419,7 @@ pkgconf_pkg_new_from_file(pkgconf_client_t *client, const char *filename, FILE *
 	pkgconf_pkg_t *pkg;
 	char *idptr;
 
-	pkg = calloc(sizeof(pkgconf_pkg_t), 1);
+	pkg = calloc(1, sizeof(pkgconf_pkg_t));
 	pkg->owner = client;
 	pkg->filename = strdup(filename);
 	pkg->pc_filedir = pkg_get_parent_dir(pkg);

--- a/libpkgconf/queue.c
+++ b/libpkgconf/queue.c
@@ -43,7 +43,7 @@
 void
 pkgconf_queue_push(pkgconf_list_t *list, const char *package)
 {
-	pkgconf_queue_t *pkgq = calloc(sizeof(pkgconf_queue_t), 1);
+	pkgconf_queue_t *pkgq = calloc(1, sizeof(pkgconf_queue_t));
 
 	pkgq->package = strdup(package);
 	pkgconf_node_insert_tail(&pkgq->iter, pkgq, list);

--- a/libpkgconf/tuple.c
+++ b/libpkgconf/tuple.c
@@ -156,7 +156,7 @@ pkgconf_tuple_find_delete(pkgconf_list_t *list, const char *key)
 static char *
 dequote(const char *value)
 {
-	char *buf = calloc((strlen(value) + 1) * 2, 1);
+	char *buf = calloc(1, (strlen(value) + 1) * 2);
 	char *bptr = buf;
 	const char *i;
 	char quote = 0;
@@ -236,7 +236,7 @@ pkgconf_tuple_t *
 pkgconf_tuple_add(const pkgconf_client_t *client, pkgconf_list_t *list, const char *key, const char *value, bool parse, unsigned int flags)
 {
 	char *dequote_value;
-	pkgconf_tuple_t *tuple = calloc(sizeof(pkgconf_tuple_t), 1);
+	pkgconf_tuple_t *tuple = calloc(1, sizeof(pkgconf_tuple_t));
 
 	pkgconf_tuple_find_delete(list, key);
 


### PR DESCRIPTION
GCC 14 introduces a new -Walloc-size included in -Wextra which gives:
```
libpkgconf/personality.c:260:11: warning: allocation of insufficient size '1' for type 'pkgconf_cross_personality_t' {aka 'struct pkgconf_cross_personality_'} with size '48' [-Walloc-size]
libpkgconf/queue.c:46:33: warning: allocation of insufficient size '1' for type 'pkgconf_queue_t' {aka'struct pkgconf_queue_'} with size '16' [-Walloc-size]
libpkgconf/client.c:164:33: warning: allocation of insufficient size '1' for type 'pkgconf_client_t' {aka 'struct pkgconf_client_'} with size '120' [-Walloc-size]
libpkgconf/path.c:105:14: warning: allocation of insufficient size '1' for type 'pkgconf_path_t' {aka 'struct pkgconf_path_'} with size '24' [-Walloc-size]
libpkgconf/path.c:237:22: warning: allocation of insufficient size '1' for type 'pkgconf_path_t' {aka 'struct pkgconf_path_'} with size '24' [-Walloc-size]
libpkgconf/tuple.c:239:34: warning: allocation of insufficient size '1' for type 'pkgconf_tuple_t' {aka 'struct pkgconf_tuple_'} with size '24' [-Walloc-size]
libpkgconf/dependency.c:133:13: warning: allocation of insufficient size '1' for type 'pkgconf_dependency_t' {aka 'struct pkgconf_dependency_'} with size '44' [-Walloc-size]
libpkgconf/dependency.c:472:17: warning: allocation of insufficient size '1' for type 'pkgconf_dependency_t' {aka 'struct pkgconf_dependency_'} with size '44' [-Walloc-size]
libpkgconf/fragment.c:146:22: warning: allocation of insufficient size '1' for type 'pkgconf_fragment_t' {aka 'struct pkgconf_fragment_'} with size '24' [-Walloc-size]
libpkgconf/fragment.c:195:22: warning: allocation of insufficient size '1' for type 'pkgconf_fragment_t' {aka 'struct pkgconf_fragment_'} with size '24' [-Walloc-size]
libpkgconf/fragment.c:356:14: warning: allocation of insufficient size '1' for type 'pkgconf_fragment_t' {aka 'struct pkgconf_fragment_'} with size '24' [-Walloc-size]
libpkgconf/pkg.c:422:13: warning: allocation of insufficient size '1' for type 'pkgconf_pkg_t' {aka 'struct pkgconf_pkg_'} with size '188' [-Walloc-size]
libpkgconf/client.c:164:33: warning: allocation of insufficient size '1' for type 'pkgconf_client_t' {aka 'struct pkgconf_client_'} with size '224' [-Walloc-size]
libpkgconf/personality.c:260:11: warning: allocation of insufficient size '1' for type 'pkgconf_cross_personality_t' {aka 'struct pkgconf_cross_personality_'} with size '96' [-Walloc-size]
libpkgconf/dependency.c:133:13: warning: allocation of insufficient size '1' for type 'pkgconf_dependency_t' {aka 'struct pkgconf_dependency_'} with size '80' [-Walloc-size]
libpkgconf/dependency.c:472:17: warning: allocation of insufficient size '1' for type 'pkgconf_dependency_t' {aka 'struct pkgconf_dependency_'} with size '80' [-Walloc-size]
libpkgconf/path.c:105:14: warning: allocation of insufficient size '1' for type 'pkgconf_path_t' {aka 'struct pkgconf_path_'} with size '48' [-Walloc-size]
libpkgconf/path.c:237:22: warning: allocation of insufficient size '1' for type 'pkgconf_path_t' {aka 'struct pkgconf_path_'} with size '48' [-Walloc-size]
libpkgconf/queue.c:46:33: warning: allocation of insufficient size '1' for type 'pkgconf_queue_t' {aka 'struct pkgconf_queue_'} with size '32' [-Walloc-size]
libpkgconf/tuple.c:239:34: warning: allocation of insufficient size '1' for type 'pkgconf_tuple_t' {aka 'struct pkgconf_tuple_'} with size '48' [-Walloc-size]
libpkgconf/fragment.c:146:22: warning: allocation of insufficient size '1' for type 'pkgconf_fragment_t' {aka 'struct pkgconf_fragment_'} with size '48' [-Walloc-size]
libpkgconf/fragment.c:195:22: warning: allocation of insufficient size '1' for type 'pkgconf_fragment_t' {aka 'struct pkgconf_fragment_'} with size '48' [-Walloc-size]
libpkgconf/fragment.c:356:14: warning: allocation of insufficient size '1' for type 'pkgconf_fragment_t' {aka 'struct pkgconf_fragment_'} with size '48' [-Walloc-size]
libpkgconf/pkg.c:422:13: warning: allocation of insufficient size '1' for type 'pkgconf_pkg_t' {aka 'struct pkgconf_pkg_'} with size '360' [-Walloc-size]
```

The calloc prototype is:
```
void *calloc(size_t nmemb, size_t size);
    ```

So, just swap the number of members and size arguments to match the prototype, as
we're initialising 1 struct of size `sizeof(struct ...)`. GCC then sees we're not
doing anything wrong.

The only exception there is for argv which I fixed while at it.