### PR TITLE
meson: add support for _DEFAULT_SOURCE

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -31,7 +31,7 @@ check_functions = [
 
 foreach f : check_functions
   name = f[0].to_upper().underscorify()
-  if cc.has_function(f[0], prefix : '#define _BSD_SOURCE\n#include <@0@>'.format(f[1])) and cc.has_header_symbol(f[1], f[0], prefix : '#define _BSD_SOURCE')
+  if cc.has_function(f[0], prefix : '#define _BSD_SOURCE\n#define _DEFAULT_SOURCE\n#include <@0@>'.format(f[1])) and cc.has_header_symbol(f[1], f[0], prefix : '#define _BSD_SOURCE\n#define _DEFAULT_SOURCE')
     cdata.set('HAVE_@0@'.format(name), 1)
     cdata.set('HAVE_DECL_@0@'.format(name), 1)
   else


### PR DESCRIPTION
Due to `_BSD_SOURCE` is deprecated, we need to add `_DEFAULT_SOURCE` to check functions and symbols correctly.

https://github.com/mesonbuild/meson/issues/13525

https://man7.org/linux/man-pages/man7/feature_test_macros.7.html
>        _BSD_SOURCE (deprecated since glibc 2.20)
>               Defining this macro with any value causes header files to
>               expose BSD-derived definitions.
> 
>               In glibc versions up to and including 2.18, defining this
>               macro also causes BSD definitions to be preferred in some
>               situations where standards conflict, unless one or more of
>               _SVID_SOURCE, _POSIX_SOURCE, _POSIX_C_SOURCE,
>               _XOPEN_SOURCE, _XOPEN_SOURCE_EXTENDED, or _GNU_SOURCE is
>               defined, in which case BSD definitions are disfavored.
>               Since glibc 2.19, _BSD_SOURCE no longer causes BSD
>               definitions to be preferred in case of conflicts.
> 
>               Since glibc 2.20, this macro is deprecated.  It now has
>               the same effect as defining _DEFAULT_SOURCE, but generates
>               a compile-time warning (unless _DEFAULT_SOURCE is also
>               defined).  Use _DEFAULT_SOURCE instead.  To allow code
>               that requires _BSD_SOURCE in glibc 2.19 and earlier and
>               _DEFAULT_SOURCE in glibc 2.20 and later to compile without
>               warnings, define both _BSD_SOURCE and _DEFAULT_SOURCE.