### PR TITLE
 meson: add MSI build target 

### DIFF
--- a/libpkgconf/stdinc.h
+++ b/libpkgconf/stdinc.h
@@ -32,7 +32,7 @@
 # include <malloc.h>
 # define PATH_DEV_NULL	"nul"
 # ifdef _WIN64
-#  define SIZE_FMT_SPECIFIER	"%I64u"
+#  define SIZE_FMT_SPECIFIER	"%llu"
 # else
 #  define SIZE_FMT_SPECIFIER	"%u"
 # endif

--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,8 @@
 project('pkgconf', 'c',
   version : '2.4.3',
   license : 'ISC',
-  meson_version : '>=0.49',
   default_options : ['c_std=c99'],
+  meson_version: '>=0.52',
 )
 
 cc = meson.get_compiler('c')
@@ -146,3 +146,38 @@ install_man('man/pkgconf-personality.5')
 install_data('pkg.m4', install_dir: 'share/aclocal')
 install_data('AUTHORS', install_dir: 'share/doc/pkgconf')
 install_data('README.md', install_dir: 'share/doc/pkgconf')
+
+if host_machine.system() == 'windows'
+  conf_data = configuration_data()
+  conf_data.set('VERSION', meson.project_version())
+  conf_data.set('EXE', pkgconf_exe.full_path())
+  conf_data.set('DLL', libpkgconf.full_path())
+  if host_machine.cpu() != 'x86_64'
+    wixl_arch = 'x86'
+  else
+    wixl_arch = 'x64'
+  endif
+  conf_data.set('WIXL_ARCH', wixl_arch)
+
+  wixl = find_program('wixl', required: false, version: '>= 0.105')
+  unoconv = find_program('unoconv', required: false)
+  msi_filename = 'pkgconf-@0@-@1@.msi'.format(wixl_arch, meson.project_version())
+
+  wxsfile = configure_file(input: 'pkgconf.wxs.in', output: 'pkgconf.wxs', configuration: conf_data)
+
+  if wixl.found() and unoconv.found()
+    licensefile = custom_target(
+      'License.rtf',
+      input: 'COPYING',
+      output: 'License.rtf',
+      command: [unoconv, '-f', 'rtf', '-o', '@OUTPUT@', '@INPUT@'],
+    )
+
+    custom_target(
+      msi_filename,
+      input: [wxsfile, licensefile],
+      output: msi_filename,
+      command: [wixl, '--arch', wixl_arch, '--ext', 'ui', '-o', msi_filename, wxsfile],
+    )
+  endif
+endif

--- a/pkgconf.wxs.in
+++ b/pkgconf.wxs.in
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+
+  <?define Arch = "@WIXL_ARCH@"?>
+  <?if $(var.Arch) = "x64"?>
+      <?define GLIB_ARCH = "win64"?>
+      <?define ArchString = "64-bit"?>
+      <?define ArchProgramFilesFolder = "ProgramFiles64Folder"?>
+      <?define Win64 = "yes"?>
+  <?else?>
+      <?define GLIB_ARCH = "win32"?>
+      <?define ArchString = "32-bit"?>
+      <?define ArchProgramFilesFolder = "ProgramFilesFolder"?>
+      <?define Win64 = "no"?>
+  <?endif?>
+
+
+  <Product Id="*"
+           Name="pkgconf @VERSION@ ($(var.ArchString))"
+           Language="1033"
+           Version="@VERSION@"
+           Manufacturer="pkgconf"
+           UpgradeCode="4faedad2-3f9d-45cc-89a7-3732ad2db0f7">
+
+      <Package InstallerVersion="200"
+               Compressed="yes"
+               InstallScope="perMachine" />
+
+      <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+      <MediaTemplate EmbedCab="yes" />
+
+      <Feature Id="ProductFeature" Title="pkgconf" Level="1">
+          <ComponentGroupRef Id="ProductComponents" />
+      </Feature>
+
+      <Directory Id="TARGETDIR" Name="SourceDir">
+          <Directory Id="$(var.ArchProgramFilesFolder)">
+              <Directory Id="INSTALLFOLDER" Name="pkgconf @VERSION@" />
+          </Directory>
+      </Directory>
+
+      <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+          <Component Id="PkgconfExe" Guid="*" Win64="$(var.Win64)">
+              <File Id="PkgconfExeFile"
+                    Source="@EXE@"
+                    KeyPath="yes" />
+              <File Id="PkgconfigExeFile"
+                    Name="pkg-config.exe"
+                    Source="@EXE@"/>
+              <File Id="PkgconfDllFile"
+                    Source="@DLL@"/>
+              <Environment Id="PATH"
+                           Name="PATH"
+                           Value="[INSTALLFOLDER]"
+                           Permanent="no"
+                           Part="last"
+                           Action="set"
+                           System="yes" />
+          </Component>
+      </ComponentGroup>
+
+      <UIRef Id="WixUI_Minimal" />
+   </Product>
+</Wix>


### PR DESCRIPTION
It would be nice to provide a release MSI for Windows users.

Requires wixl & unoconv.

Tested on Fedora, with mingw64 cross-build.
