### PR TITLE
pkg.m4: Bump serial.  Use URL instead of obsolete FSF postal address.

### DIFF
--- a/pkg.m4
+++ b/pkg.m4
@@ -1,5 +1,5 @@
 # pkg.m4 - Macros to locate and use pkg-config.   -*- Autoconf -*-
-# serial 12 (pkg-config-0.29.2)
+# serial 13 (pkgconf)
 
 dnl Copyright © 2004 Scott James Remnant <scott@netsplit.com>.
 dnl Copyright © 2012-2015 Dan Nicholson <dbn.lists@gmail.com>
@@ -15,9 +15,7 @@ dnl MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
 dnl General Public License for more details.
 dnl
 dnl You should have received a copy of the GNU General Public License
-dnl along with this program; if not, write to the Free Software
-dnl Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-dnl 02111-1307, USA.
+dnl along with this program; if not, see <https://www.gnu.org/licenses/>.
 dnl
 dnl As a special exception to the GNU General Public License, if you
 dnl distribute this file as part of a program that contains a


### PR DESCRIPTION
Hi!

 I noticed you copied `pkg.m4` from pkg-config.  The file uses the old FSF postal address.

This pull request update it to use the latest GPLv2 recommended style with URL instead, the FSF has made this change in the GPLv2 license too: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html

Also this bumps the serial which is necessary for all changes (should have been done with your earlier changes too).

What do you think?

Thanks,
/Simon