### PR TITLE
Add Source-tag to libpkgconf

### DIFF
--- a/libpkgconf.pc.in
+++ b/libpkgconf.pc.in
@@ -7,6 +7,7 @@ Name: libpkgconf
 Description: a library for accessing and manipulating development framework configuration
 URL: https://gitea.treehouse.systems/ariadne/pkgconf
 License: ISC
+Source: https://github.com/pkgconf/pkgconf
 Version: @PACKAGE_VERSION@
 CFlags: -I${includedir}/pkgconf
 Libs: -L${libdir} -lpkgconf

--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -160,6 +160,7 @@ struct pkgconf_pkg_ {
 	char *license;
 	char *maintainer;
 	char *copyright;
+	char *source;
 	char *why;
 
 	pkgconf_list_t libs;

--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -261,6 +261,7 @@ static const pkgconf_pkg_parser_keyword_pair_t pkgconf_pkg_parser_keyword_funcs[
 	{"Requires", pkgconf_pkg_parser_dependency_func, offsetof(pkgconf_pkg_t, required)},
 	{"Requires.internal", pkgconf_pkg_parser_internal_dependency_func, offsetof(pkgconf_pkg_t, requires_private)},
 	{"Requires.private", pkgconf_pkg_parser_private_dependency_func, offsetof(pkgconf_pkg_t, requires_private)},
+	{"Source", pkgconf_pkg_parser_tuple_func, offsetof(pkgconf_pkg_t, source)},
 	{"URL", pkgconf_pkg_parser_tuple_func, offsetof(pkgconf_pkg_t, url)},
 	{"Version", pkgconf_pkg_parser_version_func, offsetof(pkgconf_pkg_t, version)},
 };

--- a/man/pc.5
+++ b/man/pc.5
@@ -120,6 +120,12 @@ The asserted SPDX license tag that should be applied to the given package.
 The preferred contact for the maintainer.  This should be in the format of a
 name followed by an e-mail address or website.
 (optional; literal; pkgconf extension)
+.It Source
+The asserted SPDX downloadLocation tag that should be applied to the given package.
+Source should be URI contain tarball with exact version or Repository that contains
+tag with version same as mentioned in version tag. It can be also be URI with hash
+that is exact release point of the source.
+(optional; literal; pkgconf extension)
 .It Requires
 Required dependencies that must be met for the package to be usable.
 All dependencies must be satisfied or the pkg-config implementation must not use

--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -79,6 +79,7 @@ command line and do not look at dependencies.
 Limited-output options:
 .Fl -validate ,
 .Fl -license ,
+.Fl -source ,
 .Fl -uninstalled ,
 and
 .Fl -env :

--- a/tests/basic.sh
+++ b/tests/basic.sh
@@ -43,6 +43,8 @@ tests_init \
 	with_path \
 	relocatable \
 	single_depth_selectors \
+	source_foo \
+	source_empty \
 	print_variables_env \
 	variable_env \
 	variable_no_recurse
@@ -338,6 +340,20 @@ license_noassertion_body()
 	atf_check \
 		-o inline:"bar: NOASSERTION\nfoo: ISC\n" \
 		pkgconf --with-path=${selfdir}/lib1 --license bar
+}
+
+source_foo_body()
+{
+	atf_check \
+		-o inline:"foo: https://foo.bar/foo\n" \
+		pkgconf --with-path=${selfdir}/lib1 --source foo
+}
+
+source_empty_body()
+{
+	atf_check \
+		-o inline:"bar: \nfoo: https://foo.bar/foo\n" \
+		pkgconf --with-path=${selfdir}/lib1 --source bar
 }
 
 modversion_noflatten_body()

--- a/tests/lib1/c-comment.pc
+++ b/tests/lib1/c-comment.pc
@@ -15,3 +15,4 @@ Libs: -L${libdir} -lfoo
 Cflags: -fPIC -I${includedir}/foo
 Cflags.private: -DFOO_STATIC
 License: ISC
+Source: https://foo.bar/foo

--- a/tests/lib1/foo.pc
+++ b/tests/lib1/foo.pc
@@ -10,3 +10,4 @@ Libs: -L${libdir} -lfoo
 Cflags: -fPIC -I${includedir}/foo
 Cflags.private: -DFOO_STATIC
 License: ISC
+Source: https://foo.bar/foo

--- a/tests/lib1/foobar.pc
+++ b/tests/lib1/foobar.pc
@@ -10,3 +10,4 @@ Libs: -L${libdir} -lfoobar
 Cflags: -fPIC -I${includedir}/foobar
 Cflags.private: -DFOOBAR_STATIC
 License: ISC
+Source: https://foo.bar/foo


### PR DESCRIPTION
For the SBOM would be easier to have separate `Source`-tag from `URL`-tag. This makes sure that there is mention for correct upstream location where this package have been originally fetched.

It can be also use to satisfy SPDX `Software/downloadLocation` tag. As tag in SPDX documentation it's also optional in `pkgconf`