### PR TITLE
Support WiX version 7.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           dotnet tool install --global wix
           $wixVersion = (wix --version).Trim()
-          wix extension add -g "WixToolset.UI.wixext/$wixVersion"
+          wix extension add -g "WixToolset.UI.wixext/$wixVersion" -acceptEula wix7
 
       - name: Build
         run: |

--- a/meson.build
+++ b/meson.build
@@ -280,7 +280,7 @@ if host_machine.system() == 'windows'
   )
   conf_data.set('LICENSE_RTF', licensefile.full_path())
 
-  wix = find_program('wix', required: false, version: '>= 5.0.0')
+  wix = find_program('wix', required: false, version: '>= 7.0.0')
   msi_filename = 'pkgconf-@0@-@1@.msi'.format(wix_arch, meson.project_version())
 
   wxsfile = configure_file(input: 'pkgconf.wxs.in', output: 'pkgconf.wxs', configuration: conf_data)
@@ -290,7 +290,7 @@ if host_machine.system() == 'windows'
       msi_filename,
       input: [wxsfile, licensefile, pkgconf_exe],
       output: msi_filename,
-      command: [wix, 'build', wxsfile, '-arch', wix_arch, '-ext', 'WixToolset.UI.wixext', '-o', msi_filename],
+      command: [wix, 'build', wxsfile, '-arch', wix_arch, '-ext', 'WixToolset.UI.wixext', '-o', msi_filename, '-acceptEula', 'wix7'],
     )
 
     alias_target('msi', msi)


### PR DESCRIPTION
Wow, I can't believe in just 5 days since this PR was merged (https://github.com/pkgconf/pkgconf/pull/486), it is already broken.
WiX 7.0.0 require us to pass the option "-acceptEula". See: https://docs.firegiant.com/wix/osmf/#accept-the-eula-wix-v7-and-later
It does sucks, but there isn't really any good alternative to WiX, so I guess we can live with it.