### PR TITLE
Replace ``wixl`` by ``WiX``

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,14 +43,29 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install meson ninja
 
+      - name: Install WiX
+        run: |
+          dotnet tool install --global wix
+          $wixVersion = (wix --version).Trim()
+          wix extension add -g "WixToolset.UI.wixext/$wixVersion"
+
       - name: Build
         run: |
           meson _build --vsenv
-          meson compile -C _build
+          meson compile -C _build msi
 
       - name: Run tests
         run: |
           meson test -v -C _build
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output-${{ matrix.msbuild_arch }}
+          path: |
+            _build/*.exe
+            _build/*.dll
+            _build/*.msi
 
   msys2:
     runs-on: windows-latest
@@ -73,7 +88,6 @@ jobs:
             mingw-w64-${{ matrix.arch }}-meson
             mingw-w64-${{ matrix.arch }}-ninja
             mingw-w64-${{ matrix.arch }}-gcc
-            mingw-w64-${{ matrix.arch }}-msitools
 
       - name: Build
         shell: msys2 {0}
@@ -82,21 +96,12 @@ jobs:
           export CFLAGS=-D__USE_MINGW_ANSI_STDIO=0
 
           meson _build
-          meson compile -C _build msi
+          meson compile -C _build
 
       - name: Run tests
         shell: msys2 {0}
         run: |
           meson test -v -C _build
-
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-output
-          path: |
-            _build/*.exe
-            _build/*.dll
-            _build/*.msi
 
   debian-meson:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up MSBuild
-        uses: microsoft/setup-msbuild@v3
+        uses: ilammy/msvc-dev-cmd@v1
         with:
-          msbuild-architecture: ${{ matrix.msbuild_arch }}
+          arch: ${{ matrix.msbuild_arch }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/meson.build
+++ b/meson.build
@@ -260,32 +260,37 @@ if host_machine.system() == 'windows'
   conf_data.set('VERSION', meson.project_version())
   conf_data.set('EXE', pkgconf_exe.full_path())
   conf_data.set('DLL', libpkgconf.full_path())
-  if host_machine.cpu() != 'x86_64'
-    wixl_arch = 'x86'
+
+  if host_machine.cpu_family() == 'x86'
+    wix_arch = 'x86'
+  elif host_machine.cpu_family() == 'x86_64'
+    wix_arch = 'x64'
+  elif host_machine.cpu_family() == 'aarch64'
+    wix_arch = 'arm64'
   else
-    wixl_arch = 'x64'
+    error('WIX does not support CPU family ' + host_machine.cpu_family())
   endif
-  conf_data.set('WIXL_ARCH', wixl_arch)
 
   python = find_program('python3')
-  wixl = find_program('wixl', required: false, version: '>= 0.105')
-  msi_filename = 'pkgconf-@0@-@1@.msi'.format(wixl_arch, meson.project_version())
+  licensefile = custom_target(
+    'License.rtf',
+    input: 'COPYING',
+    output: 'License.rtf',
+    command: [python, files('txt2rtf.py'), '@INPUT@', '@OUTPUT@'],
+  )
+  conf_data.set('LICENSE_RTF', licensefile.full_path())
+
+  wix = find_program('wix', required: false, version: '>= 5.0.0')
+  msi_filename = 'pkgconf-@0@-@1@.msi'.format(wix_arch, meson.project_version())
 
   wxsfile = configure_file(input: 'pkgconf.wxs.in', output: 'pkgconf.wxs', configuration: conf_data)
 
-  if wixl.found()
-    licensefile = custom_target(
-      'License.rtf',
-      input: 'COPYING',
-      output: 'License.rtf',
-      command: [python, files('txt2rtf.py'), '@INPUT@', '@OUTPUT@'],
-    )
-
+  if wix.found()
     msi = custom_target(
       msi_filename,
       input: [wxsfile, licensefile, pkgconf_exe],
       output: msi_filename,
-      command: [wixl, '--arch', wixl_arch, '--ext', 'ui', '-o', msi_filename, wxsfile],
+      command: [wix, 'build', wxsfile, '-arch', wix_arch, '-ext', 'WixToolset.UI.wixext', '-o', msi_filename],
     )
 
     alias_target('msi', msi)

--- a/pkgconf.wxs.in
+++ b/pkgconf.wxs.in
@@ -1,30 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
 
-  <?define Arch = "@WIXL_ARCH@"?>
-  <?if $(var.Arch) = "x64"?>
-      <?define GLIB_ARCH = "win64"?>
-      <?define ArchString = "64-bit"?>
-      <?define ArchProgramFilesFolder = "ProgramFiles64Folder"?>
-      <?define Win64 = "yes"?>
-  <?else?>
-      <?define GLIB_ARCH = "win32"?>
-      <?define ArchString = "32-bit"?>
-      <?define ArchProgramFilesFolder = "ProgramFilesFolder"?>
-      <?define Win64 = "no"?>
-  <?endif?>
-
-
-  <Product Id="*"
-           Name="pkgconf @VERSION@ ($(var.ArchString))"
+  <Package Name="pkgconf @VERSION@ ($(sys.BUILDARCH))"
            Language="1033"
            Version="@VERSION@"
            Manufacturer="pkgconf"
-           UpgradeCode="4faedad2-3f9d-45cc-89a7-3732ad2db0f7">
-
-      <Package InstallerVersion="200"
-               Compressed="yes"
-               InstallScope="perMachine" />
+           UpgradeCode="4faedad2-3f9d-45cc-89a7-3732ad2db0f7"
+           InstallerVersion="200"
+           Compressed="yes"
+           Scope="perMachine">
 
       <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
       <MediaTemplate EmbedCab="yes" />
@@ -33,22 +18,15 @@
           <ComponentGroupRef Id="ProductComponents" />
       </Feature>
 
-      <Directory Id="TARGETDIR" Name="SourceDir">
-          <Directory Id="$(var.ArchProgramFilesFolder)">
-              <Directory Id="INSTALLFOLDER" Name="pkgconf @VERSION@" />
-          </Directory>
-      </Directory>
+      <StandardDirectory Id="ProgramFiles6432Folder">
+          <Directory Id="INSTALLFOLDER" Name="pkgconf @VERSION@" />
+      </StandardDirectory>
 
       <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
-          <Component Id="PkgconfExe" Guid="*" Win64="$(var.Win64)">
+          <Component Id="PkgconfExe" Guid="*">
               <File Id="PkgconfExeFile"
                     Source="@EXE@"
                     KeyPath="yes" />
-              <File Id="PkgconfigExeFile"
-                    Name="pkg-config.exe"
-                    Source="@EXE@"/>
-              <File Id="PkgconfDllFile"
-                    Source="@DLL@"/>
               <Environment Id="PATH"
                            Name="PATH"
                            Value="[INSTALLFOLDER]"
@@ -57,8 +35,20 @@
                            Action="set"
                            System="yes" />
           </Component>
+          <Component Id="PkgconfigExe" Guid="*">
+              <File Id="PkgconfigExeFile"
+                    Name="pkg-config.exe"
+                    Source="@EXE@"
+                    KeyPath="yes" />
+          </Component>
+          <Component Id="PkgconfDll" Guid="*">
+              <File Id="PkgconfDllFile"
+                    Source="@DLL@"
+                    KeyPath="yes" />
+          </Component>
       </ComponentGroup>
 
-      <UIRef Id="WixUI_Minimal" />
-   </Product>
+      <ui:WixUI Id="WixUI_Minimal" InstallDirectory="INSTALLFOLDER" />
+      <WixVariable Id="WixUILicenseRtf" Value="@LICENSE_RTF@" />
+   </Package>
 </Wix>


### PR DESCRIPTION
Fix: https://github.com/pkgconf/pkgconf/issues/406#issuecomment-4187551065

The goal of this PR is to properly build msi on arm.
Since ``wixl`` doesn't support arm (https://gitlab.gnome.org/GNOME/msitools/-/issues/61), I thought we could try to replace it with  ``WiX``.