### PR TITLE
Replace -I with -isystem

### DIFF
--- a/doc/libpkgconf-fragment.rst
+++ b/doc/libpkgconf-fragment.rst
@@ -3,7 +3,7 @@ libpkgconf `fragment` module
 ============================
 
 The `fragment` module provides low-level management and rendering of fragment lists.  A
-`fragment list` contains various `fragments` of text (such as ``-I /usr/include``) in a matter
+`fragment list` contains various `fragments` of text (such as ``-isystem /usr/include``) in a matter
 which is composable, mergeable and reorderable.
 
 .. c:function:: void pkgconf_fragment_add(const pkgconf_client_t *client, pkgconf_list_t *list, const char *string, unsigned int flags)

--- a/libpkgconf.pc.in
+++ b/libpkgconf.pc.in
@@ -8,5 +8,5 @@ Description: a library for accessing and manipulating development framework conf
 URL: https://gitea.treehouse.systems/ariadne/pkgconf
 License: ISC
 Version: @PACKAGE_VERSION@
-CFlags: -I${includedir}/pkgconf
+CFlags: -isystem ${includedir}/pkgconf
 Libs: -L${libdir} -lpkgconf

--- a/libpkgconf/fragment.c
+++ b/libpkgconf/fragment.c
@@ -23,7 +23,7 @@
  * ============================
  *
  * The `fragment` module provides low-level management and rendering of fragment lists.  A
- * `fragment list` contains various `fragments` of text (such as ``-I /usr/include``) in a matter
+ * `fragment list` contains various `fragments` of text (such as ``-isystem /usr/include``) in a matter
  * which is composable, mergeable and reorderable.
  */
 

--- a/man/pc.5
+++ b/man/pc.5
@@ -171,7 +171,7 @@ Requires: libbar > 2.0.0
 Conflicts: libbaz <= 3.0.0
 Libs: -L${libdir} -lfoo
 Libs.private: -lm
-Cflags: -I${includedir}/libfoo
+Cflags: -isystem ${includedir}/libfoo
 .Ed
 .Sh SEE ALSO
 .Xr pkgconf 1 ,

--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -225,7 +225,7 @@ If set to PKG_CONFIG_SYSROOT_DIR, assume that PKG_CONFIG_FDO_SYSROOT_RULES is se
 .Sh EXAMPLES
 Displaying the CFLAGS of a package:
 .Dl $ pkgconf --cflags foo
-.Dl -fPIC -I/usr/include/foo
+.Dl -fPIC -isystem /usr/include/foo
 .Sh SEE ALSO
 .Xr pc 5 ,
 .Xr pkg.m4 7


### PR DESCRIPTION
GCC 14.2 CPP Manual says:
> All warnings, other than those generated by ‘#warning’ (see
> Diagnostics), are suppressed while GCC is processing a system header.
> Macros defined in a system header are immune to a few warnings
> wherever they are expanded.
https://gcc.gnu.org/onlinedocs/gcc-14.2.0/cpp/System-Headers.html

Clang 18.1.8 documentation also says:
> Warnings are suppressed when they occur in system headers. By default,
> an included file is treated as a system header if it is found in an
> include path specified by -isystem, but this can be overridden in
> several ways.
https://releases.llvm.org/18.1.8/tools/clang/docs/UsersManual.html#controlling-diagnostics-in-system-headers

clang-tidy is a clang-based C++ "linter" tool and emits project-specific warnings, and it also distinguishes system headers and suppresses warnings for them:
https://releases.llvm.org/18.1.8/tools/clang/tools/extra/docs/clang-tidy/index.html

Users are likely to focus on warnings on their code, and -isystem enables that by suppressing warnings from libraries. Let's use it for pkgconf/libpkgconf.pc.in and update the documentation to use -isystem in included examples.

-I flag usage local to pkgconf is preserved so that pkgconf developers can find warnings in their headers. -I flags also remain in tests as changing them have no real benefit.