### PR TITLE
man/pkgconf.1: do not use all caps for the arguments of .Ar macros

### DIFF
--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -123,7 +123,7 @@ flags, or only the linker flags that are neither library path
 nor library flags, respectively.
 .It Fl -list-all
 Walk all directories listed in the
-.Va PKG_CONFIG_PATH
+.Ev PKG_CONFIG_PATH
 environmental variable and display information on packages which have registered
 information there.
 .It Fl -max-version Ns = Ns Ar version
@@ -285,51 +285,51 @@ Paths added in this way are given preference before other paths.
 .El
 .Sh ENVIRONMENT
 .Bl -tag -width indent
-.It Va PKG_CONFIG_PATH
-List of secondary directories where
-.Sq .pc
-files are looked up.
-.It Va PKG_CONFIG_LIBDIR
-List of primary directories where
-.Sq .pc
-files are looked up.
-.It Va PKG_CONFIG_SYSROOT_DIR
-.Sq sysroot
-directory, will be prepended to every path defined in
-.Va PKG_CONFIG_PATH .
-Useful for cross compilation.
-.It Va PKG_CONFIG_TOP_BUILD_DIR
-Provides an alternative setting for the
-.Sq pc_top_builddir
-global variable.
-.It Va PKG_CONFIG_PURE_DEPGRAPH
-If set, enables the same behaviour as the
-.Fl -pure
-flag.
-.It Va PKG_CONFIG_SYSTEM_INCLUDE_PATH
-List of paths that are considered system include paths by the toolchain.
-This is a pkgconf-specific extension.
-.It Va PKG_CONFIG_SYSTEM_LIBRARY_PATH
-List of paths that are considered system library paths by the toolchain.
-This is a pkgconf-specific extension.
-.It Va PKG_CONFIG_DISABLE_UNINSTALLED
+.It Ev DESTDIR
+If set to PKG_CONFIG_SYSROOT_DIR, assume that PKG_CONFIG_FDO_SYSROOT_RULES is set.
+.It Ev PKG_CONFIG_DEBUG_SPEW
+If set, enables additional debug logging.
+The format of the debug log messages is implementation-specific.
+.It Ev PKG_CONFIG_DISABLE_UNINSTALLED
 If set, enables the same behaviour as the
 .Fl -no-uninstalled
 flag.
-.It Va PKG_CONFIG_LOG
+.It Ev PKG_CONFIG_DONT_RELOCATE_PATHS
+If set, disables the path relocation feature.
+.It Ev PKG_CONFIG_FDO_SYSROOT_RULES
+If set, follow the sysroot prefixing rules that freedesktop.org pkg-config uses.
+.It Ev PKG_CONFIG_LIBDIR
+List of primary directories where
+.Sq .pc
+files are looked up.
+.It Ev PKG_CONFIG_LOG
 .Sq logfile
 which is used for dumping audit information concerning installed module versions.
-.It Va PKG_CONFIG_DEBUG_SPEW
-If set, enables additional debug logging.
-The format of the debug log messages is implementation-specific.
-.It Va PKG_CONFIG_DONT_RELOCATE_PATHS
-If set, disables the path relocation feature.
-.It Va PKG_CONFIG_MSVC_SYNTAX
+.It Ev PKG_CONFIG_MSVC_SYNTAX
 If set, uses MSVC syntax for fragments.
-.It Va PKG_CONFIG_FDO_SYSROOT_RULES
-If set, follow the sysroot prefixing rules that freedesktop.org pkg-config uses.
-.It Va DESTDIR
-If set to PKG_CONFIG_SYSROOT_DIR, assume that PKG_CONFIG_FDO_SYSROOT_RULES is set.
+.It Ev PKG_CONFIG_PATH
+List of secondary directories where
+.Sq .pc
+files are looked up.
+.It Ev PKG_CONFIG_PURE_DEPGRAPH
+If set, enables the same behaviour as the
+.Fl -pure
+flag.
+.It Ev PKG_CONFIG_SYSROOT_DIR
+.Sq sysroot
+directory, will be prepended to every path defined in
+.Ev PKG_CONFIG_PATH .
+Useful for cross compilation.
+.It Ev PKG_CONFIG_SYSTEM_INCLUDE_PATH
+List of paths that are considered system include paths by the toolchain.
+This is a pkgconf-specific extension.
+.It Ev PKG_CONFIG_SYSTEM_LIBRARY_PATH
+List of paths that are considered system library paths by the toolchain.
+This is a pkgconf-specific extension.
+.It Ev PKG_CONFIG_TOP_BUILD_DIR
+Provides an alternative setting for the
+.Sq pc_top_builddir
+global variable.
 .El
 .Sh EXIT STATUS
 .Ex -std

--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -42,7 +42,7 @@ is less than the specified
 number.
 .It Fl -cflags , Fl -cflags-only-I , Fl -cflags-only-other
 Print all compiler flags required to compile against the
-.Cm module ,
+.Ar module ,
 or only the include path
 .Pq Fl I
 flags, or only the compiler flags that are not include path flags,
@@ -111,7 +111,7 @@ Keep CFLAGS or linker flag fragments that would be filtered due to being
 included by default in the compiler.
 .It Fl -libs , Fl -libs-only-L , Fl -libs-only-l , Fl -libs-only-other
 Print all linker flags required to link against the
-.Cm module ,
+.Ar module ,
 or only the library path
 .Pq Fl L
 flags, or only the library

--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -70,6 +70,9 @@ Dump the dependency resolver's solution as a graphviz
 .Sq dot
 file.
 This can be used with graphviz to visualize module interdependencies.
+This option is only available if the preprocessor macro
+.Dv PKGCONF_LITE
+was not defined during compilation.
 .It Fl -dont-define-prefix
 Disables the
 .Sq define-prefix
@@ -225,6 +228,9 @@ and
 Simulates resolving a dependency graph based on the requested modules on the
 command line.
 Dumps a series of trees denoting pkgconf's resolver state.
+This option is only available if the preprocessor macro
+.Dv PKGCONF_LITE
+was not defined during compilation.
 .It Fl -static
 Compute a deeper dependency graph and use compiler/linker flags intended for
 static linking.

--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -165,9 +165,13 @@ rules in modules when resolving dependencies.
 Forbids the dependency resolver from considering 'uninstalled' modules as part
 of a solution.
 .It Fl -path
-Display the filenames of the
-.Sq .pc
-files used by the dependency resolver for a given dependency set.
+For the first
+.Ar module
+given on the command line, let the dependency resolver find the
+.Xr pc 5
+file describing that module, print the absolute pathname of that file
+to standard output, and exit immediately,
+ignoring most other options and all other arguments.
 .It Fl -prefix-variable Ns = Ns Ar variable
 Sets the
 .Sq prefix

--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -62,7 +62,7 @@ This is mainly useful for platforms where framework SDKs are relocatable, such a
 Define
 .Ar varname
 as
-.Va value .
+.Ar value .
 Variables are used in query output, and some modules' results may change based
 on the presence of a variable definition.
 .It Fl -digraph
@@ -262,7 +262,7 @@ Validate specific
 files for correctness.
 .It Fl -variable Ns = Ns Ar varname
 Print the value of
-.Va varname .
+.Ar varname .
 .It Fl -verbose
 This option only has an effect if
 .Fl -modversion

--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -28,14 +28,16 @@ The
 .Ar options
 are as follows:
 .Bl -tag -width indent
-.It Fl -atleast-pkgconfig-version Ns = Ns Ar VERSION
+.It Fl -atleast-pkgconfig-version Ns = Ns Ar version
 Exit with error if the requested
-.Ar VERSION
+.Ar version
 number is greater than the version number of the
 .Nm
 program.
-.It Fl -atleast-version Ns = Ns Ar VERSION
-Exit with error if a module's version is less than the specified version.
+.It Fl -atleast-version Ns = Ns Ar version
+Exit with error if a module's version number is less than the specified
+.Ar version
+number.
 .It Fl -cflags , Fl -cflags-only-I , Fl -cflags-only-other
 Print all compiler flags required to compile against the
 .Cm module ,
@@ -54,11 +56,11 @@ this option also prints many debugging messages to standard error output.
 .It Fl -define-prefix
 Attempts to determine the prefix variable to use for CFLAGS and LIBS entry relocations.
 This is mainly useful for platforms where framework SDKs are relocatable, such as Windows.
-.It Fl -define-variable Ns = Ns Ar VARNAME Ns = Ns Ar VALUE
+.It Fl -define-variable Ns = Ns Ar varname Ns = Ns Ar value
 Define
-.Va VARNAME
+.Ar varname
 as
-.Va VALUE .
+.Va value .
 Variables are used in query output, and some modules' results may change based
 on the presence of a variable definition.
 .It Fl -digraph
@@ -72,7 +74,7 @@ Disables the
 feature.
 .It Fl -dont-relocate-paths
 Disables the path relocation feature.
-.It Fl -env Ns = Ns Ar VARNAME
+.It Fl -env Ns = Ns Ar varname
 Print the requested values as variable declarations in a similar format as the
 .Xr env 1
 command.
@@ -81,8 +83,10 @@ Learn about pkgconf's configuration strictly from environmental variables.
 .It Fl -errors-to-stdout
 Print all error, warning, and debugging messages to standard output
 instead of to standard error output.
-.It Fl -exact-version Ns = Ns Ar VERSION
-Exit with error if a module's version is not exactly the specified version.
+.It Fl -exact-version Ns = Ns Ar version
+Exit with error if a module's version number is not exactly the specified
+.Ar version
+number.
 .It Fl -exists
 Exit with a non-zero exit status
 if the dependency resolver is unable to find all of the requested
@@ -91,8 +95,9 @@ This option is active by default and cannot be disabled.
 However, various other options cause
 .Nm
 to exit and report success or failure before all arguments have been inspected.
-.It Fl -fragment-filter Ns = Ns Ar TYPES
-Filter the fragment lists for the specified types.
+.It Fl -fragment-filter Ns = Ns Ar types
+Filter the fragment lists for the specified
+.Ar types .
 .It Fl -ignore-conflicts
 Ignore
 .Sq Conflicts
@@ -114,11 +119,15 @@ Walk all directories listed in the
 .Va PKG_CONFIG_PATH
 environmental variable and display information on packages which have registered
 information there.
-.It Fl -max-version Ns = Ns Ar VERSION
-Exit with error if a module's version is greater than the specified version.
-.It Fl -maximum-traverse-depth Ns = Ns Ar DEPTH
+.It Fl -max-version Ns = Ns Ar version
+Exit with error if a module's version number is greater than the specified
+.Ar version
+number.
+.It Fl -maximum-traverse-depth Ns = Ns Ar depth
 Impose a limit on the allowed depth in the dependency graph.
-For example, a depth of 2 will restrict the resolver from acting on child
+For example, a
+.Ar depth
+of 2 restricts the resolver from acting on child
 dependencies of modules added to the resolver's solution.
 .It Fl -modversion
 Print the version of the queried module.
@@ -136,7 +145,7 @@ of a solution.
 Display the filenames of the
 .Sq .pc
 files used by the dependency resolver for a given dependency set.
-.It Fl -prefix-variable Ns = Ns Ar VARIABLE
+.It Fl -prefix-variable Ns = Ns Ar variable
 Sets the
 .Sq prefix
 variable used by the
@@ -193,7 +202,7 @@ Treats the computed dependency graph as if it were pure.
 This is mainly intended for use with the
 .Fl -static
 flag.
-.It Fl -relocate Ns = Ns Ar PATH
+.It Fl -relocate Ns = Ns Ar path
 Relocates a path using the pkgconf_path_relocate API.
 This is mainly used by the testsuite to provide a guaranteed interface
 to the system's path relocation backend.
@@ -221,16 +230,20 @@ module as part of its solution.
 Validate specific
 .Sq .pc
 files for correctness.
-.It Fl -variable Ns = Ns Ar VARNAME
+.It Fl -variable Ns = Ns Ar varname
 Print the value of
-.Va VARNAME .
+.Va varname .
 .It Fl -version
 Print the version number of the
 .Nm
 program to standard output and exit.
 Most other options and all command line arguments are ignored.
-.It Fl -with-path Ns = Ns Ar PATH
-Adds a new module search path to pkgconf's dependency resolver.
+.It Fl -with-path Ns = Ns Ar path
+Add a new module search
+.Ar path
+to
+.Nm Ap s
+dependency resolver.
 Paths added in this way are given preference before other paths.
 .El
 .Sh ENVIRONMENT

--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -35,7 +35,9 @@ number is greater than the version number of the
 .Nm
 program.
 .It Fl -atleast-version Ns = Ns Ar version
-Exit with error if a module's version number is less than the specified
+Exit with error if the version number of each
+.Ar module
+is less than the specified
 .Ar version
 number.
 .It Fl -cflags , Fl -cflags-only-I , Fl -cflags-only-other
@@ -84,7 +86,9 @@ Learn about pkgconf's configuration strictly from environmental variables.
 Print all error, warning, and debugging messages to standard output
 instead of to standard error output.
 .It Fl -exact-version Ns = Ns Ar version
-Exit with error if a module's version number is not exactly the specified
+Exit with error if no
+.Ar module
+has exactly the specified
 .Ar version
 number.
 .It Fl -exists
@@ -120,7 +124,9 @@ Walk all directories listed in the
 environmental variable and display information on packages which have registered
 information there.
 .It Fl -max-version Ns = Ns Ar version
-Exit with error if a module's version number is greater than the specified
+Exit with error if the version number of each
+.Ar module
+is greater than the specified
 .Ar version
 number.
 .It Fl -maximum-traverse-depth Ns = Ns Ar depth

--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -139,7 +139,21 @@ For example, a
 of 2 restricts the resolver from acting on child
 dependencies of modules added to the resolver's solution.
 .It Fl -modversion
-Print the version of the queried module.
+For each specified
+.Ar module ,
+print the version number to standard output.
+If the
+.Fl -verbose
+option is also specified, the name of the respective
+.Ar module
+and a colon is printed before each version number.
+This option implies
+.Fl -maximum-traverse-depth Ns =1
+and overrides and disables all
+.Fl -cflags
+and
+.Fl -libs
+flags.
 .It Fl -no-cache
 Skip caching packages when they are loaded into the internal resolver.
 This may result in an alternate dependency graph being computed.
@@ -245,6 +259,13 @@ files for correctness.
 .It Fl -variable Ns = Ns Ar varname
 Print the value of
 .Va varname .
+.It Fl -verbose
+This option only has an effect if
+.Fl -modversion
+is also specified.
+It prints the name of the respective
+.Ar module
+and a colon before each version number.
 .It Fl -version
 Print the version number of the
 .Nm


### PR DESCRIPTION
Very little text change, only minimal wording and markup improvements in the immediate vicinity.

Rationale:
In a manual page, it would be highly unusual to use all caps for the placeholders for option arguments.  In general, all caps harms accessibility because screen readers often pronounce the letters of such words one-by-one rather than pronouncing the whole word.  Consequently, unnecessary all caps is better avoided.

Additionally, there is no need for such pedestrian markup.  The .Ar macro already results in italic font, or on terminals that don't provide an italic font, it results in underlining.