### PR TITLE
libpkgconf: document buffer API and return errors when buffer API fails

### DIFF
--- a/libpkgconf/buffer.c
+++ b/libpkgconf/buffer.c
@@ -47,25 +47,23 @@ buffer_debug(pkgconf_buffer_t *buffer)
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_buffer_append(pkgconf_buffer_t *buffer, const char *text)
+ * .. c:function:: bool pkgconf_buffer_append(pkgconf_buffer_t *buffer, const char *text)
  *
  *    Append a null-terminated string to the buffer, reallocating as necessary.
  *
  *    :param pkgconf_buffer_t *buffer: The buffer to append to.
  *    :param char *text: The null-terminated string to append.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_buffer_append(pkgconf_buffer_t *buffer, const char *text)
 {
 	size_t needed = strlen(text) + 1;
 	size_t newsize = pkgconf_buffer_len(buffer) + needed;
 
 	char *newbase = realloc(buffer->base, target_allocation_size(newsize));
-
-	/* XXX: silently failing here is antisocial */
 	if (newbase == NULL)
-		return;
+		return false;
 
 	char *newend = newbase + pkgconf_buffer_len(buffer);
 	memcpy(newend, text, needed);
@@ -74,43 +72,49 @@ pkgconf_buffer_append(pkgconf_buffer_t *buffer, const char *text)
 	buffer->end = newend + (needed - 1);
 
 	*buffer->end = '\0';
+	return true;
 }
 
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_buffer_append_slice(pkgconf_buffer_t *buf, const char *p, size_t n)
+ * .. c:function:: bool pkgconf_buffer_append_slice(pkgconf_buffer_t *buf, const char *p, size_t n)
  *
  *    Append a slice of *n* bytes to the buffer. Does nothing if *n* is zero.
  *
  *    :param pkgconf_buffer_t *buf: The buffer to append to.
  *    :param char *p: Pointer to the byte sequence to append.
  *    :param size_t n: Number of bytes to append.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_buffer_append_slice(pkgconf_buffer_t *buf, const char *p, size_t n)
 {
 	if (n == 0)
-		return;
+		return true;
 
 	for (size_t i = 0; i < n; i++)
-		pkgconf_buffer_push_byte(buf, p[i]);
+	{
+		if (!pkgconf_buffer_push_byte(buf, p[i]))
+			return false;
+	}
+
+	return true;
 }
 
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_buffer_append_vfmt(pkgconf_buffer_t *buffer, const char *fmt, va_list src_va)
+ * .. c:function:: bool pkgconf_buffer_append_vfmt(pkgconf_buffer_t *buffer, const char *fmt, va_list src_va)
  *
  *    Append a formatted string to the buffer using a :code:`va_list`.
  *
  *    :param pkgconf_buffer_t *buffer: The buffer to append to.
  *    :param char *fmt: A printf-style format string.
  *    :param va_list src_va: The variadic argument list for the format string.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_buffer_append_vfmt(pkgconf_buffer_t *buffer, const char *fmt, va_list src_va)
 {
 	va_list va;
@@ -122,84 +126,95 @@ pkgconf_buffer_append_vfmt(pkgconf_buffer_t *buffer, const char *fmt, va_list sr
 	va_end(va);
 
 	buf = malloc(needed);
+	if (buf == NULL)
+		return false;
 
 	va_copy(va, src_va);
 	vsnprintf(buf, needed, fmt, va);
 	va_end(va);
 
-	pkgconf_buffer_append(buffer, buf);
+	bool ret = pkgconf_buffer_append(buffer, buf);
 
 	free(buf);
+
+	return ret;
 }
 
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_buffer_append_fmt(pkgconf_buffer_t *buffer, const char *fmt, ...)
+ * .. c:function:: bool pkgconf_buffer_append_fmt(pkgconf_buffer_t *buffer, const char *fmt, ...)
  *
  *    Append a formatted string to the buffer using variadic arguments.
  *
  *    :param pkgconf_buffer_t *buffer: The buffer to append to.
  *    :param char *fmt: A printf-style format string.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_buffer_append_fmt(pkgconf_buffer_t *buffer, const char *fmt, ...)
 {
 	va_list va;
 
 	va_start(va, fmt);
-	pkgconf_buffer_append_vfmt(buffer, fmt, va);
+	bool ret = pkgconf_buffer_append_vfmt(buffer, fmt, va);
 	va_end(va);
+
+	return ret;
 }
 
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_buffer_prepend(pkgconf_buffer_t *buffer, const char *text)
+ * .. c:function:: bool pkgconf_buffer_prepend(pkgconf_buffer_t *buffer, const char *text)
  *
  *    Prepend a null-terminated string to the beginning of the buffer.
  *    If *text* is NULL, the buffer contents are unchanged.
  *
  *    :param pkgconf_buffer_t *buffer: The buffer to prepend to.
  *    :param char *text: The null-terminated string to prepend, or NULL.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_buffer_prepend(pkgconf_buffer_t *buffer, const char *text)
 {
 	pkgconf_buffer_t tmpbuf = PKGCONF_BUFFER_INITIALIZER;
 
-	if (text != NULL)
-		pkgconf_buffer_append(&tmpbuf, text);
-	pkgconf_buffer_append(&tmpbuf, pkgconf_buffer_str_or_empty(buffer));
+	if (text != NULL && !pkgconf_buffer_append(&tmpbuf, text))
+		return false;
+
+	if (!pkgconf_buffer_append(&tmpbuf, pkgconf_buffer_str_or_empty(buffer)))
+	{
+		pkgconf_buffer_finalize(&tmpbuf);
+		return false;
+	}
 
 	if (pkgconf_buffer_len(&tmpbuf))
 		pkgconf_buffer_copy(&tmpbuf, buffer);
 
 	pkgconf_buffer_finalize(&tmpbuf);
+
+	return true;
 }
 
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_buffer_push_byte(pkgconf_buffer_t *buffer, char byte)
+ * .. c:function:: bool pkgconf_buffer_push_byte(pkgconf_buffer_t *buffer, char byte)
  *
  *    Append a single byte to the buffer, reallocating as necessary.
  *
  *    :param pkgconf_buffer_t *buffer: The buffer to append to.
  *    :param char byte: The byte to append.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_buffer_push_byte(pkgconf_buffer_t *buffer, char byte)
 {
 	size_t newsize = pkgconf_buffer_len(buffer) + 1;
 	char *newbase = realloc(buffer->base, target_allocation_size(newsize));
-
-	/* XXX: silently failing here remains antisocial */
 	if (newbase == NULL)
-		return;
+		return false;
 
 	char *newend = newbase + newsize;
 	*(newend - 1) = byte;
@@ -207,27 +222,34 @@ pkgconf_buffer_push_byte(pkgconf_buffer_t *buffer, char byte)
 
 	buffer->base = newbase;
 	buffer->end = newend;
+
+	return true;
 }
 
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_buffer_trim_byte(pkgconf_buffer_t *buffer)
+ * .. c:function:: bool pkgconf_buffer_trim_byte(pkgconf_buffer_t *buffer)
  *
  *    Remove the last byte from the buffer. The buffer must be non-empty.
  *
  *    :param pkgconf_buffer_t *buffer: The buffer to trim.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_buffer_trim_byte(pkgconf_buffer_t *buffer)
 {
 	size_t newsize = pkgconf_buffer_len(buffer) - 1;
 	char *newbase = realloc(buffer->base, target_allocation_size(newsize));
 
+	if (newbase == NULL)
+		return false;
+
 	buffer->base = newbase;
 	buffer->end = newbase + newsize;
 	*(buffer->end) = '\0';
+
+	return true;
 }
 
 /*
@@ -250,28 +272,35 @@ pkgconf_buffer_finalize(pkgconf_buffer_t *buffer)
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_buffer_fputs(pkgconf_buffer_t *buffer, FILE *out)
+ * .. c:function:: bool pkgconf_buffer_fputs(pkgconf_buffer_t *buffer, FILE *out)
  *
  *    Write the buffer contents followed by a newline to a file stream.
  *    If the buffer is empty, only a newline is written.
  *
  *    :param pkgconf_buffer_t *buffer: The buffer to write.
  *    :param FILE *out: The output file stream.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on I/O error.
+ *             :code:`errno` will be set by fputs/fputc.
  */
-void
+bool
 pkgconf_buffer_fputs(pkgconf_buffer_t *buffer, FILE *out)
 {
 	if (pkgconf_buffer_len(buffer) != 0)
-		fputs(pkgconf_buffer_str(buffer), out);
+	{
+		if (fputs(pkgconf_buffer_str(buffer), out) == EOF)
+			return false;
+	}
 
-	fputc('\n', out);
+	if (fputc('\n', out) == EOF)
+		return false;
+
+	return true;
 }
 
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_buffer_vjoin(pkgconf_buffer_t *buffer, char delim, va_list src_va)
+ * .. c:function:: bool pkgconf_buffer_vjoin(pkgconf_buffer_t *buffer, char delim, va_list src_va)
  *
  *    Join a NULL-terminated list of strings into the buffer, separated by *delim*.
  *    Uses a :code:`va_list` for the string arguments.
@@ -279,9 +308,9 @@ pkgconf_buffer_fputs(pkgconf_buffer_t *buffer, FILE *out)
  *    :param pkgconf_buffer_t *buffer: The buffer to join into.
  *    :param char delim: The delimiter byte inserted between each argument.
  *    :param va_list src_va: The variadic argument list of :code:`const char *` strings, terminated by NULL.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_buffer_vjoin(pkgconf_buffer_t *buffer, char delim, va_list src_va)
 {
 	va_list va;
@@ -292,34 +321,48 @@ pkgconf_buffer_vjoin(pkgconf_buffer_t *buffer, char delim, va_list src_va)
 	while ((arg = va_arg(va, const char *)) != NULL)
 	{
 		if (pkgconf_buffer_str(buffer) != NULL)
-			pkgconf_buffer_push_byte(buffer, delim);
+		{
+			if (!pkgconf_buffer_push_byte(buffer, delim))
+			{
+				va_end(va);
+				return false;
+			}
+		}
 
-		pkgconf_buffer_append(buffer, arg);
+		if (!pkgconf_buffer_append(buffer, arg))
+		{
+			va_end(va);
+			return false;
+		}
 	}
 
 	va_end(va);
+
+	return true;
 }
 
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_buffer_join(pkgconf_buffer_t *buffer, int delim, ...)
+ * .. c:function:: bool pkgconf_buffer_join(pkgconf_buffer_t *buffer, int delim, ...)
  *
  *    Join a NULL-terminated list of strings into the buffer, separated by *delim*.
  *    The *delim* parameter is typed as :code:`int` due to C variadic promotion rules.
  *
  *    :param pkgconf_buffer_t *buffer: The buffer to join into.
  *    :param int delim: The delimiter byte inserted between each argument (cast to :code:`char` internally).
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_buffer_join(pkgconf_buffer_t *buffer, int delim, ...)
 {
 	va_list va;
 
 	va_start(va, delim);
-	pkgconf_buffer_vjoin(buffer, (char)delim, va);
+	bool ret = pkgconf_buffer_vjoin(buffer, (char)delim, va);
 	va_end(va);
+
+	return ret;
 }
 
 /*
@@ -407,7 +450,7 @@ pkgconf_buffer_match(const pkgconf_buffer_t *haystack, const pkgconf_buffer_t *n
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_buffer_subst(pkgconf_buffer_t *dest, const pkgconf_buffer_t *src, const char *pattern, const char *value)
+ * .. c:function:: bool pkgconf_buffer_subst(pkgconf_buffer_t *dest, const pkgconf_buffer_t *src, const char *pattern, const char *value)
  *
  *    Copy *src* into *dest*, replacing all occurrences of *pattern* with *value*.
  *    If *pattern* is empty, *src* is appended to *dest* unmodified.
@@ -416,39 +459,43 @@ pkgconf_buffer_match(const pkgconf_buffer_t *haystack, const pkgconf_buffer_t *n
  *    :param pkgconf_buffer_t *src: The source buffer.
  *    :param char *pattern: The pattern string to search for.
  *    :param char *value: The replacement string.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_buffer_subst(pkgconf_buffer_t *dest, const pkgconf_buffer_t *src, const char *pattern, const char *value)
 {
 	const char *iter = src->base;
 	size_t pattern_len = strlen(pattern);
 
 	if (!pkgconf_buffer_len(src))
-		return;
+		return true;
 
 	if (!pattern_len)
-	{
-		pkgconf_buffer_append(dest, pkgconf_buffer_str(src));
-		return;
-	}
+		return pkgconf_buffer_append(dest, pkgconf_buffer_str(src));
 
 	while (iter < src->end)
 	{
 		if ((size_t)(src->end - iter) >= pattern_len && !memcmp(iter, pattern, pattern_len))
 		{
-			pkgconf_buffer_append(dest, value);
+			if (!pkgconf_buffer_append(dest, value))
+				return false;
+
 			iter += pattern_len;
 		}
 		else
-			pkgconf_buffer_push_byte(dest, *iter++);
+		{
+			if (!pkgconf_buffer_push_byte(dest, *iter++))
+				return false;
+		}
 	}
+
+	return true;
 }
 
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_buffer_escape(pkgconf_buffer_t *dest, const pkgconf_buffer_t *src, const pkgconf_span_t *spans, size_t nspans)
+ * .. c:function:: bool pkgconf_buffer_escape(pkgconf_buffer_t *dest, const pkgconf_buffer_t *src, const pkgconf_span_t *spans, size_t nspans)
  *
  *    Copy *src* into *dest*, inserting a backslash before any byte that falls
  *    within the provided character spans.
@@ -457,21 +504,27 @@ pkgconf_buffer_subst(pkgconf_buffer_t *dest, const pkgconf_buffer_t *src, const 
  *    :param pkgconf_buffer_t *src: The source buffer.
  *    :param pkgconf_span_t *spans: Array of character spans to escape.
  *    :param size_t nspans: Number of entries in the *spans* array.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_buffer_escape(pkgconf_buffer_t *dest, const pkgconf_buffer_t *src, const pkgconf_span_t *spans, size_t nspans)
 {
 	const char *p = pkgconf_buffer_str(src);
 
 	if (!pkgconf_buffer_len(src))
-		return;
+		return true;
 
 	for (; *p; p++)
 	{
 		if (pkgconf_span_contains((unsigned char) *p, spans, nspans))
-			pkgconf_buffer_push_byte(dest, '\\');
+		{
+			if (!pkgconf_buffer_push_byte(dest, '\\'))
+				return false;
+		}
 
-		pkgconf_buffer_push_byte(dest, *p);
+		if (!pkgconf_buffer_push_byte(dest, *p))
+			return false;
 	}
+
+	return true;
 }

--- a/libpkgconf/buffer.c
+++ b/libpkgconf/buffer.c
@@ -44,6 +44,17 @@ buffer_debug(pkgconf_buffer_t *buffer)
 }
 #endif
 
+/*
+ * !doc
+ *
+ * .. c:function:: void pkgconf_buffer_append(pkgconf_buffer_t *buffer, const char *text)
+ *
+ *    Append a null-terminated string to the buffer, reallocating as necessary.
+ *
+ *    :param pkgconf_buffer_t *buffer: The buffer to append to.
+ *    :param char *text: The null-terminated string to append.
+ *    :return: nothing
+ */
 void
 pkgconf_buffer_append(pkgconf_buffer_t *buffer, const char *text)
 {
@@ -65,6 +76,18 @@ pkgconf_buffer_append(pkgconf_buffer_t *buffer, const char *text)
 	*buffer->end = '\0';
 }
 
+/*
+ * !doc
+ *
+ * .. c:function:: void pkgconf_buffer_append_slice(pkgconf_buffer_t *buf, const char *p, size_t n)
+ *
+ *    Append a slice of *n* bytes to the buffer. Does nothing if *n* is zero.
+ *
+ *    :param pkgconf_buffer_t *buf: The buffer to append to.
+ *    :param char *p: Pointer to the byte sequence to append.
+ *    :param size_t n: Number of bytes to append.
+ *    :return: nothing
+ */
 void
 pkgconf_buffer_append_slice(pkgconf_buffer_t *buf, const char *p, size_t n)
 {
@@ -75,6 +98,18 @@ pkgconf_buffer_append_slice(pkgconf_buffer_t *buf, const char *p, size_t n)
 		pkgconf_buffer_push_byte(buf, p[i]);
 }
 
+/*
+ * !doc
+ *
+ * .. c:function:: void pkgconf_buffer_append_vfmt(pkgconf_buffer_t *buffer, const char *fmt, va_list src_va)
+ *
+ *    Append a formatted string to the buffer using a :code:`va_list`.
+ *
+ *    :param pkgconf_buffer_t *buffer: The buffer to append to.
+ *    :param char *fmt: A printf-style format string.
+ *    :param va_list src_va: The variadic argument list for the format string.
+ *    :return: nothing
+ */
 void
 pkgconf_buffer_append_vfmt(pkgconf_buffer_t *buffer, const char *fmt, va_list src_va)
 {
@@ -97,6 +132,17 @@ pkgconf_buffer_append_vfmt(pkgconf_buffer_t *buffer, const char *fmt, va_list sr
 	free(buf);
 }
 
+/*
+ * !doc
+ *
+ * .. c:function:: void pkgconf_buffer_append_fmt(pkgconf_buffer_t *buffer, const char *fmt, ...)
+ *
+ *    Append a formatted string to the buffer using variadic arguments.
+ *
+ *    :param pkgconf_buffer_t *buffer: The buffer to append to.
+ *    :param char *fmt: A printf-style format string.
+ *    :return: nothing
+ */
 void
 pkgconf_buffer_append_fmt(pkgconf_buffer_t *buffer, const char *fmt, ...)
 {
@@ -107,6 +153,18 @@ pkgconf_buffer_append_fmt(pkgconf_buffer_t *buffer, const char *fmt, ...)
 	va_end(va);
 }
 
+/*
+ * !doc
+ *
+ * .. c:function:: void pkgconf_buffer_prepend(pkgconf_buffer_t *buffer, const char *text)
+ *
+ *    Prepend a null-terminated string to the beginning of the buffer.
+ *    If *text* is NULL, the buffer contents are unchanged.
+ *
+ *    :param pkgconf_buffer_t *buffer: The buffer to prepend to.
+ *    :param char *text: The null-terminated string to prepend, or NULL.
+ *    :return: nothing
+ */
 void
 pkgconf_buffer_prepend(pkgconf_buffer_t *buffer, const char *text)
 {
@@ -122,6 +180,17 @@ pkgconf_buffer_prepend(pkgconf_buffer_t *buffer, const char *text)
 	pkgconf_buffer_finalize(&tmpbuf);
 }
 
+/*
+ * !doc
+ *
+ * .. c:function:: void pkgconf_buffer_push_byte(pkgconf_buffer_t *buffer, char byte)
+ *
+ *    Append a single byte to the buffer, reallocating as necessary.
+ *
+ *    :param pkgconf_buffer_t *buffer: The buffer to append to.
+ *    :param char byte: The byte to append.
+ *    :return: nothing
+ */
 void
 pkgconf_buffer_push_byte(pkgconf_buffer_t *buffer, char byte)
 {
@@ -140,6 +209,16 @@ pkgconf_buffer_push_byte(pkgconf_buffer_t *buffer, char byte)
 	buffer->end = newend;
 }
 
+/*
+ * !doc
+ *
+ * .. c:function:: void pkgconf_buffer_trim_byte(pkgconf_buffer_t *buffer)
+ *
+ *    Remove the last byte from the buffer. The buffer must be non-empty.
+ *
+ *    :param pkgconf_buffer_t *buffer: The buffer to trim.
+ *    :return: nothing
+ */
 void
 pkgconf_buffer_trim_byte(pkgconf_buffer_t *buffer)
 {
@@ -151,6 +230,16 @@ pkgconf_buffer_trim_byte(pkgconf_buffer_t *buffer)
 	*(buffer->end) = '\0';
 }
 
+/*
+ * !doc
+ *
+ * .. c:function:: void pkgconf_buffer_finalize(pkgconf_buffer_t *buffer)
+ *
+ *    Free all memory owned by the buffer and reset it to an empty state.
+ *
+ *    :param pkgconf_buffer_t *buffer: The buffer to finalize.
+ *    :return: nothing
+ */
 void
 pkgconf_buffer_finalize(pkgconf_buffer_t *buffer)
 {
@@ -158,6 +247,18 @@ pkgconf_buffer_finalize(pkgconf_buffer_t *buffer)
 	buffer->base = buffer->end = NULL;
 }
 
+/*
+ * !doc
+ *
+ * .. c:function:: void pkgconf_buffer_fputs(pkgconf_buffer_t *buffer, FILE *out)
+ *
+ *    Write the buffer contents followed by a newline to a file stream.
+ *    If the buffer is empty, only a newline is written.
+ *
+ *    :param pkgconf_buffer_t *buffer: The buffer to write.
+ *    :param FILE *out: The output file stream.
+ *    :return: nothing
+ */
 void
 pkgconf_buffer_fputs(pkgconf_buffer_t *buffer, FILE *out)
 {
@@ -167,6 +268,19 @@ pkgconf_buffer_fputs(pkgconf_buffer_t *buffer, FILE *out)
 	fputc('\n', out);
 }
 
+/*
+ * !doc
+ *
+ * .. c:function:: void pkgconf_buffer_vjoin(pkgconf_buffer_t *buffer, char delim, va_list src_va)
+ *
+ *    Join a NULL-terminated list of strings into the buffer, separated by *delim*.
+ *    Uses a :code:`va_list` for the string arguments.
+ *
+ *    :param pkgconf_buffer_t *buffer: The buffer to join into.
+ *    :param char delim: The delimiter byte inserted between each argument.
+ *    :param va_list src_va: The variadic argument list of :code:`const char *` strings, terminated by NULL.
+ *    :return: nothing
+ */
 void
 pkgconf_buffer_vjoin(pkgconf_buffer_t *buffer, char delim, va_list src_va)
 {
@@ -186,8 +300,18 @@ pkgconf_buffer_vjoin(pkgconf_buffer_t *buffer, char delim, va_list src_va)
 	va_end(va);
 }
 
-// NOTE: due to C's rules regarding promotion in variable args and permissible variables, delim must
-// be an int here.
+/*
+ * !doc
+ *
+ * .. c:function:: void pkgconf_buffer_join(pkgconf_buffer_t *buffer, int delim, ...)
+ *
+ *    Join a NULL-terminated list of strings into the buffer, separated by *delim*.
+ *    The *delim* parameter is typed as :code:`int` due to C variadic promotion rules.
+ *
+ *    :param pkgconf_buffer_t *buffer: The buffer to join into.
+ *    :param int delim: The delimiter byte inserted between each argument (cast to :code:`char` internally).
+ *    :return: nothing
+ */
 void
 pkgconf_buffer_join(pkgconf_buffer_t *buffer, int delim, ...)
 {
@@ -198,6 +322,17 @@ pkgconf_buffer_join(pkgconf_buffer_t *buffer, int delim, ...)
 	va_end(va);
 }
 
+/*
+ * !doc
+ *
+ * .. c:function:: bool pkgconf_buffer_has_prefix(const pkgconf_buffer_t *haystack, const pkgconf_buffer_t *prefix)
+ *
+ *    Test whether the buffer begins with the contents of *prefix*.
+ *
+ *    :param pkgconf_buffer_t *haystack: The buffer to search in.
+ *    :param pkgconf_buffer_t *prefix: The prefix to test for.
+ *    :return: :code:`true` if *haystack* starts with *prefix*, :code:`false` otherwise.
+ */
 bool
 pkgconf_buffer_has_prefix(const pkgconf_buffer_t *haystack, const pkgconf_buffer_t *prefix)
 {
@@ -207,6 +342,17 @@ pkgconf_buffer_has_prefix(const pkgconf_buffer_t *haystack, const pkgconf_buffer
 	return strncmp(haystack_str, prefix_str, strlen(prefix_str)) == 0;
 }
 
+/*
+ * !doc
+ *
+ * .. c:function:: bool pkgconf_buffer_contains(const pkgconf_buffer_t *haystack, const pkgconf_buffer_t *needle)
+ *
+ *    Test whether the buffer contains the contents of *needle* as a substring.
+ *
+ *    :param pkgconf_buffer_t *haystack: The buffer to search in.
+ *    :param pkgconf_buffer_t *needle: The substring to search for.
+ *    :return: :code:`true` if *needle* is found, :code:`false` otherwise.
+ */
 bool
 pkgconf_buffer_contains(const pkgconf_buffer_t *haystack, const pkgconf_buffer_t *needle)
 {
@@ -216,6 +362,18 @@ pkgconf_buffer_contains(const pkgconf_buffer_t *haystack, const pkgconf_buffer_t
 	return strstr(haystack_str, needle_str) != NULL;
 }
 
+/*
+ * !doc
+ *
+ * .. c:function:: bool pkgconf_buffer_contains_byte(const pkgconf_buffer_t *haystack, char needle)
+ *
+ *    Test whether the buffer contains a given byte.
+ *
+ *    :param pkgconf_buffer_t *haystack: The buffer to search in.
+ *    :param char needle: The byte to search for.
+ *    :return: :code:`true` if *needle* is found, :code:`false` otherwise.
+ */
+
 bool
 pkgconf_buffer_contains_byte(const pkgconf_buffer_t *haystack, char needle)
 {
@@ -223,6 +381,17 @@ pkgconf_buffer_contains_byte(const pkgconf_buffer_t *haystack, char needle)
 	return strchr(haystack_str, needle) != NULL;
 }
 
+/*
+ * !doc
+ *
+ * .. c:function:: bool pkgconf_buffer_match(const pkgconf_buffer_t *haystack, const pkgconf_buffer_t *needle)
+ *
+ *    Test whether two buffers have identical contents.
+ *
+ *    :param pkgconf_buffer_t *haystack: The first buffer.
+ *    :param pkgconf_buffer_t *needle: The second buffer.
+ *    :return: :code:`true` if the buffers have the same length and contents, :code:`false` otherwise.
+ */
 bool
 pkgconf_buffer_match(const pkgconf_buffer_t *haystack, const pkgconf_buffer_t *needle)
 {
@@ -235,6 +404,20 @@ pkgconf_buffer_match(const pkgconf_buffer_t *haystack, const pkgconf_buffer_t *n
 	return memcmp(haystack_str, needle_str, pkgconf_buffer_len(haystack)) == 0;
 }
 
+/*
+ * !doc
+ *
+ * .. c:function:: void pkgconf_buffer_subst(pkgconf_buffer_t *dest, const pkgconf_buffer_t *src, const char *pattern, const char *value)
+ *
+ *    Copy *src* into *dest*, replacing all occurrences of *pattern* with *value*.
+ *    If *pattern* is empty, *src* is appended to *dest* unmodified.
+ *
+ *    :param pkgconf_buffer_t *dest: The destination buffer.
+ *    :param pkgconf_buffer_t *src: The source buffer.
+ *    :param char *pattern: The pattern string to search for.
+ *    :param char *value: The replacement string.
+ *    :return: nothing
+ */
 void
 pkgconf_buffer_subst(pkgconf_buffer_t *dest, const pkgconf_buffer_t *src, const char *pattern, const char *value)
 {
@@ -262,6 +445,20 @@ pkgconf_buffer_subst(pkgconf_buffer_t *dest, const pkgconf_buffer_t *src, const 
 	}
 }
 
+/*
+ * !doc
+ *
+ * .. c:function:: void pkgconf_buffer_escape(pkgconf_buffer_t *dest, const pkgconf_buffer_t *src, const pkgconf_span_t *spans, size_t nspans)
+ *
+ *    Copy *src* into *dest*, inserting a backslash before any byte that falls
+ *    within the provided character spans.
+ *
+ *    :param pkgconf_buffer_t *dest: The destination buffer.
+ *    :param pkgconf_buffer_t *src: The source buffer.
+ *    :param pkgconf_span_t *spans: Array of character spans to escape.
+ *    :param size_t nspans: Number of entries in the *spans* array.
+ *    :return: nothing
+ */
 void
 pkgconf_buffer_escape(pkgconf_buffer_t *dest, const pkgconf_buffer_t *src, const pkgconf_span_t *spans, size_t nspans)
 {

--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -585,23 +585,23 @@ static inline bool pkgconf_span_contains(unsigned char c, const pkgconf_span_t *
 	return false;
 }
 
-PKGCONF_API void pkgconf_buffer_append(pkgconf_buffer_t *buffer, const char *text);
-PKGCONF_API void pkgconf_buffer_append_slice(pkgconf_buffer_t *buf, const char *p, size_t n);
-PKGCONF_API void pkgconf_buffer_append_fmt(pkgconf_buffer_t *buffer, const char *fmt, ...) PRINTFLIKE(2, 3);
-PKGCONF_API void pkgconf_buffer_append_vfmt(pkgconf_buffer_t *buffer, const char *fmt, va_list va) PRINTFLIKE(2, 0);
-PKGCONF_API void pkgconf_buffer_prepend(pkgconf_buffer_t *buffer, const char *text);
-PKGCONF_API void pkgconf_buffer_push_byte(pkgconf_buffer_t *buffer, char byte);
-PKGCONF_API void pkgconf_buffer_trim_byte(pkgconf_buffer_t *buffer);
+PKGCONF_API bool pkgconf_buffer_append(pkgconf_buffer_t *buffer, const char *text);
+PKGCONF_API bool pkgconf_buffer_append_slice(pkgconf_buffer_t *buf, const char *p, size_t n);
+PKGCONF_API bool pkgconf_buffer_append_fmt(pkgconf_buffer_t *buffer, const char *fmt, ...) PRINTFLIKE(2, 3);
+PKGCONF_API bool pkgconf_buffer_append_vfmt(pkgconf_buffer_t *buffer, const char *fmt, va_list va) PRINTFLIKE(2, 0);
+PKGCONF_API bool pkgconf_buffer_prepend(pkgconf_buffer_t *buffer, const char *text);
+PKGCONF_API bool pkgconf_buffer_push_byte(pkgconf_buffer_t *buffer, char byte);
+PKGCONF_API bool pkgconf_buffer_trim_byte(pkgconf_buffer_t *buffer);
 PKGCONF_API void pkgconf_buffer_finalize(pkgconf_buffer_t *buffer);
-PKGCONF_API void pkgconf_buffer_fputs(pkgconf_buffer_t *buffer, FILE *out);
-PKGCONF_API void pkgconf_buffer_vjoin(pkgconf_buffer_t *buffer, char delim, va_list va);
-PKGCONF_API void pkgconf_buffer_join(pkgconf_buffer_t *buffer, int delim, ...);
+PKGCONF_API bool pkgconf_buffer_fputs(pkgconf_buffer_t *buffer, FILE *out);
+PKGCONF_API bool pkgconf_buffer_vjoin(pkgconf_buffer_t *buffer, char delim, va_list va);
+PKGCONF_API bool pkgconf_buffer_join(pkgconf_buffer_t *buffer, int delim, ...);
 PKGCONF_API bool pkgconf_buffer_has_prefix(const pkgconf_buffer_t *haystack, const pkgconf_buffer_t *prefix);
 PKGCONF_API bool pkgconf_buffer_contains(const pkgconf_buffer_t *haystack, const pkgconf_buffer_t *needle);
 PKGCONF_API bool pkgconf_buffer_contains_byte(const pkgconf_buffer_t *haystack, char needle);
 PKGCONF_API bool pkgconf_buffer_match(const pkgconf_buffer_t *haystack, const pkgconf_buffer_t *needle);
-PKGCONF_API void pkgconf_buffer_subst(pkgconf_buffer_t *dest, const pkgconf_buffer_t *src, const char *pattern, const char *value);
-PKGCONF_API void pkgconf_buffer_escape(pkgconf_buffer_t *dest, const pkgconf_buffer_t *src, const pkgconf_span_t *spans, size_t nspans);
+PKGCONF_API bool pkgconf_buffer_subst(pkgconf_buffer_t *dest, const pkgconf_buffer_t *src, const char *pattern, const char *value);
+PKGCONF_API bool pkgconf_buffer_escape(pkgconf_buffer_t *dest, const pkgconf_buffer_t *src, const pkgconf_span_t *spans, size_t nspans);
 static inline const char *pkgconf_buffer_str(const pkgconf_buffer_t *buffer) {
 	return buffer->base;
 }


### PR DESCRIPTION
This PR documents the buffer API and returns errors when the buffer API fails.

No functional changes except for additional bounds checks are intended by this pull request.

No functions are updated yet to use the new API changes; this can be performed incrementally. The API changes are all backwards-compatible; only the return types of some buffer functions are changed from `void` to `bool`.