### PR TITLE
spdxtool: Update variables that are const to const

### DIFF
--- a/cli/spdxtool/core.c
+++ b/cli/spdxtool/core.c
@@ -167,7 +167,7 @@ spdxtool_core_creation_info_new(pkgconf_client_t *client, char *agent_id, char *
 		creation_struct->created = time;
 	}
 	creation_struct->created_by = agent_id;
-	creation_struct->created_using="pkgconf spdxtool";
+	creation_struct->created_using = "pkgconf spdxtool";
 	creation_struct->spec_version = spdxtool_util_get_spdx_version(client);
 	return creation_struct;
 }
@@ -237,7 +237,7 @@ spdxtool_core_creation_info_serialize(pkgconf_client_t *client, pkgconf_buffer_t
 	spdxtool_serialize_parm_and_char(buffer, "createdBy", '[', 3, false);
 	spdxtool_serialize_string(buffer, creation_struct->created_by, 4, false);
 	spdxtool_serialize_array_end(buffer, 3, true);
-	spdxtool_serialize_parm_and_string(buffer, "specVersion", (char *)creation_struct->spec_version, 3, false);
+	spdxtool_serialize_parm_and_string(buffer, "specVersion", creation_struct->spec_version, 3, false);
 	spdxtool_serialize_obj_end(buffer, 2, last);
 }
 

--- a/cli/spdxtool/main.c
+++ b/cli/spdxtool/main.c
@@ -132,8 +132,8 @@ generate_spdx(pkgconf_client_t *client, pkgconf_pkg_t *world, char *creation_tim
 	int eflag;
 	pkgconf_buffer_t buffer = PKGCONF_BUFFER_INITIALIZER;
 
-	char *agent_name_string = "Default";
-	char *creation_id_string = "_:creationinfo_1";
+	const char *agent_name_string = "Default";
+	const char *creation_id_string = "_:creationinfo_1";
 	char *creation_time_string = NULL;
 
 
@@ -230,10 +230,12 @@ main(int argc, char *argv[])
 	char *creation_time = NULL;
 	char *creation_id = NULL;
 	char *agent_name = NULL;
+	char world_id[] = "virtual:world";
+	char world_realname[] = "virtual world package";
 	pkgconf_pkg_t world =
 	{
-		.id = "virtual:world",
-		.realname = "virtual world package",
+		.id = world_id,
+		.realname = world_realname,
 		.flags = PKGCONF_PKG_PROPF_STATIC | PKGCONF_PKG_PROPF_VIRTUAL,
 	};
 

--- a/cli/spdxtool/serialize.c
+++ b/cli/spdxtool/serialize.c
@@ -60,7 +60,7 @@ serialize_end_object(pkgconf_buffer_t *buffer, char ch, unsigned int level, bool
  *    :return: nothing
  */
 void
-spdxtool_serialize_parm_and_string(pkgconf_buffer_t *buffer, char *parm, char *string, unsigned int level, bool more)
+spdxtool_serialize_parm_and_string(pkgconf_buffer_t *buffer, const char *parm, const char *string, unsigned int level, bool more)
 {
 	serialize_add_indent(buffer, level);
 	pkgconf_buffer_append_fmt(buffer, "\"%s\": \"%s\"", parm, string);
@@ -82,7 +82,7 @@ spdxtool_serialize_parm_and_string(pkgconf_buffer_t *buffer, char *parm, char *s
  *    :return: nothing
  */
 void
-spdxtool_serialize_parm_and_char(pkgconf_buffer_t *buffer, char *parm, char ch, unsigned int level, bool more)
+spdxtool_serialize_parm_and_char(pkgconf_buffer_t *buffer, const char *parm, char ch, unsigned int level, bool more)
 {
 	serialize_add_indent(buffer, level);
 	pkgconf_buffer_append_fmt(buffer, "\"%s\": %c", parm, ch);
@@ -104,7 +104,7 @@ spdxtool_serialize_parm_and_char(pkgconf_buffer_t *buffer, char *parm, char ch, 
  *    :return: nothing
  */
 void
-spdxtool_serialize_parm_and_int(pkgconf_buffer_t *buffer, char *parm, int integer, unsigned int level, bool more)
+spdxtool_serialize_parm_and_int(pkgconf_buffer_t *buffer, const char *parm, int integer, unsigned int level, bool more)
 {
 	serialize_add_indent(buffer, level);
 	pkgconf_buffer_append_fmt(buffer, "\"%s\": %d", parm, integer);

--- a/cli/spdxtool/serialize.h
+++ b/cli/spdxtool/serialize.h
@@ -20,13 +20,13 @@ extern "C" {
 #endif
 
 void
-spdxtool_serialize_parm_and_string(pkgconf_buffer_t *buffer, char *parm, char *string, unsigned int level, bool comma);
+spdxtool_serialize_parm_and_string(pkgconf_buffer_t *buffer, const char *parm, const char *string, unsigned int level, bool comma);
 
 void
-spdxtool_serialize_parm_and_char(pkgconf_buffer_t *buffer, char *parm, char ch, unsigned int level, bool comma);
+spdxtool_serialize_parm_and_char(pkgconf_buffer_t *buffer, const char *parm, char ch, unsigned int level, bool comma);
 
 void
-spdxtool_serialize_parm_and_int(pkgconf_buffer_t *buffer, char *parm, int integer, unsigned int level, bool comma);
+spdxtool_serialize_parm_and_int(pkgconf_buffer_t *buffer, const char *parm, int integer, unsigned int level, bool comma);
 
 void
 spdxtool_serialize_string(pkgconf_buffer_t *buffer, char *string, unsigned int level, bool comma);

--- a/cli/spdxtool/util.c
+++ b/cli/spdxtool/util.c
@@ -151,7 +151,7 @@ static size_t last_id = 0;
  *    :return: URI
  */
 char *
-spdxtool_util_get_spdx_id_int(pkgconf_client_t *client, char *part)
+spdxtool_util_get_spdx_id_int(pkgconf_client_t *client, const char *part)
 {
 	const 	char *global_xsd_any_uri = spdxtool_util_get_uri_root(client);
 	pkgconf_buffer_t current_uri = PKGCONF_BUFFER_INITIALIZER;
@@ -176,7 +176,7 @@ spdxtool_util_get_spdx_id_int(pkgconf_client_t *client, char *part)
  *    :return: URI
  */
 char *
-spdxtool_util_get_spdx_id_string(pkgconf_client_t *client, char *part, char *string_id)
+spdxtool_util_get_spdx_id_string(pkgconf_client_t *client, const char *part, char *string_id)
 {
 	const 	char *global_xsd_any_uri = spdxtool_util_get_uri_root(client);
 	pkgconf_buffer_t current_uri = PKGCONF_BUFFER_INITIALIZER;

--- a/cli/spdxtool/util.h
+++ b/cli/spdxtool/util.h
@@ -22,7 +22,7 @@ typedef struct spdxtool_core_agent_
 {
 	int refcount;
 	char *spdx_id;
-	char *type;
+	const char *type;
 	char *creation_info;
 	char *name;
 } spdxtool_core_agent_t;
@@ -31,17 +31,17 @@ typedef struct spdxtool_core_creation_info_
 {
 	int refcount;
 	char *id;
-	char *type;
+	const char *type;
 	char *created;
 	char *created_by;
-	char *created_using;
+	const char *created_using;
 	const char *spec_version;
 } spdxtool_core_creation_info_t;
 
 typedef struct spdxtool_core_spdx_document
 {
 	int refcount;
-	char *type;
+	const char *type;
 	char *spdx_id;
 	char *creation_info;
 	char *agent;
@@ -54,7 +54,7 @@ typedef struct spdxtool_software_sbom_
 {
 	int refcount;
 	char *spdx_id;
-	char *type;
+	const char *type;
 	char *creation_info;
 	char *sbom_type;
 	spdxtool_core_spdx_document_t *spdx_document;
@@ -64,7 +64,7 @@ typedef struct spdxtool_software_sbom_
 typedef struct spdxtool_simplelicensing_license_expression_
 {
 	int refcount;
-	char *type;
+	const char *type;
 	char *spdx_id;
 	char *license_expression;
 } spdxtool_simplelicensing_license_expression_t;
@@ -72,7 +72,7 @@ typedef struct spdxtool_simplelicensing_license_expression_
 typedef struct spdxtool_core_relationship_
 {
 	int refcount;
-	char *type;
+	const char *type;
 	char *spdx_id;
 	char *creation_info;
 	char *from;
@@ -102,10 +102,10 @@ const char *
 spdxtool_util_get_spdx_license(pkgconf_client_t *client);
 
 char *
-spdxtool_util_get_spdx_id_int(pkgconf_client_t *client, char *part);
+spdxtool_util_get_spdx_id_int(pkgconf_client_t *client, const char *part);
 
 char *
-spdxtool_util_get_spdx_id_string(pkgconf_client_t *client, char *part, char *string_id);
+spdxtool_util_get_spdx_id_string(pkgconf_client_t *client, const char *part, char *string_id);
 
 char *
 spdxtool_util_get_iso8601_time(time_t *wanted_time);


### PR DESCRIPTION
In spdxtool there is lot of variables that should be const and they are mutable without being that. Turn everything that is immutable to const.

Sponsored by: The FreeBSD Foundation