### PR TITLE
personality.c: _WIN32 does not want_default_static

### DIFF
--- a/libpkgconf/personality.c
+++ b/libpkgconf/personality.c
@@ -37,15 +37,6 @@ static unsigned default_personality_init = 0;
 
 static pkgconf_cross_personality_t default_personality = {
 	.name = "default",
-#ifdef _WIN32
-	/* PE/COFF uses a different linking model than ELF and Mach-O, where
-	 * all transitive dependency references must be processed by the linker
-	 * when linking the final executable image, even if those dependencies
-	 * are pulled in as DLLs.
-	 * This translates to always using --static on Windows targets.
-	 */
-	.want_default_static = true,
-#endif
 };
 
 static inline void


### PR DESCRIPTION
Discussed in https://github.com/pkgconf/pkgconf/issues/364.
Applied in msys2's mingw packages, https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-pkgconf/0004-no-default-static.patch.
(Somewhat) tested in vcpkg.