### PR TITLE
spdxtool: Fix SPDX 3 conformance

### DIFF
--- a/cli/spdxtool/core.c
+++ b/cli/spdxtool/core.c
@@ -117,7 +117,7 @@ spdxtool_core_agent_serialize(pkgconf_client_t *client, pkgconf_buffer_t *buffer
 {
 	(void) client;
 	spdxtool_serialize_obj_start(buffer, 2);
-	spdxtool_serialize_parm_and_string(buffer, "@type", agent_struct->type, 3, 1);
+	spdxtool_serialize_parm_and_string(buffer, "type", agent_struct->type, 3, 1);
 	spdxtool_serialize_parm_and_string(buffer, "creationInfo", agent_struct->creation_info, 3, 1);
 	spdxtool_serialize_parm_and_string(buffer, "spdxId", agent_struct->spdx_id, 3, 1);
 	spdxtool_serialize_parm_and_string(buffer, "name", agent_struct->name, 3, 0);
@@ -231,7 +231,7 @@ spdxtool_core_creation_info_serialize(pkgconf_client_t *client, pkgconf_buffer_t
 	(void) client;
 
 	spdxtool_serialize_obj_start(buffer, 2);
-	spdxtool_serialize_parm_and_string(buffer, "@type", creation_struct->type, 3, true);
+	spdxtool_serialize_parm_and_string(buffer, "type", creation_struct->type, 3, true);
 	spdxtool_serialize_parm_and_string(buffer, "@id", creation_struct->id, 3, true);
 	spdxtool_serialize_parm_and_string(buffer, "created", creation_struct->created, 3, true);
 	spdxtool_serialize_parm_and_char(buffer, "createdBy", '[', 3, false);
@@ -520,7 +520,7 @@ spdxtool_core_spdx_document_serialize(pkgconf_client_t *client, pkgconf_buffer_t
 	}
 
 	spdxtool_serialize_obj_start(buffer, 2);
-	spdxtool_serialize_parm_and_string(buffer, "@type", spdx_struct->type, 3, true);
+	spdxtool_serialize_parm_and_string(buffer, "type", spdx_struct->type, 3, true);
 	spdxtool_serialize_parm_and_string(buffer, "creationInfo", spdx_struct->creation_info, 3, true);
 	spdxtool_serialize_parm_and_string(buffer, "spdxId", spdx_struct->spdx_id, 3, true);
 	spdxtool_serialize_parm_and_char(buffer, "rootElement", '[', 3, false);
@@ -678,7 +678,7 @@ spdxtool_core_relationship_serialize(pkgconf_client_t *client, pkgconf_buffer_t 
 	(void) client;
 
 	spdxtool_serialize_obj_start(buffer, 2);
-	spdxtool_serialize_parm_and_string(buffer, "@type", relationship_struct->type, 3, true);
+	spdxtool_serialize_parm_and_string(buffer, "type", relationship_struct->type, 3, true);
 	spdxtool_serialize_parm_and_string(buffer, "creationInfo", relationship_struct->creation_info, 3, true);
 	spdxtool_serialize_parm_and_string(buffer, "spdxId", relationship_struct->spdx_id, 3, true);
 	spdxtool_serialize_parm_and_string(buffer, "from", relationship_struct->from, 3, true);

--- a/cli/spdxtool/software.c
+++ b/cli/spdxtool/software.c
@@ -115,7 +115,7 @@ spdxtool_software_sbom_serialize(pkgconf_client_t *client, pkgconf_buffer_t *buf
 	char *value;
 
 	spdxtool_serialize_obj_start(buffer, 2);
-	spdxtool_serialize_parm_and_string(buffer, "@type", sbom_struct->type, 3, true);
+	spdxtool_serialize_parm_and_string(buffer, "type", sbom_struct->type, 3, true);
 	spdxtool_serialize_parm_and_string(buffer, "creationInfo", sbom_struct->creation_info, 3, true);
 	spdxtool_serialize_parm_and_string(buffer, "spdxId", sbom_struct->spdx_id, 3, true);
 	spdxtool_serialize_parm_and_char(buffer, "software_sbomType", '[', 3, false);
@@ -189,7 +189,7 @@ spdxtool_software_package_serialize(pkgconf_client_t *client, pkgconf_buffer_t *
 	(void) last;
 
 	spdxtool_serialize_obj_start(buffer, 2);
-	spdxtool_serialize_parm_and_string(buffer, "@type", "software_Package", 3, true);
+	spdxtool_serialize_parm_and_string(buffer, "type", "software_Package", 3, true);
 	spdxtool_serialize_parm_and_string(buffer, "creationInfo", pkgconf_tuple_find(client, &pkg->vars, "creationInfo"), 3, true);
 	spdxtool_serialize_parm_and_string(buffer, "spdxId", pkgconf_tuple_find(client, &pkg->vars, "spdxId"), 3, true);
 	spdxtool_serialize_parm_and_string(buffer, "name", pkg->realname, 3, true);

--- a/man/spdxtool.1
+++ b/man/spdxtool.1
@@ -106,13 +106,13 @@ Generating an SBOM for the package named foo:
 .Dl    "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
 .Dl    "@graph": [
 .Dl        {
-.Dl            "@type": "Agent",
+.Dl            "type": "Agent",
 .Dl            "creationInfo": "_:creationinfo_1",
 .Dl            "spdxId": "https://github.com/pkgconf/pkgconf/Agent/default",
 .Dl            "name": "Default"
 .Dl        },
 .Dl        {
-.Dl            "@type": "CreationInfo",
+.Dl            "type": "CreationInfo",
 .Dl            "@id": "_:creationinfo_1",
 .Dl [...]
 .Sh SEE ALSO


### PR DESCRIPTION
Fixes the SPDX 3 output generation to conform with the SPDX 3 JSON schema (https://spdx.org/schema/3.0.1/spdx-json-schema.json)