### PR TITLE
Use traverse_id to prevent traverse pkgdep twice

### DIFF
--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -137,6 +137,8 @@ struct pkgconf_path_ {
 #define PKGCONF_PKG_PROPF_CACHED		0x02
 #define PKGCONF_PKG_PROPF_UNINSTALLED		0x08
 #define PKGCONF_PKG_PROPF_VIRTUAL		0x10
+#define PKGCONF_PKG_PROPF_VISITED		0x20
+#define PKGCONF_PKG_PROPF_VISITED_PRIVATE	0x40
 
 struct pkgconf_pkg_ {
 	int refcount;
@@ -176,6 +178,7 @@ struct pkgconf_pkg_ {
 
 	uint64_t serial;
 	uint64_t identifier;
+	uint64_t traverse_id;
 };
 
 typedef bool (*pkgconf_pkg_iteration_func_t)(const pkgconf_pkg_t *pkg, void *data);
@@ -212,6 +215,7 @@ struct pkgconf_client_ {
 
 	uint64_t serial;
 	uint64_t identifier;
+	uint64_t traverse_id;
 
 	pkgconf_pkg_t **cache_table;
 	size_t cache_count;

--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -1628,6 +1628,21 @@ pkgconf_pkg_traverse_main(pkgconf_client_t *client,
 	if (maxdepth == 0)
 		return eflags;
 
+	unsigned int visited_flag = (client->flags & PKGCONF_PKG_PKGF_ITER_PKG_IS_PRIVATE) ? PKGCONF_PKG_PROPF_VISITED_PRIVATE : PKGCONF_PKG_PROPF_VISITED;
+
+	if (root->traverse_id == client->traverse_id)
+	{
+		if (root->flags & visited_flag)
+			return eflags;
+	}
+	else
+	{
+		root->traverse_id = client->traverse_id;
+		root->flags &= ~(PKGCONF_PKG_PROPF_VISITED | PKGCONF_PKG_PROPF_VISITED_PRIVATE);
+	}
+
+	root->flags |= visited_flag;
+
 	PKGCONF_TRACE(client, "%s: level %d, serial %"PRIu64, root->id, maxdepth, client->serial);
 
 	if ((root->flags & PKGCONF_PKG_PROPF_VIRTUAL) != PKGCONF_PKG_PROPF_VIRTUAL || (client->flags & PKGCONF_PKG_PKGF_SKIP_ROOT_VIRTUAL) != PKGCONF_PKG_PKGF_SKIP_ROOT_VIRTUAL)
@@ -1672,6 +1687,9 @@ pkgconf_pkg_traverse(pkgconf_client_t *client,
 	int maxdepth,
 	unsigned int skip_flags)
 {
+	static uint64_t traverse_id = 0;
+	client->traverse_id = ++traverse_id;
+
 	if (root->flags & PKGCONF_PKG_PROPF_VIRTUAL)
 		client->serial++;
 


### PR DESCRIPTION
Context: https://issuetracker.google.com/issues/317357322

In the ChromeOS build system, the pkg-config is very slow because we have a very complex dependency graph.

After deep diving into the code of pkg-config, I think it would not work very well when we have a "deep" dependency graph.

For example:
```
O
|\
| \
O  O
|\/|
|/\|
O  O
|\/|
|/\|
O  O
...
|\/|
|/\|
O  O
|\/|
|/\|
O  O
```

If we have this kind of dependency graph, the time complexity of pkg-config will become `O(2^N)`, that is not an acceptable time complexity.

To fix the issue, I add a traverse_id into the client and root to make sure we don't traverse a package multiple times.