### PR TITLE
build: add buffer.c to SRCS in Makefile.lite

### DIFF
--- a/Makefile.lite
+++ b/Makefile.lite
@@ -16,6 +16,7 @@ SRCS = \
 	libpkgconf/argvsplit.c		\
 	libpkgconf/audit.c		\
 	libpkgconf/bsdstubs.c		\
+	libpkgconf/buffer.c		\
 	libpkgconf/cache.c		\
 	libpkgconf/client.c		\
 	libpkgconf/dependency.c		\


### PR DESCRIPTION
I noticed the file `libpkgconf/buffer.c` was missing from the sources in `Makefile.lite`, adding it fixed my compile errors when attempting to build a statically linked pkgconf binary.