### PR TITLE
man/pkgconf.1: use conventional syntax for the synopsis line

### DIFF
--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -39,7 +39,12 @@ This option is implied by many other options, but not by all.
 It can be overridden with
 .Fl -silence-errors .
 .It Fl -silence-errors
-Do not display any errors at all.
+Do not print any error, warning, or debugging messages at all.
+Overrides all of
+.Fl -debug ,
+.Fl -errors-to-stdout ,
+and
+.Fl -print-errors .
 .It Fl -debug
 Print some non-fatal warning messages to standard error output
 that would otherwise silently be ignored.

--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -133,14 +133,14 @@ or only the include path
 flags, or only the compiler flags that are not include path flags,
 respectively.
 .It Fl -libs , Fl -libs-only-L , Fl -libs-only-l , Fl -libs-only-other
-Display either all linker flags, only
-.Fl L
-linker flags, only
-.Fl l
-linker flags or only linker flags that are not
-.Fl L
-or
-.Fl l .
+Print all linker flags required to link against the
+.Cm module ,
+or only the library path
+.Pq Fl L
+flags, or only the library
+.Pq Fl l
+flags, or only the linker flags that are neither library path
+nor library flags, respectively.
 .It Fl -keep-system-cflags , Fl -keep-system-libs
 Keep CFLAGS or linker flag fragments that would be filtered due to being
 included by default in the compiler.

--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -118,10 +118,12 @@ of a solution.
 .Sh QUERY-SPECIFIC OPTIONS
 .Bl -tag -width indent
 .It Fl -cflags , Fl -cflags-only-I , Fl -cflags-only-other
-Display either all CFLAGS, only
-.Fl I
-CFLAGS or only CFLAGS that are not
-.Fl I .
+Print all compiler flags required to compile against the
+.Cm module ,
+or only the include path
+.Pq Fl I
+flags, or only the compiler flags that are not include path flags,
+respectively.
 .It Fl -libs , Fl -libs-only-L , Fl -libs-only-l , Fl -libs-only-other
 Display either all linker flags, only
 .Fl L

--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -16,7 +16,7 @@
 .Sh SYNOPSIS
 .Nm
 .Op Ar options
-.Op Ar list of modules
+.Ar module ...
 .Sh DESCRIPTION
 .Nm
 is a program which helps to configure compiler and linker flags for

--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -34,13 +34,13 @@ Print all errors on the main output stream instead of the error output stream.
 .It Fl -silence-errors
 Do not display any errors at all.
 .It Fl -debug
-Print some non-fatal warning messages to standard output
+Print some non-fatal warning messages to standard error output
 that would otherwise silently be ignored.
 If
 .Nm
 was compiled without defining the preprocessor macro
 .Dv PKGCONF_LITE ,
-this option also prints many debugging messages to standard output.
+this option also prints many debugging messages to standard error output.
 .It Fl -list-all
 Walk all directories listed in the
 .Va PKG_CONFIG_PATH

--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -32,6 +32,12 @@ Exit with error if we do not support the requested pkg-config version.
 .It Fl -errors-to-stdout
 Print all error, warning, and debugging messages to standard output
 instead of to standard error output.
+.It Fl -print-errors
+Print some messages about fatal errors to standard error output
+that would otherwise be omitted.
+This option is implied by many other options, but not by all.
+It can be overridden with
+.Fl -silence-errors .
 .It Fl -silence-errors
 Do not display any errors at all.
 .It Fl -debug

--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -33,6 +33,14 @@ Exit with error if we do not support the requested pkg-config version.
 Print all errors on the main output stream instead of the error output stream.
 .It Fl -silence-errors
 Do not display any errors at all.
+.It Fl -debug
+Print some non-fatal warning messages to standard output
+that would otherwise silently be ignored.
+If
+.Nm
+was compiled without defining the preprocessor macro
+.Dv PKGCONF_LITE ,
+this option also prints many debugging messages to standard output.
 .It Fl -list-all
 Walk all directories listed in the
 .Va PKG_CONFIG_PATH

--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -30,7 +30,8 @@ Display the supported pkg-config version and exit.
 .It Fl -atleast-pkgconfig-version Ns = Ns Ar VERSION
 Exit with error if we do not support the requested pkg-config version.
 .It Fl -errors-to-stdout
-Print all errors on the main output stream instead of the error output stream.
+Print all error, warning, and debugging messages to standard output
+instead of to standard error output.
 .It Fl -silence-errors
 Do not display any errors at all.
 .It Fl -debug


### PR DESCRIPTION
Hello,

OpenBSD <www.openbsd.org> just imported pkgconf(1) into the OpenBSD base system, see
https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/pkgconf/
The main reason for switching from our old implementation of pkg-config(1) written in Perl
https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/pkg-config/
to the more widely used and more actively developed pkgconf(1) was that our old pkg-config(1) was unbearably slow when dealing with projects using large numbers of modules.

My job in this context is getting the documentation = manual pages up to speed.
I'm the maintainer of the mandoc(1) documentation toolkit <mandoc.bsd.lv>
that is used by default by OpenBSD, Alpine, Void and Chimera Linux, FreeBSD, NetBSD, illumos and macOS and also optionally available on Arch, SUSE, Fedora, Gentoo, and Debian.
I'm also a developer in the GNU roff project, <www.gnu.org/software/groff>.

Rather than improving the manual pages only in the OpenBSD tree, my plan is to work upstream with you instead, which will likely result in large numbers of pull requests because the pkgconf(1) documentation is currently significantly below OpenBSD quality standards.  This is not intended as an insult, i'm not saying your documentation is bad, but merely as a statement of fact.  OpenBSD documentation quality standards are unusually high and unusually strict.

My plan is to start with very small patches, implementing one small improvement each, in the hope that they will be easy to verify and pull, or if need be, easy to reason about.  When we get to know each other better and i develop a feeling how you usually work, maybe patches can become slightly bigger over time.

Here is the first small patch:
 * In the synopsis line, avoid prose like "list of modules".  The conventional way to express a list of one or more arguments is to provide a placeholder for the first argument ("module"), then use three dots to indicate that more arguments of the same kind can optionally follow.  Here is a typical example: https://man.openbsd.org/file.1
 * Introduce the placeholder ".Ar module" such that it can later be used in the text, making the text more precise.  Such future usage is not yet included in this patch.
 * The "module" argument is *not* optional.  For normal use of the program, that argument is always required.  If you wonder about the very small number of options like --version and --help where the argument can be omitted, considering those in the synopsis would massively over-emphasize them.  If at all, the description of --version and similar options could later say that this option does not require an argument and ignores it if provided.  It is not usually possible to address every arcane special case in the synopsis, and trying to merely confuses users.