### PR TITLE
Mark user input in error message

### DIFF
--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -1456,7 +1456,11 @@ pkgconf_pkg_report_graph_error(pkgconf_client_t *client, pkgconf_pkg_t *parent, 
 			client->already_sent_notice = true;
 		}
 
-		pkgconf_error(client, "Package '%s', required by '%s', not found\n", node->package, parent->id);
+		if (parent->flags & PKGCONF_PKG_PROPF_VIRTUAL)
+			pkgconf_error(client, "Package '%s' not found\n", node->package);
+		else
+			pkgconf_error(client, "Package '%s', required by '%s', not found\n", node->package, parent->id);
+
 		pkgconf_audit_log(client, "%s NOT-FOUND\n", node->package);
 	}
 	else if (eflags & PKGCONF_PKG_ERRF_PACKAGE_VER_MISMATCH)

--- a/libpkgconf/queue.c
+++ b/libpkgconf/queue.c
@@ -230,7 +230,7 @@ pkgconf_queue_verify(pkgconf_client_t *client, pkgconf_pkg_t *world, pkgconf_lis
 {
 	unsigned int result;
 	pkgconf_pkg_t initial_world = {
-		.id = "virtual:world",
+		.id = "user:request",
 		.realname = "virtual world package",
 		.flags = PKGCONF_PKG_PROPF_STATIC | PKGCONF_PKG_PROPF_VIRTUAL,
 	};


### PR DESCRIPTION
Before:
~~~
Package 'zlib', required by 'virtual:world', not found
~~~
After:
~~~
Package 'zlib' not found
~~~

Edit: Omitting `required by ` for virtual nodes, approximating https://github.com/pkgconf/pkgconf/pull/348#issuecomment-2012109116.