### PR TITLE
`pkg.m4`: add missing quotes in `PKG_WITH_MODULES`

### DIFF
--- a/pkg.m4
+++ b/pkg.m4
@@ -1,5 +1,5 @@
 # pkg.m4 - Macros to locate and use pkg-config.   -*- Autoconf -*-
-# serial 15 (pkgconf)
+# serial 16 (pkgconf)
 
 dnl Copyright © 2004 Scott James Remnant <scott@netsplit.com>.
 dnl Copyright © 2012-2015 Dan Nicholson <dbn.lists@gmail.com>
@@ -300,7 +300,7 @@ AC_ARG_WITH(with_arg,
     [AS_TR_SH([with_]with_arg)=def_arg])
 
 AS_CASE([$AS_TR_SH([with_]with_arg)],
-            [yes],[PKG_CHECK_MODULES([$1],[$2],$3,$4)],
+            [yes],[PKG_CHECK_MODULES([$1],[$2],[$3],[$4])],
             [auto],[PKG_CHECK_MODULES([$1],[$2],
                                         [m4_n([def_action_if_found]) $3],
                                         [m4_n([def_action_if_not_found]) $4])])


### PR DESCRIPTION
A small reproducer:
```m4
AC_INIT([hello], [1.0])
m4_include([pkg.m4])

AC_PROG_CC
PKG_PROG_PKG_CONFIG

PKG_WITH_MODULES([mylib], [libmylib],
  [AC_CHECK_FUNC([printf])],
  [AC_CHECK_FUNC([printf])],
  [message],
  [yes])
AC_OUTPUT
```

before this patch (your error may vary):
```console
$ autoreconf && ./configure
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether the compiler supports GNU C... yes
checking whether gcc accepts -g... yes
checking for gcc option to enable C11 features... none needed
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
./configure: line 3345: syntax error near unexpected token `in'
./configure: line 3345: `        in case <limits.h> declares $2.'
```

after this patch:
```console
$ autoreconf && ./configure
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether the compiler supports GNU C... yes
checking whether gcc accepts -g... yes
checking for gcc option to enable C11 features... none needed
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
checking for libmylib... no
checking for printf... yes
configure: creating ./config.status
```
