### PR TITLE
man/pkgconf.1: remove "pkgconf-specific extension" note where not true

### DIFF
--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -723,7 +723,6 @@ If not defined, the default list compiled into the
 program from the
 .Dv SYSTEM_INCLUDEDIR
 preprocessor macro is used instead.
-This variable is a pkgconf-specific extension.
 Any directories listed in the environment variables
 .Ev CPATH ,
 .Ev C_INCLUDE_PATH ,
@@ -743,7 +742,6 @@ If not defined, the default list compiled into the
 program from the
 .Dv SYSTEM_LIBDIR
 preprocessor macro is used instead.
-This variable is a pkgconf-specific extension.
 .It Ev PKG_CONFIG_TOP_BUILD_DIR
 The value of the
 .Va pc_top_builddir


### PR DESCRIPTION
The pkgconf.1 manpage says that PKG_CONFIG_SYSTEM_INCLUDE_PATH and PKG_CONFIG_SYSTEM_LIBRARY_PATH are "pkgconf-specific extensions", but pkg-config has supported these variables since 2011:

  pkg-config 01005bb ("Add --with-system-include-path etc.")
  https://gitlab.freedesktop.org/pkg-config/pkg-config/-/commit/01005bbbd0155b606c1f3df845ccfaff81e0c6ff