### PR TITLE
man/pkgconf.1: improve the description of --atleast-pkgconfig-version

### DIFF
--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -281,6 +281,8 @@ If set, follow the sysroot prefixing rules that freedesktop.org pkg-config uses.
 .It Va DESTDIR
 If set to PKG_CONFIG_SYSROOT_DIR, assume that PKG_CONFIG_FDO_SYSROOT_RULES is set.
 .El
+.Sh EXIT STATUS
+.Ex -std
 .Sh EXAMPLES
 Displaying the CFLAGS of a package:
 .Dl $ pkgconf --cflags foo


### PR DESCRIPTION
Rationale for the first patch:
 * Mark up VERSION with .Ar in the text body such that it becomes clear it refers to the option argument.
 * For precision and clarity, consistently talk about version numbers rather than merely "versions".
 * Precisely state what the check is (greater than) instead of using the vague wording "support".
 * Make it clearer that the version number in question is the version number of the program itself, by using the .Nm macro, by avoiding the confusing string "pkg-config" (that's not what the program in this package is called), and by adding the word "program".
 * Avoid the word "we"; in manual pages, using the first and second persons is generally frowned upon.