### PR TITLE
ci: enable back MSI build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         include: [
           { msystem: MINGW64, arch: x86_64},
-          { msystem: MINGW32, arch: i686}
         ]
     steps:
       - name: Checkout code
@@ -28,6 +27,7 @@ jobs:
             mingw-w64-${{ matrix.arch }}-meson
             mingw-w64-${{ matrix.arch }}-ninja
             mingw-w64-${{ matrix.arch }}-gcc
+            mingw-w64-${{ matrix.arch }}-msitools
 
       - name: Build
         shell: msys2 {0}
@@ -36,17 +36,16 @@ jobs:
           export CFLAGS=-D__USE_MINGW_ANSI_STDIO=0
 
           meson -Dtests=disabled _build
-          # meson compile -C _build msi
-          meson compile -C _build
+          meson compile -C _build msi
 
-#      - name: Upload Artifact
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: build-output
-#          path: |
-#            _build/*.exe
-#            _build/*.dll
-#            _build/*.msi
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: |
+            _build/*.exe
+            _build/*.dll
+            _build/*.msi
 
   debian-meson:
     runs-on: ubuntu-latest

--- a/meson.build
+++ b/meson.build
@@ -164,12 +164,11 @@ if host_machine.system() == 'windows'
 
   python = find_program('python3')
   wixl = find_program('wixl', required: false, version: '>= 0.105')
-  unoconv = find_program('unoconv', required: false)
   msi_filename = 'pkgconf-@0@-@1@.msi'.format(wixl_arch, meson.project_version())
 
   wxsfile = configure_file(input: 'pkgconf.wxs.in', output: 'pkgconf.wxs', configuration: conf_data)
 
-  if wixl.found() and unoconv.found()
+  if wixl.found()
     licensefile = custom_target(
       'License.rtf',
       input: 'COPYING',
@@ -179,7 +178,7 @@ if host_machine.system() == 'windows'
 
     msi = custom_target(
       msi_filename,
-      input: [wxsfile, licensefile],
+      input: [wxsfile, licensefile, pkgconf_exe],
       output: msi_filename,
       command: [wixl, '--arch', wixl_arch, '--ext', 'ui', '-o', msi_filename, wxsfile],
     )


### PR DESCRIPTION
Drop mingw32 arch build, see:
https://github.com/msys2/MINGW-packages/issues/24419