### PR TITLE
personality: fix improper comparison for personality booleans

### DIFF
--- a/libpkgconf/personality.c
+++ b/libpkgconf/personality.c
@@ -177,7 +177,7 @@ personality_bool_func(pkgconf_cross_personality_t *p, const char *keyword, const
 	(void) warnprefix;
 
 	bool *dest = (bool *)((char *) p + offset);
-	*dest = strcasecmp(value, "true") || strcasecmp(value, "yes") || *value == '1';
+	*dest = strcasecmp(value, "true") == 0 || strcasecmp(value, "yes") == 0 || *value == '1';
 }
 
 static void


### PR DESCRIPTION
`strcasecmp` returns `0` on match, so the personality boolean check was incorrect. This PR fixes it.