### PR TITLE
Print digraph for user request perspective

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -303,7 +303,10 @@ apply_digraph(pkgconf_client_t *client, pkgconf_pkg_t *world, void *data, int ma
 	PKGCONF_FOREACH_LIST_ENTRY(list->head, iter)
 	{
 		pkgconf_queue_t *pkgq = iter->data;
-		printf("\"user:request\" -> \"%s\" [fontname=Sans fontsize=8]\n", pkgq->package);
+		pkgconf_pkg_t *pkg = pkgconf_pkg_find(client, pkgq->package);
+		printf("\"user:request\" -> \"%s\" [fontname=Sans fontsize=8]\n", pkg == NULL ? pkgq->package : pkg->id);
+		if (pkg != NULL)
+			pkgconf_pkg_unref(client, pkg);
 	}
 
 	eflag = pkgconf_pkg_traverse(client, world, print_digraph_node, &last_seen, maxdepth, 0);

--- a/cli/main.c
+++ b/cli/main.c
@@ -263,7 +263,11 @@ print_digraph_node(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *data)
 	if(pkg->flags & PKGCONF_PKG_PROPF_VIRTUAL)
 		return;
 
-	printf("\"%s\" [fontname=Sans fontsize=8]\n", pkg->id);
+	if (pkg->flags & PKGCONF_PKG_PROPF_VISITED_PRIVATE)
+		printf("\"%s\" [fontname=Sans fontsize=8 fontcolor=gray color=gray]\n", pkg->id);
+	else
+		printf("\"%s\" [fontname=Sans fontsize=8]\n", pkg->id);
+
 	if (last_seen != NULL)
 	{
 		if (*last_seen != NULL)

--- a/tests/requires.sh
+++ b/tests/requires.sh
@@ -78,10 +78,7 @@ private_duplication_digraph_body()
 {
 	export PKG_CONFIG_PATH="${selfdir}/lib1"
 	atf_check \
-		-o 'match:"virtual:world" -> "private-libs-duplication"' \
-		-o 'match:"virtual:world" -> "bar"' \
-		-o 'match:"virtual:world" -> "baz"' \
-		-o 'match:"virtual:world" -> "foo"' \
+		-o 'match:"user:request" -> "private-libs-duplication"' \
 		-o 'match:"private-libs-duplication" -> "bar"' \
 		-o 'match:"private-libs-duplication" -> "baz"' \
 		-o 'match:"bar" -> "foo"' \


### PR DESCRIPTION
Instead of generating an image with edges from the root  "virtual world" to all other nodes without carrying the resulting order, start from the list requested by the user and show final order via red eges.

Output for private-libs-duplication test case:

| before | after | 
|---------|---------|
| ![test-before](https://github.com/pkgconf/pkgconf/assets/13567791/545240e9-babc-43d7-9cbe-db8e8ac217e2) | ![test-after](https://github.com/pkgconf/pkgconf/assets/13567791/1da7b17c-8fdd-4f9b-bd99-5f930e1eba4b) |

We might want to change the edge colors or style to make the topological-sort edges less prominent, e.g.: red for private dependency, gray for topological sort.

Not that there is no direct visualization of the nodes are only reached via private dependencies. (This used to be encoded in unique gray edges from virtual:world to node.)

---

This PR is an extended version of the generator for https://github.com/pkgconf/pkgconf/pull/345#issuecomment-2002618450 which was still based on virtual world.
With #345 and this PR, a graph for (vcpkg) `pkgconf --static --digraph zlib pango harfbuzz` looks like this:

![img4](https://github.com/pkgconf/pkgconf/assets/13567791/280e0839-ea28-4228-953f-60c12f3c1b82)
