### PR TITLE
pkg.m4: Abort by default if no pkgconf

### DIFF
--- a/pkg.m4
+++ b/pkg.m4
@@ -46,8 +46,8 @@ m4_if(m4_version_compare(PKG_MACROS_VERSION, [$1]), -1,
     [m4_fatal([pkg.m4 version $1 or higher is required but ]PKG_MACROS_VERSION[ found])])
 ])dnl PKG_PREREQ
 
-dnl PKG_PROG_PKG_CONFIG([MIN-VERSION])
-dnl ----------------------------------
+dnl PKG_PROG_PKG_CONFIG([MIN-VERSION], [ACTION-IF-NOT-FOUND])
+dnl ---------------------------------------------------------
 dnl Since: 0.16
 dnl
 dnl Search for the pkg-config tool and set the PKG_CONFIG variable to
@@ -55,6 +55,12 @@ dnl first found in the path. Checks that the version of pkg-config found
 dnl is at least MIN-VERSION. If MIN-VERSION is not specified, 0.9.0 is
 dnl used since that's the first version where most current features of
 dnl pkg-config existed.
+dnl
+dnl If pkg-config is not found or older than specified, it will result
+dnl in an empty PKG_CONFIG variable. To avoid widespread issues with
+dnl scripts not checking it, ACTION-IF-NOT-FOUND defaults to aborting.
+dnl You can specify [PKG_CONFIG=false] as an action instead, which would
+dnl result in pkg-config tests failing, but no bogus error messages.
 AC_DEFUN([PKG_PROG_PKG_CONFIG],
 [m4_pattern_forbid([^_?PKG_[A-Z_]+$])
 m4_pattern_allow([^PKG_CONFIG(_(PATH|LIBDIR|SYSROOT_DIR|ALLOW_SYSTEM_(CFLAGS|LIBS)))?$])
@@ -75,6 +81,9 @@ if test -n "$PKG_CONFIG"; then
 		AC_MSG_RESULT([no])
 		PKG_CONFIG=""
 	fi
+fi
+if test -z "$PKG_CONFIG"; then
+	m4_default([$2], [AC_MSG_ERROR([pkg-config not found])])
 fi[]dnl
 ])dnl PKG_PROG_PKG_CONFIG
 


### PR DESCRIPTION
Provide a second optional argument to PKG_PROG_PKG_CONFIG with an action to take if no pkgconf is found, and default to aborting.

Too many configure scripts in the wild don't handle an empty PKG_CONFIG, resulting in weird error messages through the run, which often confuse users.

Authors wishing to fallback to other methods can either return to the old behavior by specifying [:] as an action, or use [PKG_CONFIG=false] and call pkg-config macros normally, handling the fallback as any other failure.

Users can override PKG_CONFIG in the command line so this should imply no regression.

Closes: https://github.com/pkgconf/pkgconf/issues/350
Ref: https://gitlab.freedesktop.org/pkg-config/pkg-config/-/issues/69