### PR TITLE
Revise traversal and flattening

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -266,7 +266,10 @@ print_digraph_node(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *unused)
 	{
 		pkgconf_dependency_t *dep = node->data;
 
-		printf("\"%s\" -> \"%s\" [fontname=Sans fontsize=8]\n", pkg->id, dep->package);
+		if ((dep->flags & PKGCONF_PKG_DEPF_PRIVATE) == 0)
+			printf("\"%s\" -> \"%s\" [fontname=Sans fontsize=8]\n", pkg->id, dep->package);
+		else
+			printf("\"%s\" -> \"%s\" [fontname=Sans fontsize=8 color=gray]\n", pkg->id, dep->package);
 	}
 
 	PKGCONF_FOREACH_LIST_ENTRY(pkg->requires_private.head, node)

--- a/cli/main.c
+++ b/cli/main.c
@@ -1547,19 +1547,7 @@ cleanup3:
 			printf(" ");
 
 		if (!(want_flags & PKG_STATIC))
-		{
 			pkgconf_client_set_flags(&pkg_client, pkg_client.flags & ~PKGCONF_PKG_PKGF_SEARCH_PRIVATE);
-
-			/* redo the solution for the library set: free the solution itself, and any cached graph nodes */
-			pkgconf_solution_free(&pkg_client, &world);
-			pkgconf_cache_free(&pkg_client);
-
-			if (!pkgconf_queue_solve(&pkg_client, &pkgq, &world, maximum_traverse_depth))
-			{
-				ret = EXIT_FAILURE;
-				goto out;
-			}
-		}
 
 		apply_libs(&pkg_client, &world, NULL, 2);
 	}

--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -137,8 +137,7 @@ struct pkgconf_path_ {
 #define PKGCONF_PKG_PROPF_CACHED		0x02
 #define PKGCONF_PKG_PROPF_UNINSTALLED		0x08
 #define PKGCONF_PKG_PROPF_VIRTUAL		0x10
-#define PKGCONF_PKG_PROPF_VISITED		0x20
-#define PKGCONF_PKG_PROPF_VISITED_PRIVATE	0x40
+#define PKGCONF_PKG_PROPF_PRIVATE		0x40
 
 struct pkgconf_pkg_ {
 	int refcount;

--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -176,7 +176,6 @@ struct pkgconf_pkg_ {
 	pkgconf_tuple_t *orig_prefix;
 	pkgconf_tuple_t *prefix;
 
-	uint64_t serial;
 	uint64_t identifier;
 	uint64_t traverse_serial;
 };
@@ -213,8 +212,8 @@ struct pkgconf_client_ {
 
 	bool already_sent_notice;
 
+	/* a counter to create identifiers for pkg nodes and to identify traversals */
 	uint64_t serial;
-	uint64_t identifier;
 	uint64_t traverse_serial;
 
 	pkgconf_pkg_t **cache_table;

--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -1661,14 +1661,14 @@ pkgconf_pkg_traverse_main(pkgconf_client_t *client,
 			return eflags;
 	}
 
-	PKGCONF_TRACE(client, "%s: walking requires list", root->id);
+	PKGCONF_TRACE(client, "%s: walking 'Requires' list", root->id);
 	eflags = pkgconf_pkg_walk_list(client, root, &root->required, func, data, maxdepth, skip_flags);
 	if (eflags != PKGCONF_PKG_ERRF_OK)
 		return eflags;
 
 	if (client->flags & PKGCONF_PKG_PKGF_SEARCH_PRIVATE)
 	{
-		PKGCONF_TRACE(client, "%s: walking requires.private list", root->id);
+		PKGCONF_TRACE(client, "%s: walking 'Requires.private' list", root->id);
 
 		/* XXX: ugly */
 		client->flags |= PKGCONF_PKG_PKGF_ITER_PKG_IS_PRIVATE;

--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -1622,30 +1622,16 @@ pkgconf_pkg_traverse_main(pkgconf_client_t *client,
 	unsigned int skip_flags)
 {
 	unsigned int eflags = PKGCONF_PKG_ERRF_OK;
-	unsigned int visited_flag = (client->flags & PKGCONF_PKG_PKGF_ITER_PKG_IS_PRIVATE) ? PKGCONF_PKG_PROPF_VISITED_PRIVATE : PKGCONF_PKG_PROPF_VISITED;
 
 	if (maxdepth == 0)
 		return eflags;
 
-	/* If we have already visited this node, check if we have done so as a Requires or Requires.private
-	 * query as appropriate, and short-circuit if so.
+	/* Short-circuit if we have already visited this node.
 	 */
 	if (root->traverse_serial == client->traverse_serial)
-	{
-		if ((root->flags & PKGCONF_PKG_PROPF_VIRTUAL) == 0)
-		{
-			if (root->flags & visited_flag)
-				return eflags;
-		}
-	}
-	else
-	{
-		root->traverse_serial = client->traverse_serial;
-		root->flags &= ~(PKGCONF_PKG_PROPF_VISITED|PKGCONF_PKG_PROPF_VISITED_PRIVATE);
-	}
+		return eflags;
 
-	/* Update this node to indicate how we've visited it so far. */
-	root->flags |= visited_flag;
+	root->traverse_serial = client->traverse_serial;
 
 	PKGCONF_TRACE(client, "%s: level %d, serial %"PRIu64, root->id, maxdepth, client->serial);
 

--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -1680,6 +1680,9 @@ pkgconf_pkg_traverse(pkgconf_client_t *client,
 	if (root->flags & PKGCONF_PKG_PROPF_VIRTUAL)
 		client->traverse_serial = ++client->serial;
 
+	if ((client->flags & PKGCONF_PKG_PKGF_SEARCH_PRIVATE) == 0)
+		skip_flags |= PKGCONF_PKG_DEPF_PRIVATE;
+
 	return pkgconf_pkg_traverse_main(client, root, func, data, maxdepth, skip_flags);
 }
 

--- a/libpkgconf/queue.c
+++ b/libpkgconf/queue.c
@@ -258,12 +258,12 @@ pkgconf_queue_verify(pkgconf_client_t *client, pkgconf_pkg_t *world, pkgconf_lis
 	 */
 	++client->serial;
 
-	PKGCONF_TRACE(client, "flattening requires deps");
+	PKGCONF_TRACE(client, "flattening 'Requires' deps");
 	flatten_dependency_set(client, &world->required);
 
 	++client->serial;
 
-	PKGCONF_TRACE(client, "flattening requires.private deps");
+	PKGCONF_TRACE(client, "flattening 'Requires.private' deps");
 	flatten_dependency_set(client, &world->requires_private);
 
 	return PKGCONF_PKG_ERRF_OK;

--- a/libpkgconf/queue.c
+++ b/libpkgconf/queue.c
@@ -162,7 +162,7 @@ flatten_dependency_set(pkgconf_client_t *client, pkgconf_list_t *list)
 		if (pkg == NULL)
 			continue;
 
-		if (pkg->serial == client->serial)
+		if (pkg->identifier == client->serial)
 		{
 			pkgconf_node_delete(node, list);
 			pkgconf_dependency_unref(client, dep);
@@ -189,7 +189,7 @@ flatten_dependency_set(pkgconf_client_t *client, pkgconf_list_t *list)
 			}
 		}
 
-		pkg->serial = client->serial;
+		pkg->identifier = client->serial;
 
 		/* copy to the deps table */
 		dep_count++;

--- a/libpkgconf/queue.c
+++ b/libpkgconf/queue.c
@@ -163,7 +163,7 @@ flatten_dependency_set(pkgconf_client_t *client, pkgconf_list_t *list)
 {
 	pkgconf_node_t *node, *next;
 	pkgconf_dependency_t **deps = NULL;
-	size_t dep_count = 0, i;
+	size_t dep_count = 0, i, dep_allocation = 0;
 
 	PKGCONF_FOREACH_LIST_ENTRY_SAFE(list->head, next, node)
 	{
@@ -204,7 +204,11 @@ flatten_dependency_set(pkgconf_client_t *client, pkgconf_list_t *list)
 
 		/* copy to the deps table */
 		dep_count++;
-		deps = pkgconf_reallocarray(deps, dep_count, sizeof (void *));
+		if (dep_count > dep_allocation)
+		{
+			dep_allocation = dep_count + 31;
+			deps = pkgconf_reallocarray(deps, dep_allocation, sizeof (void *));
+		}
 		deps[dep_count - 1] = dep;
 
 		PKGCONF_TRACE(client, "added %s to dep table", dep->package);

--- a/tests/basic.sh
+++ b/tests/basic.sh
@@ -231,7 +231,7 @@ libs_circular1_body()
 libs_circular_directpc_body()
 {
 	atf_check \
-		-o inline:"-lcircular-2 -lcircular-3 -lcircular-1\n" \
+		-o inline:"-lcircular-1 -lcircular-2 -lcircular-3\n" \
 		pkgconf --libs ${selfdir}/lib1/circular-3.pc
 }
 

--- a/tests/requires.sh
+++ b/tests/requires.sh
@@ -41,7 +41,7 @@ libs_static_body()
 {
 	export PKG_CONFIG_PATH="${selfdir}/lib1"
 	atf_check \
-		-o inline:"-L/test/lib -lbaz -L/test/lib -lzee -L/test/lib -lfoo\n" \
+		-o inline:"-L/test/lib -lbaz -L/test/lib -lzee -lfoo\n" \
 		pkgconf --static --libs baz
 }
 
@@ -49,7 +49,7 @@ libs_static_pure_body()
 {
 	export PKG_CONFIG_PATH="${selfdir}/lib1"
 	atf_check \
-		-o inline:"-L/test/lib -lbaz -L/test/lib -lfoo\n" \
+		-o inline:"-L/test/lib -lbaz -lfoo\n" \
 		pkgconf --static --pure --libs baz
 }
 
@@ -73,7 +73,7 @@ private_duplication_body()
 {
 	export PKG_CONFIG_PATH="${selfdir}/lib1"
 	atf_check \
-		-o inline:"-lprivate -lbaz -lzee -lbar -lfoo -lfoo\n" \
+		-o inline:"-lprivate -lbaz -lzee -lbar -lfoo\n" \
 		pkgconf --static --libs-only-l private-libs-duplication
 }
 

--- a/tests/requires.sh
+++ b/tests/requires.sh
@@ -11,6 +11,9 @@ tests_init \
 	static_cflags \
 	private_duplication \
 	private_duplication_digraph \
+	foo_bar \
+	bar_foo \
+	foo_metapackage_3 \
 	libs_static2 \
 	missing \
 	requires_internal \
@@ -87,6 +90,30 @@ private_duplication_digraph_body()
 		-o 'match:"bar" -> "foo"' \
 		-o 'match:"baz" -> "foo"' \
 		pkgconf --static --libs-only-l private-libs-duplication --digraph
+}
+
+bar_foo_body()
+{
+	export PKG_CONFIG_PATH="${selfdir}/lib1"
+	atf_check \
+		-o inline:"-lbar -lfoo\n" \
+		pkgconf --static --libs-only-l bar foo
+}
+
+foo_bar_body()
+{
+	export PKG_CONFIG_PATH="${selfdir}/lib1"
+	atf_check \
+		-o inline:"-lbar -lfoo\n" \
+		pkgconf --static --libs-only-l foo bar
+}
+
+foo_metapackage_3_body()
+{
+	export PKG_CONFIG_PATH="${selfdir}/lib1"
+	atf_check \
+		-o inline:"-lbar -lfoo\n" \
+		pkgconf --static --libs-only-l foo metapackage-3
 }
 
 libs_static2_body()


### PR DESCRIPTION
Fixes lib order regressions.  
Limit (allocationwise) expensive traversal steps while still doing necessary steps for determining the topological sort.

**Major change:**
The solution is put as a single list into `requires` - also when walking over private dependencies.  
In this list, dependencies which result only from private paths are marked as such.
(NB: A walk with private dependencies only adds restrictions and removes possible solutions. So skipping the private dependencies of a complete solution yields a valid solution for the problem without private dependencies.)