### PR TITLE
Check buffer API for failure and return errors on failure

### DIFF
--- a/cli/bomtool/main.c
+++ b/cli/bomtool/main.c
@@ -67,7 +67,8 @@ sbom_name(pkgconf_pkg_t *world)
 	pkgconf_buffer_t name = PKGCONF_BUFFER_INITIALIZER;
 	pkgconf_node_t *node;
 
-	pkgconf_buffer_append(&name, "SBOM-SPDX");
+	if (!pkgconf_buffer_append(&name, "SBOM-SPDX"))
+		return NULL;
 
 	PKGCONF_FOREACH_LIST_ENTRY(world->required.head, node)
 	{
@@ -83,7 +84,8 @@ sbom_name(pkgconf_pkg_t *world)
 		if (!dep->match)
 			continue;
 
-		pkgconf_buffer_append_fmt(&name, "-%s", sbom_spdx_identity(match));
+		if (!pkgconf_buffer_append_fmt(&name, "-%s", sbom_spdx_identity(match)))
+			return NULL;
 	}
 
 	return pkgconf_buffer_freeze(&name);
@@ -440,7 +442,11 @@ main(int argc, char *argv[])
 
 		if (argv[pkg_optind + 1] == NULL || !PKGCONF_IS_OPERATOR_CHAR(*(argv[pkg_optind + 1])))
 		{
-			pkgconf_queue_push(&pkgq, package);
+			if (!pkgconf_queue_push(&pkgq, package))
+			{
+				ret = EXIT_FAILURE;
+				goto out;
+			}
 			pkg_optind++;
 		}
 		else
@@ -450,7 +456,11 @@ main(int argc, char *argv[])
 			snprintf(packagebuf, sizeof packagebuf, "%s %s %s", package, argv[pkg_optind + 1], argv[pkg_optind + 2]);
 			pkg_optind += 3;
 
-			pkgconf_queue_push(&pkgq, packagebuf);
+			if (!pkgconf_queue_push(&pkgq, packagebuf))
+			{
+				ret = EXIT_FAILURE;
+				goto out;
+			}
 		}
 	}
 

--- a/cli/bomtool/main.c
+++ b/cli/bomtool/main.c
@@ -48,8 +48,7 @@ error_handler(const char *msg, const pkgconf_client_t *client, void *data)
 {
 	(void) client;
 	(void) data;
-	fprintf(error_msgout, "%s", msg);
-	return true;
+	return fprintf(error_msgout, "%s", msg) >= 0;
 }
 
 static const char *
@@ -73,6 +72,9 @@ sbom_name(pkgconf_pkg_t *world)
 	PKGCONF_FOREACH_LIST_ENTRY(world->required.head, node)
 	{
 		pkgconf_dependency_t *dep = node->data;
+		if (!dep)
+			return NULL;
+
 		pkgconf_pkg_t *match = dep->match;
 
 		if ((dep->flags & PKGCONF_PKG_DEPF_QUERY) != PKGCONF_PKG_DEPF_QUERY)
@@ -87,22 +89,24 @@ sbom_name(pkgconf_pkg_t *world)
 	return pkgconf_buffer_freeze(&name);
 }
 
-static void
+static bool
 write_sbom_header(pkgconf_client_t *client, pkgconf_pkg_t *world)
 {
 	(void) client;
 	char *docname = sbom_name(world);
+	if (!docname)
+		return false;
 
-	fprintf(sbom_out, "SPDXVersion: %s\n", spdx_version);
-	fprintf(sbom_out, "DataLicense: %s\n", bom_license);
-	fprintf(sbom_out, "SPDXID: %s\n", document_ref);
-	fprintf(sbom_out, "DocumentName: %s\n", docname);
-	fprintf(sbom_out, "DocumentNamespace: https://spdx.org/spdxdocs/bomtool-%s\n", PACKAGE_VERSION);
-	fprintf(sbom_out, "Creator: Tool: bomtool %s\n", PACKAGE_VERSION);
-
-	fprintf(sbom_out, "\n\n");
+	bool ok = fprintf(sbom_out, "SPDXVersion: %s\n", spdx_version) > 0
+		&& fprintf(sbom_out, "DataLicense: %s\n", bom_license) > 0
+		&& fprintf(sbom_out, "SPDXID: %s\n", document_ref) > 0
+		&& fprintf(sbom_out, "DocumentName: %s\n", docname) > 0
+		&& fprintf(sbom_out, "DocumentNamespace: https://spdx.org/spdxdocs/bomtool-%s\n", PACKAGE_VERSION) > 0
+		&& fprintf(sbom_out, "Creator: Tool: bomtool %s\n", PACKAGE_VERSION) > 0
+		&& fprintf(sbom_out, "\n\n") > 0;
 
 	free(docname);
+	return ok;
 }
 
 static const char *
@@ -115,26 +119,28 @@ sbom_identity(pkgconf_pkg_t *pkg)
 	return buf;
 }
 
-static void
+static bool
 write_copyright_lines(const pkgconf_list_t *copyright_lines)
 {
 	const pkgconf_node_t *node;
 
 	if (copyright_lines->head == NULL)
-		return;
+		return true;
 
-	fprintf(sbom_out, "PackageCopyrightText: <text>");
+	if (fprintf(sbom_out, "PackageCopyrightText: <text>") <= 0)
+		return false;
 
 	PKGCONF_FOREACH_LIST_ENTRY(copyright_lines->head, node)
 	{
 		const pkgconf_bufferset_t *set = node->data;
-		fprintf(sbom_out, "%s%s", pkgconf_buffer_str_or_empty(&set->buffer), node->prev != NULL ? "\n" : "");
+		if (fprintf(sbom_out, "%s%s", pkgconf_buffer_str_or_empty(&set->buffer), node->prev != NULL ? "\n" : "") <= 0)
+			return false;
 	}
 
-	fprintf(sbom_out, "</text>\n");
+	return fprintf(sbom_out, "</text>\n") > 0;
 }
 
-static void
+static bool
 write_sbom_package(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *unused)
 {
 	pkgconf_buffer_t license_buf = PKGCONF_BUFFER_INITIALIZER;
@@ -142,49 +148,70 @@ write_sbom_package(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *unused)
 	(void) unused;
 
 	if (pkg->flags & PKGCONF_PKG_PROPF_VIRTUAL)
-		return;
+		return true;
 
-	fprintf(sbom_out, "##### Package: %s\n\n", sbom_identity(pkg));
-
-	fprintf(sbom_out, "PackageName: %s\n", pkg->id);
-	fprintf(sbom_out, "SPDXID: SPDXRef-Package-%s\n", sbom_spdx_identity(pkg));
-	fprintf(sbom_out, "PackageVersion: %s\n", pkg->version);
-	fprintf(sbom_out, "PackageVerificationCode: NOASSERTION\n");
+	if (fprintf(sbom_out, "##### Package: %s\n\n", sbom_identity(pkg)) <= 0
+		|| fprintf(sbom_out, "PackageName: %s\n", pkg->id) <= 0
+		|| fprintf(sbom_out, "SPDXID: SPDXRef-Package-%s\n", sbom_spdx_identity(pkg)) <= 0
+		|| fprintf(sbom_out, "PackageVersion: %s\n", pkg->version) <= 0
+		|| fprintf(sbom_out, "PackageVerificationCode: NOASSERTION\n") <= 0)
+	{
+		return false;
+	}
 
 	/* XXX: What about projects? */
 	if (pkg->maintainer != NULL)
-		fprintf(sbom_out, "PackageSupplier: Person: %s\n", pkg->maintainer);
+	{
+		if (fprintf(sbom_out, "PackageSupplier: Person: %s\n", pkg->maintainer) <= 0)
+			return false;
+	}
 
 	if (pkg->url != NULL)
-		fprintf(sbom_out, "PackageHomePage: %s\n", pkg->url);
+	{
+		if (fprintf(sbom_out, "PackageHomePage: %s\n", pkg->url) <= 0)
+			return false;
+	}
 
 	if (pkg->license.head != NULL)
 	{
-		pkgconf_license_render(client, &pkg->license, &license_buf);
-		fprintf(sbom_out, "PackageLicenseDeclared: %s\n", pkgconf_buffer_str_or_empty(&license_buf));
+		bool ok = pkgconf_license_render(client, &pkg->license, &license_buf)
+			&& fprintf(sbom_out, "PackageLicenseDeclared: %s\n", pkgconf_buffer_str_or_empty(&license_buf)) > 0;
+
 		pkgconf_buffer_finalize(&license_buf);
+
+		if (!ok)
+			return false;
 	}
 	else
 	{
-		fprintf(sbom_out, "PackageLicenseDeclared: NOASSERTION\n");
+		if (fprintf(sbom_out, "PackageLicenseDeclared: NOASSERTION\n") <= 0)
+			return false;
 	}
 
-
-	write_copyright_lines(&pkg->copyright);
+	if (!write_copyright_lines(&pkg->copyright))
+		return false;
 
 	if (pkg->description != NULL)
-		fprintf(sbom_out, "PackageSummary: <text>%s</text>\n", pkg->description);
+	{
+		if (fprintf(sbom_out, "PackageSummary: <text>%s</text>\n", pkg->description) <= 0)
+			return false;
+	}
 
 	if (pkg->source != NULL)
-		fprintf(sbom_out, "PackageDownloadLocation: %s\n", pkg->source);
+	{
+		if (fprintf(sbom_out, "PackageDownloadLocation: %s\n", pkg->source) <= 0)
+			return false;
+	}
 	else
-		fprintf(sbom_out, "PackageDownloadLocation: NOASSERTION\n");
+	{
+		if (fprintf(sbom_out, "PackageDownloadLocation: NOASSERTION\n") <= 0)
+			return false;
+	}
 
-
-	fprintf(sbom_out, "\n\n");
+	return fprintf(sbom_out, "\n\n") > 0;
 }
 
-static void
+static bool
 write_sbom_relationships(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *unused)
 {
 	(void) client;
@@ -194,36 +221,54 @@ write_sbom_relationships(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *unu
 	pkgconf_node_t *node;
 
 	if (pkg->flags & PKGCONF_PKG_PROPF_VIRTUAL)
-		return;
+		return true;
 
-	snprintf(baseref, sizeof baseref, "SPDXRef-Package-%sC64%s", pkg->id, pkg->version);
+	if (snprintf(baseref, sizeof(baseref), "SPDXRef-Package-%sC64%s", pkg->id, pkg->version) >= (int)sizeof(baseref))
+		return false;
 
 	PKGCONF_FOREACH_LIST_ENTRY(pkg->required.head, node)
 	{
 		pkgconf_dependency_t *dep = node->data;
+		if (!dep)
+			return false;
+
 		pkgconf_pkg_t *match = dep->match;
 
 		if (!dep->match)
 			continue;
 
-		fprintf(sbom_out, "Relationship: %s DEPENDS_ON SPDXRef-Package-%s\n", baseref, sbom_spdx_identity(match));
-		fprintf(sbom_out, "Relationship: SPDXRef-Package-%s DEPENDENCY_OF %s\n", sbom_spdx_identity(match), baseref);
+		if (fprintf(sbom_out, "Relationship: %s DEPENDS_ON SPDXRef-Package-%s\n", baseref, sbom_spdx_identity(match)) <= 0
+			|| fprintf(sbom_out, "Relationship: SPDXRef-Package-%s DEPENDENCY_OF %s\n", sbom_spdx_identity(match), baseref) <= 0)
+		{
+			return false;
+		}
 	}
 
 	PKGCONF_FOREACH_LIST_ENTRY(pkg->requires_private.head, node)
 	{
 		pkgconf_dependency_t *dep = node->data;
+		if (!dep)
+			return false;
+
 		pkgconf_pkg_t *match = dep->match;
 
 		if (!dep->match)
 			continue;
 
-		fprintf(sbom_out, "Relationship: %s DEPENDS_ON SPDXRef-Package-%s\n", baseref, sbom_spdx_identity(match));
-		fprintf(sbom_out, "Relationship: SPDXRef-Package-%s DEV_DEPENDENCY_OF %s\n", sbom_spdx_identity(match), baseref);
+		if (fprintf(sbom_out, "Relationship: %s DEPENDS_ON SPDXRef-Package-%s\n", baseref, sbom_spdx_identity(match)) <= 0
+			|| fprintf(sbom_out, "Relationship: SPDXRef-Package-%s DEV_DEPENDENCY_OF %s\n", sbom_spdx_identity(match), baseref) <= 0)
+		{
+			return false;
+		}
 	}
 
 	if (pkg->required.head != NULL || pkg->requires_private.head != NULL)
-		fprintf(sbom_out, "\n\n");
+	{
+		if (fprintf(sbom_out, "\n\n") <= 0)
+			return false;
+	}
+
+	return true;
 }
 
 static bool
@@ -232,7 +277,8 @@ generate_sbom_from_world(pkgconf_client_t *client, pkgconf_pkg_t *world)
 	int eflag;
 	pkgconf_node_t *node;
 
-	write_sbom_header(client, world);
+	if (!write_sbom_header(client, world))
+		return false;
 
 	eflag = pkgconf_pkg_traverse(client, world, write_sbom_package, NULL, maximum_traverse_depth, 0);
 	if (eflag != PKGCONF_PKG_ERRF_OK)
@@ -245,12 +291,16 @@ generate_sbom_from_world(pkgconf_client_t *client, pkgconf_pkg_t *world)
 	PKGCONF_FOREACH_LIST_ENTRY(world->required.head, node)
 	{
 		pkgconf_dependency_t *dep = node->data;
+		if (!dep)
+			return false;
+
 		pkgconf_pkg_t *match = dep->match;
 
 		if (!dep->match)
 			continue;
 
-		fprintf(sbom_out, "Relationship: %s DESCRIBES SPDXRef-Package-%s\n", document_ref, sbom_spdx_identity(match));
+		if (fprintf(sbom_out, "Relationship: %s DESCRIBES SPDXRef-Package-%s\n", document_ref, sbom_spdx_identity(match)) <= 0)
+			return false;
 	}
 
 	return true;
@@ -314,7 +364,7 @@ main(int argc, char *argv[])
 		{ "version", no_argument, &want_flags, PKG_VERSION, },
 		{ "about", no_argument, &want_flags, PKG_ABOUT, },
 		{ "help", no_argument, &want_flags, PKG_HELP, },
-		{ "output", required_argument, NULL, PKG_OUTPUT, }, 
+		{ "output", required_argument, NULL, PKG_OUTPUT, },
 		{ NULL, 0, NULL, 0 }
 	};
 
@@ -339,13 +389,23 @@ main(int argc, char *argv[])
 		}
 	}
 
-	pkgconf_client_init(&pkg_client, error_handler, NULL, personality, NULL, environ_lookup_handler);
+	if (!pkgconf_client_init(&pkg_client, error_handler, NULL, personality, NULL, environ_lookup_handler))
+	{
+		fprintf(stderr, "unable to initialize pkgconf client");
+		ret = EXIT_FAILURE;
+		goto out;
+	}
 
 	/* we have determined what features we want most likely.  in some cases, we override later. */
 	pkgconf_client_set_flags(&pkg_client, want_client_flags);
 
 	/* at this point, want_client_flags should be set, so build the dir list */
-	pkgconf_client_dir_list_build(&pkg_client, personality);
+	if (!pkgconf_client_dir_list_build(&pkg_client, personality))
+	{
+		fprintf(stderr, "pkgconf_client_dir_list_build failed");
+		ret = EXIT_FAILURE;
+		goto out;
+	}
 
 	if ((want_flags & PKG_ABOUT) == PKG_ABOUT)
 		return about();

--- a/cli/core.c
+++ b/cli/core.c
@@ -384,11 +384,16 @@ apply_modversion(pkgconf_client_t *client, pkgconf_pkg_t *world, void *data, int
 				continue;
 			}
 
-			if (pkg->version != NULL) {
+			if (pkg->version != NULL)
+			{
 				if (state->verbosity)
-					pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "%s: ", pkg->id);
+                {
+                    if (!pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "%s: ", pkg->id))
+					    return false;
+                }
 
-				pkgconf_output_puts(client->output, PKGCONF_OUTPUT_STDOUT, pkg->version);
+				if (!pkgconf_output_puts(client->output, PKGCONF_OUTPUT_STDOUT, pkg->version))
+					return false;
 			}
 
 			break;
@@ -408,9 +413,15 @@ apply_variables(pkgconf_client_t *client, pkgconf_pkg_t *world, void *unused, in
 	PKGCONF_FOREACH_LIST_ENTRY(world->required.head, iter)
 	{
 		pkgconf_dependency_t *dep = iter->data;
+		if (!dep)
+		{
+			pkgconf_error(client, "requires list corrupt");
+			return false;
+		}
 		pkgconf_pkg_t *pkg = dep->match;
 
-		print_variables(client->output, pkg);
+		if (!print_variables(client->output, pkg))
+			return false;
 	}
 
 	return true;
@@ -430,7 +441,10 @@ apply_path(pkgconf_client_t *client, pkgconf_pkg_t *world, void *unused, int max
 
 		/* a module entry with no filename is either virtual, static (builtin) or synthesized. */
 		if (pkg->filename != NULL)
-			pkgconf_output_puts(client->output, PKGCONF_OUTPUT_STDOUT, pkg->filename);
+		{
+			if (!pkgconf_output_puts(client->output, PKGCONF_OUTPUT_STDOUT, pkg->filename))
+				return false;
+		}
 	}
 
 	return true;
@@ -456,7 +470,10 @@ variable_eval(pkgconf_client_t *client, const pkgconf_list_t *vars, const char *
 	{
 		/* if sysroot is set, and value does not already begin with sysroot */
 		if (!pkgconf_buffer_has_prefix(&varbuf, sysroot_dir))
-			pkgconf_buffer_prepend(&varbuf, pkgconf_buffer_str_or_empty(sysroot_dir));
+		{
+			if (!pkgconf_buffer_prepend(&varbuf, pkgconf_buffer_str_or_empty(sysroot_dir)))
+				return NULL;
+		}
 	}
 
 	return pkgconf_buffer_freeze(&varbuf);
@@ -471,6 +488,11 @@ apply_variable(pkgconf_client_t *client, pkgconf_pkg_t *world, const void *varia
 	PKGCONF_FOREACH_LIST_ENTRY(world->required.head, iter)
 	{
 		pkgconf_dependency_t *dep = iter->data;
+		if (!dep)
+		{
+			pkgconf_error(client, "requires list corrupt");
+			return false;
+		}
 		pkgconf_pkg_t *pkg = dep->match;
 		char *result;
 
@@ -478,16 +500,18 @@ apply_variable(pkgconf_client_t *client, pkgconf_pkg_t *world, const void *varia
 			continue;
 
 		result = variable_eval(client, &pkg->vars, variable);
-
 		if (result != NULL)
 		{
-			pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT,
+			bool ok = pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT,
 				"%s%s", iter->prev != NULL ? " " : "", result);
 			free(result);
+			if (!ok)
+				return false;
 		}
 	}
 
-	pkgconf_output_puts(client->output, PKGCONF_OUTPUT_STDOUT, "");
+	if (!pkgconf_output_puts(client->output, PKGCONF_OUTPUT_STDOUT, ""))
+		return false;
 
 	return true;
 }
@@ -496,46 +520,58 @@ static bool
 apply_env_var(const char *prefix, pkgconf_client_t *client, pkgconf_pkg_t *world, int maxdepth,
 	unsigned int (*collect_fn)(pkgconf_client_t *client, pkgconf_pkg_t *world, pkgconf_list_t *list, int maxdepth),
 	bool (*filter_fn)(const pkgconf_client_t *client, const pkgconf_fragment_t *frag, void *data),
-	void (*postprocess_fn)(pkgconf_client_t *client, pkgconf_pkg_t *world, pkgconf_list_t *fragment_list))
+	bool (*postprocess_fn)(pkgconf_client_t *client, pkgconf_pkg_t *world, pkgconf_list_t *fragment_list))
 {
 	pkgconf_cli_state_t *state = client->client_data;
 	pkgconf_list_t unfiltered_list = PKGCONF_LIST_INITIALIZER;
 	pkgconf_list_t filtered_list = PKGCONF_LIST_INITIALIZER;
 	pkgconf_buffer_t render_buf = PKGCONF_BUFFER_INITIALIZER;
 	unsigned int eflag;
+	bool ret = false;
 
 	eflag = collect_fn(client, world, &unfiltered_list, maxdepth);
 	if (eflag != PKGCONF_PKG_ERRF_OK)
-		return false;
-
-	pkgconf_fragment_filter(client, &filtered_list, &unfiltered_list, filter_fn, NULL);
-
-	if (postprocess_fn != NULL)
-		postprocess_fn(client, world, &filtered_list);
-
-	if (filtered_list.head == NULL)
 		goto out;
 
-	pkgconf_fragment_render_buf(&filtered_list, &render_buf, true, state->want_render_ops, (state->want_flags & PKG_NEWLINES) ? '\n' : ' ');
-	pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "%s='%s'\n",
-		prefix, pkgconf_buffer_str_or_empty(&render_buf));
+	if (!pkgconf_fragment_filter(client, &filtered_list, &unfiltered_list, filter_fn, NULL))
+		goto out;
+
+	if (postprocess_fn != NULL)
+	{
+		if (!postprocess_fn(client, world, &filtered_list))
+			goto out;
+	}
+
+	if (filtered_list.head == NULL)
+	{
+		ret = true;
+		goto out;
+	}
+
+	if (!(pkgconf_fragment_render_buf(&filtered_list, &render_buf, true, state->want_render_ops, (state->want_flags & PKG_NEWLINES) ? '\n' : ' ')
+		&& pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "%s='%s'\n", prefix, pkgconf_buffer_str_or_empty(&render_buf))))
+	{
+		goto out;
+	}
 	pkgconf_buffer_finalize(&render_buf);
+
+	ret = true;
 
 out:
 	pkgconf_fragment_free(&unfiltered_list);
 	pkgconf_fragment_free(&filtered_list);
 
-	return true;
+	return ret;
 }
 
-static void
+static bool
 maybe_add_module_definitions(pkgconf_client_t *client, pkgconf_pkg_t *world, pkgconf_list_t *fragment_list)
 {
 	pkgconf_node_t *world_iter;
 	pkgconf_cli_state_t *state = client->client_data;
 
 	if ((state->want_flags & PKG_EXISTS_CFLAGS) != PKG_EXISTS_CFLAGS)
-		return;
+		return true;
 
 	PKGCONF_FOREACH_LIST_ENTRY(world->required.head, world_iter)
 	{
@@ -565,11 +601,14 @@ maybe_add_module_definitions(pkgconf_client_t *client, pkgconf_pkg_t *world, pkg
 			}
 		}
 
-		pkgconf_fragment_insert(client, fragment_list, 'D', havebuf, false);
+		if (!pkgconf_fragment_insert(client, fragment_list, 'D', havebuf, false))
+			return false;
 	}
+
+	return true;
 }
 
-static void
+static bool
 apply_env_variables(pkgconf_client_t *client, pkgconf_pkg_t *world, const char *env_prefix)
 {
 	pkgconf_node_t *world_iter;
@@ -578,6 +617,12 @@ apply_env_variables(pkgconf_client_t *client, pkgconf_pkg_t *world, const char *
 	PKGCONF_FOREACH_LIST_ENTRY(world->required.head, world_iter)
 	{
 		pkgconf_dependency_t *dep = world_iter->data;
+		if (!dep)
+		{
+			pkgconf_error(client, "requires list corrupted");
+			return false;
+		}
+
 		pkgconf_pkg_t *pkg = dep->match;
 		pkgconf_node_t *tuple_iter;
 
@@ -590,6 +635,12 @@ apply_env_variables(pkgconf_client_t *client, pkgconf_pkg_t *world, const char *
 		PKGCONF_FOREACH_LIST_ENTRY(pkg->vars.head, tuple_iter)
 		{
 			pkgconf_tuple_t *tuple = tuple_iter->data;
+			if (!tuple)
+			{
+				pkgconf_error(client, "package vars corrupted");
+				return false;
+			}
+
 			char havebuf[PKGCONF_ITEM_SIZE];
 			char *p;
 
@@ -613,11 +664,23 @@ apply_env_variables(pkgconf_client_t *client, pkgconf_pkg_t *world, const char *
 			}
 
 			char *val = pkgconf_variable_eval_str(client, &pkg->vars, tuple, NULL);
-			pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT,
-				"%s='%s'\n", havebuf, val);
+			if (!val)
+			{
+				pkgconf_error(client, "pkgconf_variable_eval_str failed");
+				return false;
+			}
+
+			bool ok = pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "%s='%s'\n", havebuf, val);
 			free(val);
+			if (!ok)
+			{
+				pkgconf_error(client, "pkgconf_output_fmt failed");
+				return false;
+			}
 		}
 	}
+
+	return true;
 }
 
 static bool
@@ -636,14 +699,26 @@ apply_env(pkgconf_client_t *client, pkgconf_pkg_t *world, const void *env_prefix
 
 	snprintf(workbuf, sizeof workbuf, "%s_CFLAGS", want_env_prefix);
 	if (!apply_env_var(workbuf, client, world, maxdepth, pkgconf_pkg_cflags, filter_cflags, maybe_add_module_definitions))
+	{
+		pkgconf_error(client, "apply_env_var failed");
 		return false;
+	}
 
 	snprintf(workbuf, sizeof workbuf, "%s_LIBS", want_env_prefix);
 	if (!apply_env_var(workbuf, client, world, maxdepth, pkgconf_pkg_libs, filter_libs, NULL))
+	{
+		pkgconf_error(client, "apply_env_var failed");
 		return false;
+	}
 
 	if ((state->want_flags & PKG_VARIABLES) == PKG_VARIABLES || state->want_variable != NULL)
-		apply_env_variables(client, world, want_env_prefix);
+	{
+		if (!apply_env_variables(client, world, want_env_prefix))
+		{
+			pkgconf_error(client, "apply_env_var failed");
+			return false;
+		}
+	}
 
 	return true;
 }
@@ -654,24 +729,34 @@ apply_cflags(pkgconf_client_t *client, pkgconf_pkg_t *world, pkgconf_list_t *tar
 	pkgconf_list_t unfiltered_list = PKGCONF_LIST_INITIALIZER;
 	pkgconf_list_t filtered_list = PKGCONF_LIST_INITIALIZER;
 	int eflag;
+	bool ret = false;
 
 	eflag = pkgconf_pkg_cflags(client, world, &unfiltered_list, maxdepth);
 	if (eflag != PKGCONF_PKG_ERRF_OK)
-		return false;
-
-	pkgconf_fragment_filter(client, &filtered_list, &unfiltered_list, filter_cflags, NULL);
-	maybe_add_module_definitions(client, world, &filtered_list);
-
-	if (filtered_list.head == NULL)
 		goto out;
 
-	pkgconf_fragment_copy_list(client, target_list, &filtered_list);
+	if (!(pkgconf_fragment_filter(client, &filtered_list, &unfiltered_list, filter_cflags, NULL)
+		&& maybe_add_module_definitions(client, world, &filtered_list)))
+	{
+		goto out;
+	}
+
+	if (filtered_list.head == NULL)
+	{
+		ret = true;
+		goto out;
+	}
+
+	if (!pkgconf_fragment_copy_list(client, target_list, &filtered_list))
+		goto out;
+
+	ret = true;
 
 out:
 	pkgconf_fragment_free(&unfiltered_list);
 	pkgconf_fragment_free(&filtered_list);
 
-	return true;
+	return ret;
 }
 
 static bool
@@ -680,23 +765,31 @@ apply_libs(pkgconf_client_t *client, pkgconf_pkg_t *world, pkgconf_list_t *targe
 	pkgconf_list_t unfiltered_list = PKGCONF_LIST_INITIALIZER;
 	pkgconf_list_t filtered_list = PKGCONF_LIST_INITIALIZER;
 	int eflag;
+	bool ret = false;
 
 	eflag = pkgconf_pkg_libs(client, world, &unfiltered_list, maxdepth);
 	if (eflag != PKGCONF_PKG_ERRF_OK)
-		return false;
-
-	pkgconf_fragment_filter(client, &filtered_list, &unfiltered_list, filter_libs, NULL);
-
-	if (filtered_list.head == NULL)
 		goto out;
 
-	pkgconf_fragment_copy_list(client, target_list, &filtered_list);
+	if (!pkgconf_fragment_filter(client, &filtered_list, &unfiltered_list, filter_libs, NULL))
+		goto out;
+
+	if (filtered_list.head == NULL)
+	{
+		ret = true;
+		goto out;
+	}
+
+	if (!pkgconf_fragment_copy_list(client, target_list, &filtered_list))
+		goto out;
+
+	ret = true;
 
 out:
 	pkgconf_fragment_free(&unfiltered_list);
 	pkgconf_fragment_free(&filtered_list);
 
-	return true;
+	return ret;
 }
 
 static bool
@@ -709,9 +802,13 @@ apply_requires(pkgconf_client_t *client, pkgconf_pkg_t *world, void *unused, int
 	PKGCONF_FOREACH_LIST_ENTRY(world->required.head, iter)
 	{
 		pkgconf_dependency_t *dep = iter->data;
+		if (!dep)
+			return false;
+
 		pkgconf_pkg_t *pkg = dep->match;
 
-		print_dependency_list(client->output, &pkg->required);
+		if (!print_dependency_list(client->output, &pkg->required))
+			return false;
 	}
 
 	return true;
@@ -727,9 +824,15 @@ apply_requires_private(pkgconf_client_t *client, pkgconf_pkg_t *world, void *unu
 	PKGCONF_FOREACH_LIST_ENTRY(world->required.head, iter)
 	{
 		pkgconf_dependency_t *dep = iter->data;
+		if (!dep)
+		{
+			pkgconf_error(client, "requires list corrupted");
+			return false;
+		}
 		pkgconf_pkg_t *pkg = dep->match;
 
-		print_dependency_list(client->output, &pkg->requires_private);
+		if (!print_dependency_list(client->output, &pkg->requires_private))
+			return false;
 	}
 	return true;
 }
@@ -821,7 +924,7 @@ apply_simulate(pkgconf_client_t *client, pkgconf_pkg_t *world, void *data, int m
 }
 #endif
 
-static void
+static bool
 print_fragment_tree_branch(pkgconf_output_t *output, pkgconf_list_t *fragment_list, int indent)
 {
 	pkgconf_node_t *iter;
@@ -829,19 +932,37 @@ print_fragment_tree_branch(pkgconf_output_t *output, pkgconf_list_t *fragment_li
 	PKGCONF_FOREACH_LIST_ENTRY(fragment_list->head, iter)
 	{
 		pkgconf_fragment_t *frag = iter->data;
+		if (!frag)
+			return false;
 
 		if (frag->type)
-			pkgconf_output_fmt(output, PKGCONF_OUTPUT_STDOUT,
-				"%*s'-%c%s' [type %c, %zu children]\n", indent, "", frag->type, frag->data, frag->type, frag->children.length);
+		{
+			if (!pkgconf_output_fmt(output, PKGCONF_OUTPUT_STDOUT,
+				"%*s'-%c%s' [type %c, %zu children]\n", indent, "", frag->type, frag->data, frag->type, frag->children.length))
+			{
+				return false;
+			}
+		}
 		else
-			pkgconf_output_fmt(output, PKGCONF_OUTPUT_STDOUT,
-				"%*s'%s' [untyped, %zu children]\n", indent, "", frag->data, frag->children.length);
+		{
+			if (!pkgconf_output_fmt(output, PKGCONF_OUTPUT_STDOUT,
+				"%*s'%s' [untyped, %zu children]\n", indent, "", frag->data, frag->children.length))
+			{
+				return false;
+			}
+		}
 
-		print_fragment_tree_branch(output, &frag->children, indent + 2);
+		if (!print_fragment_tree_branch(output, &frag->children, indent + 2))
+			return false;
 	}
 
 	if (fragment_list->head != NULL)
-		pkgconf_output_puts(output, PKGCONF_OUTPUT_STDOUT, "");
+	{
+		if (!pkgconf_output_puts(output, PKGCONF_OUTPUT_STDOUT, ""))
+			return false;
+	}
+
+	return true;
 }
 
 static bool
@@ -860,7 +981,9 @@ apply_fragment_tree(pkgconf_client_t *client, pkgconf_pkg_t *world, void *data, 
 	if (eflag != PKGCONF_PKG_ERRF_OK)
 		return false;
 
-	print_fragment_tree_branch(client->output, &unfiltered_list, 0);
+	if (!print_fragment_tree_branch(client->output, &unfiltered_list, 0))
+		return false;
+
 	pkgconf_fragment_free(&unfiltered_list);
 
 	return true;
@@ -963,7 +1086,7 @@ apply_source(pkgconf_client_t *client, pkgconf_pkg_t *world, void *data, int max
 	return true;
 }
 
-void
+bool
 path_list_to_buffer(const pkgconf_list_t *list, pkgconf_buffer_t *buffer, char delim)
 {
 	pkgconf_node_t *n;
@@ -971,12 +1094,17 @@ path_list_to_buffer(const pkgconf_list_t *list, pkgconf_buffer_t *buffer, char d
 	PKGCONF_FOREACH_LIST_ENTRY(list->head, n)
 	{
 		pkgconf_path_t *pn = n->data;
+		if (!pn)
+			return false;
 
-		if (n != list->head)
-			pkgconf_buffer_push_byte(buffer, delim);
+		if (n != list->head && !pkgconf_buffer_push_byte(buffer, delim))
+			return false;
 
-		pkgconf_buffer_append(buffer, pn->path);
+		if (!pkgconf_buffer_append(buffer, pn->path))
+			return false;
 	}
+
+	return true;
 }
 
 static void
@@ -1021,23 +1149,24 @@ unveil_search_paths(pkgconf_client_t *client, const pkgconf_cross_personality_t 
 }
 
 /* SAFETY: pkgconf_client_t takes ownership of these package objects */
-static void
+static bool
 register_builtins(pkgconf_client_t *client, const pkgconf_cross_personality_t *personality)
 {
+	bool ret = false;
+	pkgconf_pkg_t *pkg_config_virtual = NULL;
+	pkgconf_pkg_t *pkgconf_virtual = NULL;
 	pkgconf_buffer_t pc_path_buf = PKGCONF_BUFFER_INITIALIZER;
-	path_list_to_buffer(&personality->dir_list, &pc_path_buf, ':');
-
 	pkgconf_buffer_t pc_system_libdirs_buf = PKGCONF_BUFFER_INITIALIZER;
-	path_list_to_buffer(&personality->filter_libdirs, &pc_system_libdirs_buf, ':');
-
 	pkgconf_buffer_t pc_system_includedirs_buf = PKGCONF_BUFFER_INITIALIZER;
-	path_list_to_buffer(&personality->filter_includedirs, &pc_system_includedirs_buf, ':');
 
-	pkgconf_pkg_t *pkg_config_virtual = calloc(1, sizeof(pkgconf_pkg_t));
+	if (!path_list_to_buffer(&personality->dir_list, &pc_path_buf, ':') ||
+		!path_list_to_buffer(&personality->filter_libdirs, &pc_system_libdirs_buf, ':') ||
+		!path_list_to_buffer(&personality->filter_includedirs, &pc_system_includedirs_buf, ':'))
+		goto out;
+
+	pkg_config_virtual = calloc(1, sizeof(pkgconf_pkg_t));
 	if (pkg_config_virtual == NULL)
-	{
-		goto error;
-	}
+		goto out;
 
 	pkg_config_virtual->owner = client;
 	pkg_config_virtual->id = strdup("pkg-config");
@@ -1046,20 +1175,25 @@ register_builtins(pkgconf_client_t *client, const pkgconf_cross_personality_t *p
 	pkg_config_virtual->url = strdup(PACKAGE_BUGREPORT);
 	pkg_config_virtual->version = strdup(PACKAGE_VERSION);
 
-	pkgconf_tuple_add(client, &pkg_config_virtual->vars, "pc_system_libdirs", pkgconf_buffer_str_or_empty(&pc_system_libdirs_buf), false, 0);
-	pkgconf_tuple_add(client, &pkg_config_virtual->vars, "pc_system_includedirs", pkgconf_buffer_str_or_empty(&pc_system_includedirs_buf), false, 0);
-	pkgconf_tuple_add(client, &pkg_config_virtual->vars, "pc_path", pkgconf_buffer_str_or_empty(&pc_path_buf), false, 0);
+	if (pkg_config_virtual->id == NULL ||
+		pkg_config_virtual->realname == NULL ||
+		pkg_config_virtual->description == NULL ||
+		pkg_config_virtual->url == NULL ||
+		pkg_config_virtual->version == NULL)
+		goto out;
+
+	if (pkgconf_tuple_add(client, &pkg_config_virtual->vars, "pc_system_libdirs", pkgconf_buffer_str_or_empty(&pc_system_libdirs_buf), false, 0) == NULL ||
+		pkgconf_tuple_add(client, &pkg_config_virtual->vars, "pc_system_includedirs", pkgconf_buffer_str_or_empty(&pc_system_includedirs_buf), false, 0) == NULL ||
+		pkgconf_tuple_add(client, &pkg_config_virtual->vars, "pc_path", pkgconf_buffer_str_or_empty(&pc_path_buf), false, 0) == NULL)
+		goto out;
 
 	if (!pkgconf_client_preload_one(client, pkg_config_virtual))
-	{
-		goto error;
-	}
+		goto out;
+	pkg_config_virtual = NULL;  /* preload_one took ownership */
 
-	pkgconf_pkg_t *pkgconf_virtual = calloc(1, sizeof(pkgconf_pkg_t));
+	pkgconf_virtual = calloc(1, sizeof(pkgconf_pkg_t));
 	if (pkgconf_virtual == NULL)
-	{
-		goto error;
-	}
+		goto out;
 
 	pkgconf_virtual->owner = client;
 	pkgconf_virtual->id = strdup("pkgconf");
@@ -1068,46 +1202,70 @@ register_builtins(pkgconf_client_t *client, const pkgconf_cross_personality_t *p
 	pkgconf_virtual->url = strdup(PACKAGE_BUGREPORT);
 	pkgconf_virtual->version = strdup(PACKAGE_VERSION);
 
-	pkgconf_tuple_add(client, &pkgconf_virtual->vars, "pc_system_libdirs", pkgconf_buffer_str_or_empty(&pc_system_libdirs_buf), false, 0);
-	pkgconf_tuple_add(client, &pkgconf_virtual->vars, "pc_system_includedirs", pkgconf_buffer_str_or_empty(&pc_system_includedirs_buf), false, 0);
-	pkgconf_tuple_add(client, &pkgconf_virtual->vars, "pc_path", pkgconf_buffer_str_or_empty(&pc_path_buf), false, 0);
+	if (pkgconf_virtual->id == NULL ||
+		pkgconf_virtual->realname == NULL ||
+		pkgconf_virtual->description == NULL ||
+		pkgconf_virtual->url == NULL ||
+		pkgconf_virtual->version == NULL)
+		goto out;
 
-	if (!pkgconf_client_preload_one(client, pkgconf_virtual))
+	if (pkgconf_tuple_add(client, &pkgconf_virtual->vars, "pc_system_libdirs", pkgconf_buffer_str_or_empty(&pc_system_libdirs_buf), false, 0) == NULL ||
+		pkgconf_tuple_add(client, &pkgconf_virtual->vars, "pc_system_includedirs", pkgconf_buffer_str_or_empty(&pc_system_includedirs_buf), false, 0) == NULL ||
+		pkgconf_tuple_add(client, &pkgconf_virtual->vars, "pc_path", pkgconf_buffer_str_or_empty(&pc_path_buf), false, 0) == NULL)
 	{
-		goto error;
+		goto out;
 	}
 
-error:
+	if (!pkgconf_client_preload_one(client, pkgconf_virtual))
+		goto out;
+	pkgconf_virtual = NULL;  /* preload_one took ownership */
+
+	ret = true;
+
+out:
+	if (pkg_config_virtual != NULL)
+		pkgconf_pkg_free(client, pkg_config_virtual);
+	if (pkgconf_virtual != NULL)
+		pkgconf_pkg_free(client, pkgconf_virtual);
 	pkgconf_buffer_finalize(&pc_path_buf);
 	pkgconf_buffer_finalize(&pc_system_libdirs_buf);
 	pkgconf_buffer_finalize(&pc_system_includedirs_buf);
+	return ret;
 }
 
 #ifndef PKGCONF_LITE
-static void
+static bool
 dump_personality(pkgconf_output_t *output, const pkgconf_cross_personality_t *p)
 {
+	bool ret = false;
 	pkgconf_buffer_t pc_path_buf = PKGCONF_BUFFER_INITIALIZER;
-	path_list_to_buffer(&p->dir_list, &pc_path_buf, ':');
-
 	pkgconf_buffer_t pc_system_libdirs_buf = PKGCONF_BUFFER_INITIALIZER;
-	path_list_to_buffer(&p->filter_libdirs, &pc_system_libdirs_buf, ':');
-
 	pkgconf_buffer_t pc_system_includedirs_buf = PKGCONF_BUFFER_INITIALIZER;
-	path_list_to_buffer(&p->filter_includedirs, &pc_system_includedirs_buf, ':');
 
-	pkgconf_output_fmt(output, PKGCONF_OUTPUT_STDOUT, "Triplet: %s\n", p->name);
+	if (!path_list_to_buffer(&p->dir_list, &pc_path_buf, ':') ||
+		!path_list_to_buffer(&p->filter_libdirs, &pc_system_libdirs_buf, ':') ||
+		!path_list_to_buffer(&p->filter_includedirs, &pc_system_includedirs_buf, ':'))
+		goto out;
 
-	if (p->sysroot_dir)
-		pkgconf_output_fmt(output, PKGCONF_OUTPUT_STDOUT, "SysrootDir: %s\n", p->sysroot_dir);
+	if (!pkgconf_output_fmt(output, PKGCONF_OUTPUT_STDOUT, "Triplet: %s\n", p->name))
+		goto out;
 
-	pkgconf_output_fmt(output, PKGCONF_OUTPUT_STDOUT, "DefaultSearchPaths: %s\n", pc_path_buf.base);
-	pkgconf_output_fmt(output, PKGCONF_OUTPUT_STDOUT, "SystemIncludePaths: %s\n", pc_system_includedirs_buf.base);
-	pkgconf_output_fmt(output, PKGCONF_OUTPUT_STDOUT, "SystemLibraryPaths: %s\n", pc_system_libdirs_buf.base);
+	if (p->sysroot_dir &&
+		!pkgconf_output_fmt(output, PKGCONF_OUTPUT_STDOUT, "SysrootDir: %s\n", p->sysroot_dir))
+		goto out;
 
+	if (!pkgconf_output_fmt(output, PKGCONF_OUTPUT_STDOUT, "DefaultSearchPaths: %s\n", pkgconf_buffer_str_or_empty(&pc_path_buf)) ||
+		!pkgconf_output_fmt(output, PKGCONF_OUTPUT_STDOUT, "SystemIncludePaths: %s\n", pkgconf_buffer_str_or_empty(&pc_system_includedirs_buf)) ||
+		!pkgconf_output_fmt(output, PKGCONF_OUTPUT_STDOUT, "SystemLibraryPaths: %s\n", pkgconf_buffer_str_or_empty(&pc_system_libdirs_buf)))
+		goto out;
+
+	ret = true;
+
+out:
 	pkgconf_buffer_finalize(&pc_path_buf);
 	pkgconf_buffer_finalize(&pc_system_libdirs_buf);
 	pkgconf_buffer_finalize(&pc_system_includedirs_buf);
+	return ret;
 }
 #endif
 
@@ -1133,9 +1291,15 @@ pkgconf_cli_run(pkgconf_cli_state_t *state, int argc, char *argv[], int last_arg
 #ifndef PKGCONF_LITE
 	if ((state->want_flags & PKG_DUMP_PERSONALITY) == PKG_DUMP_PERSONALITY)
 	{
-		dump_personality(state->pkg_client.output, state->pkg_client.personality);
+		if (!dump_personality(state->pkg_client.output, state->pkg_client.personality))
+		{
+			fprintf(stderr, "failed to dump personality\n");
+			ret = EXIT_FAILURE;
+			goto out;
+		}
+		else
+			ret = EXIT_SUCCESS;
 
-		ret = EXIT_SUCCESS;
 		goto out;
 	}
 #endif
@@ -1239,13 +1403,25 @@ pkgconf_cli_run(pkgconf_cli_state_t *state, int argc, char *argv[], int last_arg
 	}
 
 	if ((builddir = pkgconf_client_getenv(&state->pkg_client, "PKG_CONFIG_TOP_BUILD_DIR")) != NULL)
-		pkgconf_client_set_buildroot_dir(&state->pkg_client, builddir);
+	{
+		if (!pkgconf_client_set_buildroot_dir(&state->pkg_client, builddir))
+		{
+			fprintf(stderr, "failed to set buildroot dir\n");
+			ret = EXIT_FAILURE;
+			goto out;
+		}
+	}
 
 	if ((sysroot_dir = pkgconf_client_getenv(&state->pkg_client, "PKG_CONFIG_SYSROOT_DIR")) != NULL)
 	{
 		const char *destdir;
 
-		pkgconf_client_set_sysroot_dir(&state->pkg_client, sysroot_dir);
+		if (!pkgconf_client_set_sysroot_dir(&state->pkg_client, sysroot_dir))
+		{
+			fprintf(stderr, "failed to set sysroot dir\n");
+			ret = EXIT_FAILURE;
+			goto out;
+		}
 
 		if ((destdir = pkgconf_client_getenv(&state->pkg_client, "DESTDIR")) != NULL)
 		{
@@ -1258,17 +1434,28 @@ pkgconf_cli_run(pkgconf_cli_state_t *state, int argc, char *argv[], int last_arg
 	pkgconf_client_set_flags(&state->pkg_client, want_client_flags);
 
 	/* at this point, want_client_flags should be set, so build the dir list */
-	pkgconf_client_dir_list_build(&state->pkg_client, state->pkg_client.personality);
+	if (!pkgconf_client_dir_list_build(&state->pkg_client, state->pkg_client.personality))
+	{
+		fprintf(stderr, "failed to set client dir list\n");
+		ret = EXIT_FAILURE;
+		goto out;
+	}
 
 	/* unveil the entire search path now that we have loaded the personality data and built the dir list. */
 	if (!unveil_search_paths(&state->pkg_client, state->pkg_client.personality))
 	{
 		fprintf(stderr, "pkgconf: unveil failed: %s\n", strerror(errno));
-		return EXIT_FAILURE;
+		ret = EXIT_FAILURE;
+		goto out;
 	}
 
 	/* register built-in packages */
-	register_builtins(&state->pkg_client, state->pkg_client.personality);
+	if (!register_builtins(&state->pkg_client, state->pkg_client.personality))
+	{
+		fprintf(stderr, "failed to register builtin packages\n");
+		ret = EXIT_FAILURE;
+		goto out;
+	}
 
 	/* preload any files in PKG_CONFIG_PRELOADED_FILES */
 	pkgconf_client_preload_from_environ(&state->pkg_client, "PKG_CONFIG_PRELOADED_FILES");
@@ -1299,10 +1486,19 @@ pkgconf_cli_run(pkgconf_cli_state_t *state, int argc, char *argv[], int last_arg
 
 	while (last_argc < argc && argv[last_argc])
 	{
+		bool ok = true;
 		if (pkgconf_buffer_len(&queryparams) > 0)
-			pkgconf_buffer_push_byte(&queryparams, ' ');
+			ok = pkgconf_buffer_push_byte(&queryparams, ' ');
 
-		pkgconf_buffer_append(&queryparams, argv[last_argc]);
+		if (ok)
+			ok = pkgconf_buffer_append(&queryparams, argv[last_argc]);
+
+		if (!ok)
+		{
+			pkgconf_buffer_finalize(&queryparams);
+			ret = EXIT_FAILURE;
+			goto out;
+		}
 		last_argc++;
 	}
 
@@ -1333,6 +1529,13 @@ pkgconf_cli_run(pkgconf_cli_state_t *state, int argc, char *argv[], int last_arg
 		PKGCONF_FOREACH_LIST_ENTRY(deplist.head, node)
 		{
 			pkgconf_dependency_t *dep = node->data;
+			if (!dep)
+			{
+				pkgconf_output_puts(state->pkg_client.output, PKGCONF_OUTPUT_STDERR,
+					"dependency list corrupted");
+				ret = EXIT_FAILURE;
+				goto out;
+			}
 
 			/* already constrained at query level */
 			if (dep->compare != PKGCONF_CMP_ANY)
@@ -1340,13 +1543,26 @@ pkgconf_cli_run(pkgconf_cli_state_t *state, int argc, char *argv[], int last_arg
 
 			dep->compare = compare;
 			dep->version = strdup(target_version);
+			if (dep->version == NULL)
+			{
+				pkgconf_output_puts(state->pkg_client.output, PKGCONF_OUTPUT_STDERR,
+					"out of memory");
+				ret = EXIT_FAILURE;
+				goto out;
+			}
 		}
 	}
 
 	PKGCONF_FOREACH_LIST_ENTRY(deplist.head, node)
 	{
 		pkgconf_dependency_t *dep = node->data;
-		pkgconf_queue_push_dependency(&pkgq, dep);
+		if (!pkgconf_queue_push_dependency(&pkgq, dep))
+		{
+			pkgconf_output_puts(state->pkg_client.output, PKGCONF_OUTPUT_STDERR,
+				"Unable to push dependency");
+			ret = EXIT_FAILURE;
+			goto out;
+		}
 	}
 
 	pkgconf_dependency_free(&deplist);
@@ -1371,7 +1587,8 @@ pkgconf_cli_run(pkgconf_cli_state_t *state, int argc, char *argv[], int last_arg
 	if (pkgconf_unveil(NULL, NULL) == -1)
 	{
 		fprintf(stderr, "pkgconf: unveil lockdown failed: %s\n", strerror(errno));
-		return EXIT_FAILURE;
+		ret = EXIT_FAILURE;
+		goto out;
 	}
 
 #ifndef PKGCONF_LITE
@@ -1380,7 +1597,12 @@ pkgconf_cli_run(pkgconf_cli_state_t *state, int argc, char *argv[], int last_arg
 		state->want_flags &= ~(PKG_CFLAGS|PKG_LIBS);
 
 		pkgconf_client_set_flags(&state->pkg_client, want_client_flags | PKGCONF_PKG_PKGF_SKIP_ERRORS);
-		apply_simulate(&state->pkg_client, &world, NULL, -1);
+		if (!apply_simulate(&state->pkg_client, &world, NULL, -1))
+		{
+			fprintf(stderr, "pkgconf: failed to simulate apply\n");
+			ret = EXIT_FAILURE;
+			goto out;
+		}
 	}
 #endif
 
@@ -1389,19 +1611,31 @@ pkgconf_cli_run(pkgconf_cli_state_t *state, int argc, char *argv[], int last_arg
 
 	if ((state->want_flags & PKG_DUMP_LICENSE) == PKG_DUMP_LICENSE)
 	{
-		apply_license(&state->pkg_client, &world, &ret, 2);
+		if (!apply_license(&state->pkg_client, &world, &ret, 2))
+		{
+			fprintf(stderr, "pkgconf: failed to apply license\n");
+			ret = EXIT_FAILURE;
+		}
 		goto out;
 	}
 
 	if ((state->want_flags & PKG_DUMP_LICENSE_FILE) == PKG_DUMP_LICENSE_FILE)
 	{
-		apply_license_file(&state->pkg_client, &world, &ret, 2);
+		if (!apply_license_file(&state->pkg_client, &world, &ret, 2))
+		{
+			fprintf(stderr, "pkgconf: failed to apply license file\n");
+			ret = EXIT_FAILURE;
+		}
 		goto out;
 	}
 
 	if ((state->want_flags & PKG_DUMP_SOURCE) == PKG_DUMP_SOURCE)
 	{
-		apply_source(&state->pkg_client, &world, &ret, 2);
+		if (!apply_source(&state->pkg_client, &world, &ret, 2))
+		{
+			fprintf(stderr, "pkgconf: failed to apply source\n");
+			ret = EXIT_FAILURE;
+		}
 		goto out;
 	}
 
@@ -1409,40 +1643,67 @@ pkgconf_cli_run(pkgconf_cli_state_t *state, int argc, char *argv[], int last_arg
 	if ((state->want_flags & PKG_UNINSTALLED) == PKG_UNINSTALLED)
 	{
 		ret = EXIT_FAILURE;
-		apply_uninstalled(&state->pkg_client, &world, &ret, 2);
+		if (!apply_uninstalled(&state->pkg_client, &world, &ret, 2))
+		{
+			fprintf(stderr, "pkgconf: failed to apply uninstalled\n");
+		}
 		goto out;
 	}
 
 	if (state->want_env_prefix != NULL)
 	{
-		apply_env(&state->pkg_client, &world, state->want_env_prefix, 2);
+		if (!apply_env(&state->pkg_client, &world, state->want_env_prefix, 2))
+		{
+			fprintf(stderr, "pkgconf: failed to apply environment\n");
+			ret = EXIT_FAILURE;
+		}
 		goto out;
 	}
 
 	if ((state->want_flags & PKG_PROVIDES) == PKG_PROVIDES)
 	{
 		state->want_flags &= ~(PKG_CFLAGS|PKG_LIBS);
-		apply_provides(&state->pkg_client, &world, NULL, 2);
+		if (!apply_provides(&state->pkg_client, &world, NULL, 2))
+		{
+			fprintf(stderr, "pkgconf: failed to apply provides\n");
+			ret = EXIT_FAILURE;
+			goto out;
+		}
 	}
 
 #ifndef PKGCONF_LITE
 	if ((state->want_flags & PKG_DIGRAPH) == PKG_DIGRAPH)
 	{
 		state->want_flags &= ~(PKG_CFLAGS|PKG_LIBS);
-		apply_digraph(&state->pkg_client, &world, &pkgq, 2);
+		if (!apply_digraph(&state->pkg_client, &world, &pkgq, 2))
+		{
+			fprintf(stderr, "pkgconf: failed to apply digraph\n");
+			ret = EXIT_FAILURE;
+			goto out;
+		}
 	}
 
 	if ((state->want_flags & PKG_SOLUTION) == PKG_SOLUTION)
 	{
 		state->want_flags &= ~(PKG_CFLAGS|PKG_LIBS);
-		apply_print_solution(&state->pkg_client, &world, NULL, 2);
+		if (!apply_print_solution(&state->pkg_client, &world, NULL, 2))
+		{
+			fprintf(stderr, "pkgconf: failed to print solution\n");
+			ret = EXIT_FAILURE;
+			goto out;
+		}
 	}
 #endif
 
 	if ((state->want_flags & PKG_MODVERSION) == PKG_MODVERSION)
 	{
 		state->want_flags &= ~(PKG_CFLAGS|PKG_LIBS);
-		apply_modversion(&state->pkg_client, &world, &pkgq, 2);
+		if (!apply_modversion(&state->pkg_client, &world, &pkgq, 2))
+		{
+			fprintf(stderr, "pkgconf: failed to apply modversion\n");
+			ret = EXIT_FAILURE;
+			goto out;
+		}
 	}
 
 	if ((state->want_flags & PKG_PATH) == PKG_PATH)
@@ -1450,13 +1711,23 @@ pkgconf_cli_run(pkgconf_cli_state_t *state, int argc, char *argv[], int last_arg
 		state->want_flags &= ~(PKG_CFLAGS|PKG_LIBS);
 
 		pkgconf_client_set_flags(&state->pkg_client, want_client_flags | PKGCONF_PKG_PKGF_SKIP_ROOT_VIRTUAL);
-		apply_path(&state->pkg_client, &world, NULL, 2);
+		if (!apply_path(&state->pkg_client, &world, NULL, 2))
+		{
+			fprintf(stderr, "pkgconf: failed to apply path\n");
+			ret = EXIT_FAILURE;
+			goto out;
+		}
 	}
 
 	if ((state->want_flags & PKG_VARIABLES) == PKG_VARIABLES)
 	{
 		state->want_flags &= ~(PKG_CFLAGS|PKG_LIBS);
-		apply_variables(&state->pkg_client, &world, NULL, 2);
+		if (!apply_variables(&state->pkg_client, &world, NULL, 2))
+		{
+			fprintf(stderr, "pkgconf: failed to apply variables\n");
+			ret = EXIT_FAILURE;
+			goto out;
+		}
 	}
 
 	if (state->want_variable != NULL)
@@ -1464,27 +1735,47 @@ pkgconf_cli_run(pkgconf_cli_state_t *state, int argc, char *argv[], int last_arg
 		state->want_flags &= ~(PKG_CFLAGS|PKG_LIBS);
 
 		pkgconf_client_set_flags(&state->pkg_client, want_client_flags | PKGCONF_PKG_PKGF_SKIP_ROOT_VIRTUAL);
-		apply_variable(&state->pkg_client, &world, state->want_variable, 2);
+		if (!apply_variable(&state->pkg_client, &world, state->want_variable, 2))
+		{
+			fprintf(stderr, "pkgconf: failed to apply variable\n");
+			ret = EXIT_FAILURE;
+			goto out;
+		}
 	}
 
 	if ((state->want_flags & PKG_REQUIRES) == PKG_REQUIRES)
 	{
 		state->want_flags &= ~(PKG_CFLAGS|PKG_LIBS);
-		apply_requires(&state->pkg_client, &world, NULL, 2);
+		if (!apply_requires(&state->pkg_client, &world, NULL, 2))
+		{
+			fprintf(stderr, "pkgconf: failed to apply requires\n");
+			ret = EXIT_FAILURE;
+			goto out;
+		}
 	}
 
 	if ((state->want_flags & PKG_REQUIRES_PRIVATE) == PKG_REQUIRES_PRIVATE)
 	{
 		state->want_flags &= ~(PKG_CFLAGS|PKG_LIBS);
 
-		apply_requires_private(&state->pkg_client, &world, NULL, 2);
+		if (!apply_requires_private(&state->pkg_client, &world, NULL, 2))
+		{
+			fprintf(stderr, "pkgconf: failed to apply requires_private\n");
+			ret = EXIT_FAILURE;
+			goto out;
+		}
 	}
 
 	if ((state->want_flags & PKG_FRAGMENT_TREE))
 	{
 		state->want_flags &= ~(PKG_CFLAGS|PKG_LIBS);
 
-		apply_fragment_tree(&state->pkg_client, &world, NULL, 2);
+		if (!apply_fragment_tree(&state->pkg_client, &world, NULL, 2))
+		{
+			fprintf(stderr, "pkgconf: failed to apply fragment tree\n");
+			ret = EXIT_FAILURE;
+			goto out;
+		}
 	}
 
 	if ((state->want_flags & (PKG_CFLAGS|PKG_LIBS)))
@@ -1493,16 +1784,42 @@ pkgconf_cli_run(pkgconf_cli_state_t *state, int argc, char *argv[], int last_arg
 		pkgconf_buffer_t render_buf = PKGCONF_BUFFER_INITIALIZER;
 
 		if ((state->want_flags & PKG_CFLAGS))
-			apply_cflags(&state->pkg_client, &world, &target_list, 2);
+		{
+			if (!apply_cflags(&state->pkg_client, &world, &target_list, 2))
+			{
+				fprintf(stderr, "pkgconf: failed to apply cflags\n");
+				ret = EXIT_FAILURE;
+				goto out;
+			}
+		}
 
 		if ((state->want_flags & PKG_LIBS) && !(state->want_flags & PKG_STATIC))
 			pkgconf_client_set_flags(&state->pkg_client, state->pkg_client.flags & ~PKGCONF_PKG_PKGF_SEARCH_PRIVATE);
 
 		if ((state->want_flags & PKG_LIBS))
-			apply_libs(&state->pkg_client, &world, &target_list, 2);
+		{
+			if (!apply_libs(&state->pkg_client, &world, &target_list, 2))
+			{
+				fprintf(stderr, "pkgconf: failed to apply libs\n");
+				ret = EXIT_FAILURE;
+				goto out;
+			}
+		}
 
-		pkgconf_fragment_render_buf(&target_list, &render_buf, true, state->want_render_ops, (state->want_flags & PKG_NEWLINES) ? '\n' : ' ');
-		pkgconf_output_putbuf(state->pkg_client.output, PKGCONF_OUTPUT_STDOUT, &render_buf, true);
+		if (!pkgconf_fragment_render_buf(&target_list, &render_buf, true, state->want_render_ops, (state->want_flags & PKG_NEWLINES) ? '\n' : ' '))
+		{
+			fprintf(stderr, "pkgconf: failed to render fragment buffer\n");
+			ret = EXIT_FAILURE;
+			goto out;
+		}
+
+		if (!pkgconf_output_putbuf(state->pkg_client.output, PKGCONF_OUTPUT_STDOUT, &render_buf, true))
+		{
+			fprintf(stderr, "pkgconf: failed to output to stdout: %s\n", strerror(errno));
+			ret = EXIT_FAILURE;
+			goto out;
+		}
+
 		pkgconf_buffer_finalize(&render_buf);
 
 		pkgconf_fragment_free(&target_list);

--- a/cli/core.c
+++ b/cli/core.c
@@ -31,18 +31,26 @@ print_list_entry(const pkgconf_pkg_t *entry, void *data)
 	if (entry->flags & PKGCONF_PKG_PROPF_UNINSTALLED)
 		return false;
 
-	pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT,
-			"%-30s %s - %s\n", entry->id, entry->realname, entry->description);
+	if (!pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT,
+			"%-30s %s - %s\n", entry->id, entry->realname, entry->description))
+	{
+		return true;
+	}
 
 	PKGCONF_FOREACH_LIST_ENTRY(entry->provides.head, n)
 	{
 		const pkgconf_dependency_t *dep = n->data;
+		if (!dep)
+			return true;
 
 		if (!strcmp(dep->package, entry->id))
 			continue;
 
-		pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT,
-			"%-30s %s - %s (provided by %s)\n", dep->package, entry->realname, entry->description, entry->id);
+		if (!pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT,
+			"%-30s %s - %s (provided by %s)\n", dep->package, entry->realname, entry->description, entry->id))
+		{
+			return true;
+		}
 	}
 
 	return false;
@@ -57,16 +65,20 @@ print_package_entry(const pkgconf_pkg_t *entry, void *data)
 	if (entry->flags & PKGCONF_PKG_PROPF_UNINSTALLED)
 		return false;
 
-	pkgconf_output_puts(client->output, PKGCONF_OUTPUT_STDOUT, entry->id);
+	if (!pkgconf_output_puts(client->output, PKGCONF_OUTPUT_STDOUT, entry->id))
+		return true;
 
 	PKGCONF_FOREACH_LIST_ENTRY(entry->provides.head, n)
 	{
 		const pkgconf_dependency_t *dep = n->data;
+		if (!dep)
+			return true;
 
 		if (!strcmp(dep->package, entry->id))
 			continue;
 
-		pkgconf_output_puts(client->output, PKGCONF_OUTPUT_STDOUT, dep->package);
+		if (!pkgconf_output_puts(client->output, PKGCONF_OUTPUT_STDOUT, dep->package))
+			return true;
 	}
 
 	return false;
@@ -116,7 +128,7 @@ filter_libs(const pkgconf_client_t *client, const pkgconf_fragment_t *frag, void
 	return (state->want_flags & got_flags) != 0;
 }
 
-static void
+static bool
 print_variables(pkgconf_output_t *output, pkgconf_pkg_t *pkg)
 {
 	pkgconf_node_t *node;
@@ -125,11 +137,14 @@ print_variables(pkgconf_output_t *output, pkgconf_pkg_t *pkg)
 	{
 		pkgconf_tuple_t *tuple = node->data;
 
-		pkgconf_output_puts(output, PKGCONF_OUTPUT_STDOUT, tuple->key);
+		if (!pkgconf_output_puts(output, PKGCONF_OUTPUT_STDOUT, tuple->key))
+			return false;
 	}
+
+	return true;
 }
 
-static void
+static bool
 print_dependency_list(pkgconf_output_t *output, pkgconf_list_t *list)
 {
 	pkgconf_node_t *node;
@@ -138,14 +153,23 @@ print_dependency_list(pkgconf_output_t *output, pkgconf_list_t *list)
 	{
 		pkgconf_dependency_t *dep = node->data;
 
-		pkgconf_output_fmt(output, PKGCONF_OUTPUT_STDOUT, "%s", dep->package);
+		if (!pkgconf_output_fmt(output, PKGCONF_OUTPUT_STDOUT, "%s", dep->package))
+			return false;
 
 		if (dep->version != NULL)
-			pkgconf_output_fmt(output, PKGCONF_OUTPUT_STDOUT, " %s %s",
-				pkgconf_pkg_get_comparator(dep), dep->version);
+		{
+			if (!pkgconf_output_fmt(output, PKGCONF_OUTPUT_STDOUT, " %s %s",
+				pkgconf_pkg_get_comparator(dep), dep->version))
+			{
+				return false;
+			}
+		}
 
-		pkgconf_output_fmt(output, PKGCONF_OUTPUT_STDOUT, "\n");
+		if (!pkgconf_output_fmt(output, PKGCONF_OUTPUT_STDOUT, "\n"))
+			return false;
 	}
+
+	return true;
 }
 
 static bool
@@ -160,34 +184,45 @@ apply_provides(pkgconf_client_t *client, pkgconf_pkg_t *world, void *unused, int
 		pkgconf_dependency_t *dep = iter->data;
 		pkgconf_pkg_t *pkg = dep->match;
 
-		print_dependency_list(client->output, &pkg->provides);
+		if (!print_dependency_list(client->output, &pkg->provides))
+			return false;
 	}
 
 	return true;
 }
 
 #ifndef PKGCONF_LITE
-static void
+static bool
 print_digraph_node(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *data)
 {
 	pkgconf_node_t *node;
 	pkgconf_pkg_t **last_seen = data;
 
 	if (pkg->flags & PKGCONF_PKG_PROPF_VIRTUAL)
-		return;
+		return true;
 
-	pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "\"%s\" [fontname=Sans fontsize=8", pkg->id);
+	if (!pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "\"%s\" [fontname=Sans fontsize=8", pkg->id))
+		return false;
 
 	if (pkg->flags & PKGCONF_PKG_PROPF_VISITED_PRIVATE)
-		pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, " fontcolor=gray color=gray");
+	{
+		if (!pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, " fontcolor=gray color=gray"))
+			return false;
+	}
 
-	pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, " label=\"%s@%s\"]\n", pkg->id, pkg->version);
+	if (!pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, " label=\"%s@%s\"]\n", pkg->id, pkg->version))
+		return false;
 
 	if (last_seen != NULL)
 	{
 		if (*last_seen != NULL)
-			pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT,
-				"\"%s\" -> \"%s\" [fontname=Sans fontsize=8 color=red]\n", (*last_seen)->id, pkg->id);
+		{
+			if (!pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT,
+				"\"%s\" -> \"%s\" [fontname=Sans fontsize=8 color=red]\n", (*last_seen)->id, pkg->id))
+			{
+				return false;
+			}
+		}
 
 		*last_seen = pkg;
 	}
@@ -195,24 +230,39 @@ print_digraph_node(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *data)
 	PKGCONF_FOREACH_LIST_ENTRY(pkg->required.head, node)
 	{
 		pkgconf_dependency_t *dep = node->data;
+		if (!dep)
+			return false;
 		const char *dep_id = (dep->match != NULL) ? dep->match->id : dep->package;
 
-		pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "\"%s\" -> \"%s\" [fontname=Sans fontsize=8",
-			pkg->id, dep_id);
+		if (!pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "\"%s\" -> \"%s\" [fontname=Sans fontsize=8",
+			pkg->id, dep_id))
+		{
+			return false;
+		}
 
 		if (dep->flags & PKGCONF_PKG_DEPF_PRIVATE)
-			pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, " color=gray");
+		{
+			if (!pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, " color=gray"))
+				return false;
+		}
 
-		pkgconf_output_puts(client->output, PKGCONF_OUTPUT_STDOUT, "]");
+		if (!pkgconf_output_puts(client->output, PKGCONF_OUTPUT_STDOUT, "]"))
+			return false;
 	}
 
 	PKGCONF_FOREACH_LIST_ENTRY(pkg->requires_private.head, node)
 	{
 		pkgconf_dependency_t *dep = node->data;
+		if (!dep)
+			return false;
+
 		const char *dep_id = (dep->match != NULL) ? dep->match->id : dep->package;
 
-		pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT,
-			"\"%s\" -> \"%s\" [fontname=Sans fontsize=8 color=gray]\n", pkg->id, dep_id);
+		if (!pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT,
+			"\"%s\" -> \"%s\" [fontname=Sans fontsize=8 color=gray]\n", pkg->id, dep_id))
+		{
+			return false;
+		}
 	}
 
 	if (!(client->flags & PKGCONF_PKG_PKGF_MERGE_PRIVATE_FRAGMENTS))
@@ -220,11 +270,19 @@ print_digraph_node(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *data)
 		PKGCONF_FOREACH_LIST_ENTRY(pkg->requires_shared.head, node)
 		{
 			pkgconf_dependency_t *dep = node->data;
+			if (!dep)
+				return false;
+
 			const char *dep_id = (dep->match != NULL) ? dep->match->id : dep->package;
-			pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT,
-				"\"%s\" -> \"%s\" [fontname=Sans fontsize=8 color=orange]\n", pkg->id, dep_id);
+			if (!pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT,
+				"\"%s\" -> \"%s\" [fontname=Sans fontsize=8 color=orange]\n", pkg->id, dep_id))
+			{
+				return false;
+			}
 		}
 	}
+
+	return true;
 }
 
 static bool
@@ -243,17 +301,26 @@ apply_digraph(pkgconf_client_t *client, pkgconf_pkg_t *world, void *data, int ma
 
 	if (state->want_flags & PKG_PRINT_DIGRAPH_QUERY_NODES)
 	{
-		pkgconf_output_puts(client->output, PKGCONF_OUTPUT_STDOUT,
-			"\"user:request\" [fontname=Sans fontsize=8]\n");
+		if (!pkgconf_output_puts(client->output, PKGCONF_OUTPUT_STDOUT,
+			"\"user:request\" [fontname=Sans fontsize=8]\n"))
+		{
+			return false;
+		}
 
 		PKGCONF_FOREACH_LIST_ENTRY(list->head, iter)
 		{
 			pkgconf_queue_t *pkgq = iter->data;
+			if (!pkgq)
+				return false;
+
 			pkgconf_pkg_t *pkg = pkgconf_pkg_find(client, pkgq->package);
 
-			pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT,
+			if (!pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT,
 				"\"user:request\" -> \"%s\" [fontname=Sans fontsize=8]\n",
-				pkg == NULL ? pkgq->package : pkg->id);
+				pkg == NULL ? pkgq->package : pkg->id))
+			{
+				return false;
+			}
 
 			if (pkg != NULL)
 				pkgconf_pkg_unref(client, pkg);
@@ -265,16 +332,15 @@ apply_digraph(pkgconf_client_t *client, pkgconf_pkg_t *world, void *data, int ma
 	if (eflag != PKGCONF_PKG_ERRF_OK)
 		return false;
 
-	pkgconf_output_puts(client->output, PKGCONF_OUTPUT_STDOUT, "}");
-	return true;
+	return pkgconf_output_puts(client->output, PKGCONF_OUTPUT_STDOUT, "}");
 }
 
-static void
+static bool
 print_solution_node(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *unused)
 {
 	(void) unused;
 
-	pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "%s (%"PRIu64")%s\n",
+	return pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "%s (%"PRIu64")%s\n",
 		pkg->id, pkg->identifier,
 		(pkg->flags & PKGCONF_PKG_PROPF_VISITED_PRIVATE) == PKGCONF_PKG_PROPF_VISITED_PRIVATE ? " [private]" : "");
 }
@@ -668,7 +734,7 @@ apply_requires_private(pkgconf_client_t *client, pkgconf_pkg_t *world, void *unu
 	return true;
 }
 
-static void
+static bool
 check_uninstalled(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *data)
 {
 	int *retval = data;
@@ -676,6 +742,8 @@ check_uninstalled(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *data)
 
 	if (pkg->flags & PKGCONF_PKG_PROPF_UNINSTALLED)
 		*retval = EXIT_SUCCESS;
+
+	return true;
 }
 
 static bool
@@ -692,38 +760,51 @@ apply_uninstalled(pkgconf_client_t *client, pkgconf_pkg_t *world, void *data, in
 }
 
 #ifndef PKGCONF_LITE
-static void
+static bool
 print_graph_node(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *data)
 {
 	pkgconf_node_t *n;
 
 	(void) data;
 
-	pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "node '%s' {\n", pkg->id);
+	if (!pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "node '%s' {\n", pkg->id))
+		return false;
 
 	if (pkg->version != NULL)
-		pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "    version = '%s';\n", pkg->version);
+	{
+		if (!pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "    version = '%s';\n", pkg->version))
+			return false;
+	}
 
 	PKGCONF_FOREACH_LIST_ENTRY(pkg->required.head, n)
 	{
 		pkgconf_dependency_t *dep = n->data;
+		if (!dep)
+			return false;
 
-		pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "    dependency '%s'", dep->package);
+		if (!pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "    dependency '%s'", dep->package))
+			return false;
 
 		if (dep->compare != PKGCONF_CMP_ANY)
 		{
-			pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT,
+			if (!pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT,
 				" {\n"
 				"        comparator = '%s';\n"
 				"        version = '%s';\n"
 				"    };\n",
-				pkgconf_pkg_get_comparator(dep), dep->version);
+				pkgconf_pkg_get_comparator(dep), dep->version))
+			{
+				return false;
+			}
 		}
 		else
-			pkgconf_output_puts(client->output, PKGCONF_OUTPUT_STDOUT, ";");
+		{
+			if (!pkgconf_output_puts(client->output, PKGCONF_OUTPUT_STDOUT, ";"))
+				return false;
+		}
 	}
 
-	pkgconf_output_puts(client->output, PKGCONF_OUTPUT_STDOUT, "};");
+	return pkgconf_output_puts(client->output, PKGCONF_OUTPUT_STDOUT, "};");
 }
 
 static bool
@@ -785,28 +866,36 @@ apply_fragment_tree(pkgconf_client_t *client, pkgconf_pkg_t *world, void *data, 
 	return true;
 }
 
-static void
+static bool
 print_license(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *data)
 {
 	pkgconf_buffer_t render_buf = PKGCONF_BUFFER_INITIALIZER;
 	(void) data;
 
 	if (pkg->flags & PKGCONF_PKG_PROPF_VIRTUAL)
-		return;
+		return true;
 
 	if (pkg->license.head == NULL)
 	{
-		pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT,
-				"%s: NOASSERTION\n", pkg->id);
+		if (!pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT,
+				"%s: NOASSERTION\n", pkg->id))
+		{
+			return false;
+		}
 	}
 	else
 	{
 		/* NOASSERTION is the default when the license is unknown, per SPDX spec § 3.15 */
-		pkgconf_license_render(client, &pkg->license, &render_buf);
-		pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "%s: ", pkg->id);
-		pkgconf_output_putbuf(client->output, PKGCONF_OUTPUT_STDOUT, &render_buf, true);
+		if (!pkgconf_license_render(client, &pkg->license, &render_buf)
+			|| !pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "%s: ", pkg->id)
+			|| !pkgconf_output_putbuf(client->output, PKGCONF_OUTPUT_STDOUT, &render_buf, true))
+		{
+			return false;
+		}
 		pkgconf_buffer_finalize(&render_buf);
 	}
+
+	return true;
 }
 
 static bool
@@ -822,16 +911,16 @@ apply_license(pkgconf_client_t *client, pkgconf_pkg_t *world, void *data, int ma
 	return true;
 }
 
-static void
+static bool
 print_license_file(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *data)
 {
 	(void) data;
 
 	if (pkg->flags & PKGCONF_PKG_PROPF_VIRTUAL)
-		return;
+		return true;
 
 	/* If license file location is not available then just print empty */
-	pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "%s: %s\n",
+	return pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "%s: %s\n",
 		pkg->id, pkg->license_file != NULL ? pkg->license_file : "");
 }
 
@@ -848,16 +937,16 @@ apply_license_file(pkgconf_client_t *client, pkgconf_pkg_t *world, void *data, i
 	return true;
 }
 
-static void
+static bool
 print_source(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *data)
 {
 	(void) data;
 
 	if (pkg->flags & PKGCONF_PKG_PROPF_VIRTUAL)
-		return;
+		return true;
 
 	/* If source is empty then empty string is printed otherwise URL */
-	pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "%s: %s\n",
+	return pkgconf_output_fmt(client->output, PKGCONF_OUTPUT_STDOUT, "%s: %s\n",
 		pkg->id, pkg->source != NULL ? pkg->source : "");
 }
 

--- a/cli/core.h
+++ b/cli/core.h
@@ -93,8 +93,8 @@ typedef struct {
 	bool opened_error_msgout;
 } pkgconf_cli_state_t;
 
-extern void path_list_to_buffer(const pkgconf_list_t *list, pkgconf_buffer_t *buffer, char delim);
-extern int pkgconf_cli_run(pkgconf_cli_state_t *state, int argc, char *argv[], int last_argc);
-extern void pkgconf_cli_state_reset(pkgconf_cli_state_t *state);
+bool path_list_to_buffer(const pkgconf_list_t *list, pkgconf_buffer_t *buffer, char delim);
+int pkgconf_cli_run(pkgconf_cli_state_t *state, int argc, char *argv[], int last_argc);
+void pkgconf_cli_state_reset(pkgconf_cli_state_t *state);
 
 #endif

--- a/cli/renderer-msvc.c
+++ b/cli/renderer-msvc.c
@@ -48,41 +48,59 @@ allowed_fragment(const pkgconf_fragment_t *frag)
 	return !(!frag->type || frag->data == NULL || strchr("DILl", frag->type) == NULL);
 }
 
-static void
+static bool
 msvc_renderer_render(const pkgconf_fragment_render_ctx_t *ctx, const pkgconf_fragment_t *frag, pkgconf_buffer_t *buf)
 {
 	pkgconf_buffer_t tmpbuf = PKGCONF_BUFFER_INITIALIZER;
 	bool escape = ctx->escape;
+	bool success = false;
 
 	if (!allowed_fragment(frag))
-		return;
+		return true;
 
 	switch(frag->type) {
 	case 'D':
 	case 'I':
-		pkgconf_buffer_append_fmt(buf, "/%c", frag->type);
+		if (!pkgconf_buffer_append_fmt(buf, "/%c", frag->type))
+			goto out;
 		break;
 	case 'L':
-		pkgconf_buffer_append(buf, "/libpath:");
+		if (!pkgconf_buffer_append(buf, "/libpath:"))
+			goto out;
 		break;
 	}
 
-	pkgconf_buffer_append(&tmpbuf, frag->data);
+	if (!pkgconf_buffer_append(&tmpbuf, frag->data))
+		goto out;
 
 	if (frag->type == 'l')
-		pkgconf_buffer_append(&tmpbuf, ".lib");
+	{
+		if (!pkgconf_buffer_append(&tmpbuf, ".lib"))
+			goto out;
+	}
 
 	escape = should_quote(&tmpbuf);
 
 	if (escape)
-		pkgconf_buffer_push_byte(buf, '"');
+	{
+		if (!pkgconf_buffer_push_byte(buf, '"'))
+			goto out;
+	}
 
-	pkgconf_buffer_append(buf, pkgconf_buffer_str_or_empty(&tmpbuf));
+	if (!pkgconf_buffer_append(buf, pkgconf_buffer_str_or_empty(&tmpbuf)))
+		goto out;
 
 	if (escape)
-		pkgconf_buffer_push_byte(buf, '"');
+	{
+		if (!pkgconf_buffer_push_byte(buf, '"'))
+			goto out;
+	}
 
+	success = true;
+
+out:
 	pkgconf_buffer_finalize(&tmpbuf);
+	return success;
 }
 
 static pkgconf_fragment_render_ops_t msvc_renderer_ops = {

--- a/cli/spdxtool/main.c
+++ b/cli/spdxtool/main.c
@@ -94,7 +94,8 @@ generate_spdx_package(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *ptr)
 	{
 		pkgconf_buffer_t spdx_id_buf = PKGCONF_BUFFER_INITIALIZER;
 
-		pkgconf_buffer_append_fmt(&spdx_id_buf, "%s%chasDeclaredLicense", pkg->id, sep);
+		if (!pkgconf_buffer_append_fmt(&spdx_id_buf, "%s%chasDeclaredLicense", pkg->id, sep))
+			goto err;
 		char *spdx_id_name = pkgconf_buffer_freeze(&spdx_id_buf);
 		if (!spdx_id_name)
 			goto err;
@@ -104,12 +105,14 @@ generate_spdx_package(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *ptr)
 		if (!package_spdx)
 			goto err;
 
-		pkgconf_tuple_add(client, &pkg->vars, "hasDeclaredLicense", package_spdx, false, 0);
+		if (!pkgconf_tuple_add(client, &pkg->vars, "hasDeclaredLicense", package_spdx, false, 0))
+			goto err;
 		free(package_spdx);
 		package_spdx = NULL;
 
 		pkgconf_buffer_t concluded_buf = PKGCONF_BUFFER_INITIALIZER;
-		pkgconf_buffer_append_fmt(&concluded_buf, "%s%chasConcludedLicense", pkg->id, sep);
+		if (!pkgconf_buffer_append_fmt(&concluded_buf, "%s%chasConcludedLicense", pkg->id, sep))
+			goto err;
 		spdx_id_name = pkgconf_buffer_freeze(&concluded_buf);
 		if (!spdx_id_name)
 			goto err;
@@ -119,7 +122,8 @@ generate_spdx_package(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *ptr)
 		if (!package_spdx)
 			goto err;
 
-		pkgconf_tuple_add(client, &pkg->vars, "hasConcludedLicense", package_spdx, false, 0);
+		if (!pkgconf_tuple_add(client, &pkg->vars, "hasConcludedLicense", package_spdx, false, 0))
+			goto err;
 		free(package_spdx);
 		package_spdx = NULL;
 
@@ -190,7 +194,7 @@ generate_spdx(pkgconf_client_t *client, pkgconf_pkg_t *world, const char *creati
 		return false;
 	}
 
-    spdxtool_serialize_value_t *root = spdxtool_serialize_sbom(client, agent, creation, document);
+	spdxtool_serialize_value_t *root = spdxtool_serialize_sbom(client, agent, creation, document);
 	if (!root)
 	{
 		spdxtool_core_spdx_document_free(document);
@@ -199,11 +203,15 @@ generate_spdx(pkgconf_client_t *client, pkgconf_pkg_t *world, const char *creati
 		return false;
 	}
 
-    pkgconf_buffer_t buffer = PKGCONF_BUFFER_INITIALIZER;
-	spdxtool_serialize_value_to_buf(&buffer, root, 0);
+	pkgconf_buffer_t buffer = PKGCONF_BUFFER_INITIALIZER;
+	if (!spdxtool_serialize_value_to_buf(&buffer, root, 0))
+		return false;
+
 	spdxtool_serialize_value_free(root);
 
-	fprintf(sbom_out, "%s\n", pkgconf_buffer_str(&buffer));
+	if (fprintf(sbom_out, "%s\n", pkgconf_buffer_str(&buffer)) <= 0)
+		return false;
+
 	pkgconf_buffer_finalize(&buffer);
 
 	spdxtool_core_spdx_document_free(document);
@@ -328,14 +336,23 @@ main(int argc, char *argv[])
 		}
 	}
 
-	pkgconf_client_init(&pkg_client, error_handler, NULL, personality, NULL, environ_lookup_handler);
+	if (!pkgconf_client_init(&pkg_client, error_handler, NULL, personality, NULL, environ_lookup_handler))
+	{
+		fprintf(stderr, "spdxtool: failed to initialize pkgconf client\n");
+		ret = EXIT_FAILURE;
+		goto out;
+	}
 
 	/* we have determined what features we want most likely.  in some cases, we override later. */
 	pkgconf_client_set_flags(&pkg_client, want_client_flags);
 
 	/* at this point, want_client_flags should be set, so build the dir list */
-	pkgconf_client_dir_list_build(&pkg_client, personality);
-
+	if (!pkgconf_client_dir_list_build(&pkg_client, personality))
+	{
+		fprintf(stderr, "spdxtool: failed to build client dir list\n");
+		ret = EXIT_FAILURE;
+		goto out;
+	}
 
 	if ((want_flags & PKG_ABOUT) == PKG_ABOUT)
 		return about();
@@ -371,7 +388,12 @@ main(int argc, char *argv[])
 
 		if (argv[pkg_optind + 1] == NULL || !PKGCONF_IS_OPERATOR_CHAR(*(argv[pkg_optind + 1])))
 		{
-			pkgconf_queue_push(&pkgq, package);
+			if (!pkgconf_queue_push(&pkgq, package))
+			{
+				fprintf(stderr, "spdxtool: failed to push package to queue\n");
+				ret = EXIT_FAILURE;
+				goto out;
+			}
 			pkg_optind++;
 		}
 		else
@@ -381,20 +403,32 @@ main(int argc, char *argv[])
 			snprintf(packagebuf, sizeof packagebuf, "%s %s %s", package, argv[pkg_optind + 1], argv[pkg_optind + 2]);
 			pkg_optind += 3;
 
-			pkgconf_queue_push(&pkgq, packagebuf);
+			if (!pkgconf_queue_push(&pkgq, packagebuf))
+			{
+				fprintf(stderr, "spdxtool: failed to push package to queue\n");
+				ret = EXIT_FAILURE;
+				goto out;
+			}
 		}
 	}
 
 	if (!pkgconf_queue_solve(&pkg_client, &pkgq, &world, maximum_traverse_depth))
 	{
+		fprintf(stderr, "spdxtool: failed to solve packages in queue\n");
 		ret = EXIT_FAILURE;
 		goto out;
 	}
 
-	spdxtool_util_set_uri_root(&pkg_client, spdx_id_base);
 	spdxtool_util_set_uri_separator_colon(&pkg_client, colon_sep);
-	spdxtool_util_set_spdx_license(&pkg_client, bom_license);
-	spdxtool_util_set_spdx_version(&pkg_client, spdx_version);
+
+	if (!(spdxtool_util_set_uri_root(&pkg_client, spdx_id_base)
+		&& spdxtool_util_set_spdx_license(&pkg_client, bom_license)
+		&& spdxtool_util_set_spdx_version(&pkg_client, spdx_version)))
+	{
+		fprintf(stderr, "spdxtool: failed to set client info\n");
+		ret = EXIT_FAILURE;
+		goto out;
+	}
 
 	if (!generate_spdx(&pkg_client, &world, creation_time, creation_id, agent_name))
 	{

--- a/cli/spdxtool/main.c
+++ b/cli/spdxtool/main.c
@@ -53,7 +53,7 @@ error_handler(const char *msg, const pkgconf_client_t *client, void *data)
 }
 
 // NOTE: this function is passed to pkgconf_pkg_traverse
-static void
+static bool
 generate_spdx_package(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *ptr)
 {
 	spdxtool_core_spdx_document_t *document = (spdxtool_core_spdx_document_t *)ptr;
@@ -64,7 +64,7 @@ generate_spdx_package(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *ptr)
 	char sep = spdxtool_util_get_uri_separator(client);
 
 	if (pkg->flags & PKGCONF_PKG_PROPF_VIRTUAL)
-		return;
+		return true;
 
 	spdx_id_string = spdxtool_util_get_spdx_id_string(client, "software_Sbom", pkg->id);
 	if (!spdx_id_string)
@@ -139,13 +139,14 @@ generate_spdx_package(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *ptr)
 		goto err;
 
 	pkgconf_node_insert_tail(node, sbom, &document->rootElement);
-	return;
+	return true;
 
 err:
 	pkgconf_error(client, "generate_spdx_package: failed for %s", pkg->id);
 	free(package_spdx);
 	free(spdx_id_string);
 	spdxtool_software_sbom_free(sbom);
+	return false;
 }
 
 static bool

--- a/cli/spdxtool/serialize.c
+++ b/cli/spdxtool/serialize.c
@@ -18,7 +18,7 @@
 #include "simplelicensing.h"
 #include "serialize.h"
 
-static void
+static bool
 serialize_escape_string(pkgconf_buffer_t *buffer, const char *s)
 {
 	for (const char *p = s; *p; p++)
@@ -26,46 +26,66 @@ serialize_escape_string(pkgconf_buffer_t *buffer, const char *s)
 		switch (*p)
 		{
 		case '\"':
-			pkgconf_buffer_append(buffer, "\\\"");
+			if (!pkgconf_buffer_append(buffer, "\\\""))
+				return false;
 			break;
 		case '\\':
-			pkgconf_buffer_append(buffer, "\\\\");
+			if (!pkgconf_buffer_append(buffer, "\\\\"))
+				return false;
 			break;
 		case '\b':
-			pkgconf_buffer_append(buffer, "\\b");
+			if (!pkgconf_buffer_append(buffer, "\\b"))
+				return false;
 			break;
 		case '\f':
-			pkgconf_buffer_append(buffer, "\\f");
+			if (!pkgconf_buffer_append(buffer, "\\f"))
+				return false;
 			break;
 		case '\n':
-			pkgconf_buffer_append(buffer, "\\n");
+			if (!pkgconf_buffer_append(buffer, "\\n"))
+				return false;
 			break;
 		case '\r':
-			pkgconf_buffer_append(buffer, "\\r");
+			if (!pkgconf_buffer_append(buffer, "\\r"))
+				return false;
 			break;
 		case '\t':
-			pkgconf_buffer_append(buffer, "\\t");
+			if (!pkgconf_buffer_append(buffer, "\\t"))
+				return false;
 			break;
 		default:
 			if (*p < 0x20)
-				pkgconf_buffer_append_fmt(buffer, "\\u%04x", (unsigned int)*p);
+			{
+				if (!pkgconf_buffer_append_fmt(buffer, "\\u%04x", (unsigned int)*p))
+					return false;
+			}
 			else
-				pkgconf_buffer_push_byte(buffer, *p);
+			{
+				if (!pkgconf_buffer_push_byte(buffer, *p))
+					return false;
+			}
 		}
 	}
+
+	return true;
 }
 
-static inline void
+static inline bool
 serialize_add_indent(pkgconf_buffer_t *buffer, unsigned int level)
 {
 	for (; level; level--)
-		pkgconf_buffer_append(buffer, "    ");
+	{
+		if (!pkgconf_buffer_append(buffer, "    "))
+			return false;
+	}
+
+	return true;
 }
 
 /*
  * !doc
  *
- * .. c:function:: void spdxtool_serialize_value_to_buf(pkgconf_buffer_t *buffer, spdxtool_serialize_value_t *value, unsigned int indent)
+ * .. c:function:: bool spdxtool_serialize_value_to_buf(pkgconf_buffer_t *buffer, spdxtool_serialize_value_t *value, unsigned int indent)
  *
  *    Serialize the given JSON to the buffer
  *
@@ -82,57 +102,96 @@ spdxtool_serialize_value_to_buf(pkgconf_buffer_t *buffer, spdxtool_serialize_val
 
 	switch(value->type) {
 		case SPDXTOOL_SERIALIZE_TYPE_STRING:
-			pkgconf_buffer_push_byte(buffer, '"');
-			serialize_escape_string(buffer, value->value.s ? value->value.s : "");
-			pkgconf_buffer_push_byte(buffer, '"');
+			if (!(pkgconf_buffer_push_byte(buffer, '"')
+				&& serialize_escape_string(buffer, value->value.s ? value->value.s : "")
+				&& pkgconf_buffer_push_byte(buffer, '"')))
+			{
+				return false;
+			}
 			break;
 		case SPDXTOOL_SERIALIZE_TYPE_INT:
-			pkgconf_buffer_append_fmt(buffer, "%d", value->value.i);
+			if (!pkgconf_buffer_append_fmt(buffer, "%d", value->value.i))
+				return false;
 			break;
 		case SPDXTOOL_SERIALIZE_TYPE_BOOL:
-			pkgconf_buffer_append(buffer, value->value.b ? "true" : "false");
+			if (!pkgconf_buffer_append(buffer, value->value.b ? "true" : "false"))
+				return false;
 			break;
 		case SPDXTOOL_SERIALIZE_TYPE_NULL:
-			pkgconf_buffer_append(buffer, "null");
+			if (!pkgconf_buffer_append(buffer, "null"))
+				return false;
 			break;
 		case SPDXTOOL_SERIALIZE_TYPE_OBJECT:
 		{
 			pkgconf_node_t *iter;
-			pkgconf_buffer_push_byte(buffer, '{');
-			pkgconf_buffer_push_byte(buffer, '\n');
+			if (!(pkgconf_buffer_push_byte(buffer, '{')
+				&& pkgconf_buffer_push_byte(buffer, '\n')))
+			{
+				return false;
+			}
 
 			PKGCONF_FOREACH_LIST_ENTRY(value->value.o->entries.head, iter)
 			{
 				spdxtool_serialize_object_t *entry = iter->data;
-				serialize_add_indent(buffer, indent + 1);
-				pkgconf_buffer_append_fmt(buffer, "\"%s\": ", entry->key);
-				spdxtool_serialize_value_to_buf(buffer, entry->value, indent + 1);
+				if (!entry)
+					return false;
+
+				if (!(serialize_add_indent(buffer, indent + 1)
+					&& pkgconf_buffer_append_fmt(buffer, "\"%s\": ", entry->key)
+					&& spdxtool_serialize_value_to_buf(buffer, entry->value, indent + 1)))
+				{
+					return false;
+				}
+
 				if (iter->next)
-					pkgconf_buffer_push_byte(buffer, ',');
-				pkgconf_buffer_push_byte(buffer, '\n');
+				{
+					if (!pkgconf_buffer_push_byte(buffer, ','))
+						return false;
+				}
+
+				if (!pkgconf_buffer_push_byte(buffer, '\n'))
+					return false;
 			}
 
-			serialize_add_indent(buffer, indent);
-			pkgconf_buffer_push_byte(buffer, '}');
+			if (!(serialize_add_indent(buffer, indent) && pkgconf_buffer_push_byte(buffer, '}')))
+				return false;
+
 			break;
 		}
 		case SPDXTOOL_SERIALIZE_TYPE_ARRAY:
 		{
 			pkgconf_node_t *iter;
-			pkgconf_buffer_push_byte(buffer, '[');
-			pkgconf_buffer_push_byte(buffer, '\n');
+			if (!(pkgconf_buffer_push_byte(buffer, '[')
+				&& pkgconf_buffer_push_byte(buffer, '\n')))
+			{
+				return false;
+			}
 
 			PKGCONF_FOREACH_LIST_ENTRY(value->value.a->items.head, iter)
 			{
 				spdxtool_serialize_value_t *entry = iter->data;
-				serialize_add_indent(buffer, indent + 1);
-				spdxtool_serialize_value_to_buf(buffer, entry, indent + 1);
-				if (iter->next)
-					pkgconf_buffer_push_byte(buffer, ',');
-				pkgconf_buffer_push_byte(buffer, '\n');
+				if (!entry)
+					return false;
+
+				if (!(serialize_add_indent(buffer, indent + 1)
+					&& spdxtool_serialize_value_to_buf(buffer, entry, indent + 1)))
+				{
+					return false;
+				}
+
+				if (iter->next && !pkgconf_buffer_push_byte(buffer, ','))
+					return false;
+
+				if (!pkgconf_buffer_push_byte(buffer, '\n'))
+					return false;
 			}
-			serialize_add_indent(buffer, indent);
-			pkgconf_buffer_push_byte(buffer, ']');
+
+			if (!(serialize_add_indent(buffer, indent)
+				&& pkgconf_buffer_push_byte(buffer, ']')))
+			{
+				return false;
+			}
+
 			break;
 		}
 	}

--- a/cli/spdxtool/software.c
+++ b/cli/spdxtool/software.c
@@ -137,7 +137,8 @@ spdxtool_software_sbom_to_object(pkgconf_client_t *client, spdxtool_software_sbo
 		pkgconf_pkg_t *match = dep->match;
 		pkgconf_buffer_t relationship_buf = PKGCONF_BUFFER_INITIALIZER;
 
-		pkgconf_buffer_append_fmt(&relationship_buf, "%s%cdependsOn%c%s", sbom->rootElement->id, sep, sep, match->id);
+		if (!pkgconf_buffer_append_fmt(&relationship_buf, "%s%cdependsOn%c%s", sbom->rootElement->id, sep, sep, match->id))
+			goto err;
 		char *relationship_str = pkgconf_buffer_freeze(&relationship_buf);
 		if (!relationship_str)
 			goto err;
@@ -247,7 +248,8 @@ serialize_copyright_lines_to_object(spdxtool_serialize_object_list_t *object_lis
 	PKGCONF_FOREACH_LIST_ENTRY(copyright_lines->head, node)
 	{
 		const pkgconf_bufferset_t *set = node->data;
-		pkgconf_buffer_join(&copyright_buf, '\n', pkgconf_buffer_str_or_empty(&set->buffer), NULL);
+		if (!set || !pkgconf_buffer_join(&copyright_buf, '\n', pkgconf_buffer_str_or_empty(&set->buffer), NULL))
+			return false;
 	}
 
 	bool ok = spdxtool_serialize_object_add_string(object_list, "software_copyrightText", pkgconf_buffer_str_or_empty(&copyright_buf)) != NULL;

--- a/cli/spdxtool/util.c
+++ b/cli/spdxtool/util.c
@@ -19,7 +19,7 @@
 /*
  * !doc
  *
- * .. c:function:: void spdxtool_util_set_key(pkgconf_client_t *client, const char *key, const char *key_value, const char *key_default)
+ * .. c:function:: bool spdxtool_util_set_key(pkgconf_client_t *client, const char *key, const char *key_value, const char *key_default)
  *
  *    Set key wit default value. Default value is used if key is NULL
  *
@@ -27,31 +27,31 @@
  *    :param const char *key: Key to be preserved
  *    :param const char *key_value: Value for key
  *    :param const char *key_default: Default value if key_value is NULL
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on failure.
  */
-void
+bool
 spdxtool_util_set_key(pkgconf_client_t *client, const char *key, const char *key_value, const char *key_default)
 {
 	PKGCONF_TRACE(client, "set uri_root to: %s", key_value != NULL ? key_value : key_default);
-	pkgconf_tuple_add_global(client, key, key_value != NULL ? key_value : key_default);
+	return pkgconf_tuple_add_global(client, key, key_value != NULL ? key_value : key_default);
 }
 
 /*
  * !doc
  *
- * .. c:function:: void spdxtool_util_set_uri_root(pkgconf_client_t *client, const char *uri_root)
+ * .. c:function:: bool spdxtool_util_set_uri_root(pkgconf_client_t *client, const char *uri_root)
  *
  *    Set URI/URL root for spdxId. Type for this is 'xsd:anyURI' which means
  *    it can they may be absolute or relative.
  *
  *    :param pkgconf_client_t* client: The pkgconf client being accessed.
  *    :param const char *uri_root: URI root.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on failure.
  */
-void
+bool
 spdxtool_util_set_uri_root(pkgconf_client_t *client, const char *uri_root)
 {
-	spdxtool_util_set_key(client, "spdx_uri_root", uri_root, "https://github.com/pkgconf/pkgconf");
+	return spdxtool_util_set_key(client, "spdx_uri_root", uri_root, "https://github.com/pkgconf/pkgconf");
 }
 
 /*
@@ -112,18 +112,18 @@ spdxtool_util_get_uri_separator(pkgconf_client_t *client)
 /*
  * !doc
  *
- * .. c:function:: void spdxtool_util_set_spdx_version(pkgconf_client_t *client, const char *spdx_version)
+ * .. c:function:: bool spdxtool_util_set_spdx_version(pkgconf_client_t *client, const char *spdx_version)
  *
  *    Set current SPDX SBOM Spec version. If not set it's 3.0.1
  *
  *    :param pkgconf_client_t* client: The pkgconf client being accessed.
  *    :param char* spdx_version: SPDX specification version.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on failure.
  */
-void
+bool
 spdxtool_util_set_spdx_version(pkgconf_client_t *client, const char *spdx_version)
 {
-	spdxtool_util_set_key(client, "spdx_version", spdx_version, "3.0.1");
+	return spdxtool_util_set_key(client, "spdx_version", spdx_version, "3.0.1");
 }
 
 /*
@@ -145,19 +145,19 @@ spdxtool_util_get_spdx_version(pkgconf_client_t *client)
 /*
  * !doc
  *
- * .. c:function:: void spdxtool_util_set_spdx_license(pkgconf_client_t *client, const char *spdx_license)
+ * .. c:function:: bool spdxtool_util_set_spdx_license(pkgconf_client_t *client, const char *spdx_license)
  *
  *    Under which license SBOM is released. License string should be in
  *    SPDX style. Something like: FreeBSD-DOC, CC0-1.0 or MIT
  *
  *    :param pkgconf_client_t* client: The pkgconf client being accessed.
  *    :param const char *spdx_license: SPDX compatible license
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on failure.
  */
-void
+bool
 spdxtool_util_set_spdx_license(pkgconf_client_t *client, const char *spdx_license)
 {
-	spdxtool_util_set_key(client, "spdx_license", spdx_license, "CC0-1.0");
+	return spdxtool_util_set_key(client, "spdx_license", spdx_license, "CC0-1.0");
 }
 
 /*
@@ -197,8 +197,11 @@ spdxtool_util_get_spdx_id_int(pkgconf_client_t *client, const char *part)
 	char sep = spdxtool_util_get_uri_separator(client);
 	pkgconf_buffer_t current_uri = PKGCONF_BUFFER_INITIALIZER;
 
-	pkgconf_buffer_join(&current_uri, sep, global_xsd_any_uri, part, NULL);
-	pkgconf_buffer_append_fmt(&current_uri, "%c" SIZE_FMT_SPECIFIER, sep, ++last_id);
+	if (!(pkgconf_buffer_join(&current_uri, sep, global_xsd_any_uri, part, NULL)
+		&& pkgconf_buffer_append_fmt(&current_uri, "%c" SIZE_FMT_SPECIFIER, sep, ++last_id)))
+	{
+		return NULL;
+	}
 
 	return pkgconf_buffer_freeze(&current_uri);
 }
@@ -223,7 +226,8 @@ spdxtool_util_get_spdx_id_string(pkgconf_client_t *client, const char *part, con
 	char sep = spdxtool_util_get_uri_separator(client);
 	pkgconf_buffer_t current_uri = PKGCONF_BUFFER_INITIALIZER;
 
-	pkgconf_buffer_join(&current_uri, sep, global_xsd_any_uri, part, string_id, NULL);
+	if (!pkgconf_buffer_join(&current_uri, sep, global_xsd_any_uri, part, string_id, NULL))
+		return NULL;
 
 	return pkgconf_buffer_freeze(&current_uri);
 }

--- a/cli/spdxtool/util.h
+++ b/cli/spdxtool/util.h
@@ -78,10 +78,10 @@ typedef struct spdxtool_core_relationship_
 	char *relationship_type;
 } spdxtool_core_relationship_t;
 
-void
+bool
 spdxtool_util_set_key(pkgconf_client_t *client, const char *key, const char *key_value, const char *key_default);
 
-void
+bool
 spdxtool_util_set_uri_root(pkgconf_client_t *client, const char *uri_root);
 
 void
@@ -93,13 +93,13 @@ spdxtool_util_get_uri_separator(pkgconf_client_t *client);
 const char *
 spdxtool_util_get_uri_root(pkgconf_client_t *client);
 
-void
+bool
 spdxtool_util_set_spdx_version(pkgconf_client_t *client, const char *spdx_version);
 
 const char *
 spdxtool_util_get_spdx_version(pkgconf_client_t *client);
 
-void
+bool
 spdxtool_util_set_spdx_license(pkgconf_client_t *client, const char *spdx_license);
 
 const char *

--- a/libpkgconf/bufferset.c
+++ b/libpkgconf/bufferset.c
@@ -30,15 +30,19 @@ pkgconf_bufferset_t *
 pkgconf_bufferset_extend(pkgconf_list_t *list, pkgconf_buffer_t *buffer)
 {
 	pkgconf_bufferset_t *set = calloc(1, sizeof(*set));
-
 	if (set == NULL)
 		return NULL;
 
 	if (pkgconf_buffer_len(buffer))
-		pkgconf_buffer_append(&set->buffer, pkgconf_buffer_str(buffer));
+	{
+		if (!pkgconf_buffer_append(&set->buffer, pkgconf_buffer_str(buffer)))
+		{
+			free(set);
+			return NULL;
+		}
+	}
 
 	pkgconf_node_insert_tail(&set->node, set, list);
-
 	return set;
 }
 

--- a/libpkgconf/bytecode.c
+++ b/libpkgconf/bytecode.c
@@ -30,34 +30,28 @@
 #define PKGCONF_EVAL_MAX_ITERATIONS (512)
 
 static bool
-pkgconf_bytecode_eval_append_slice(pkgconf_bytecode_eval_ctx_t *ctx,
-	pkgconf_buffer_t *out,
-	const char *p,
-	size_t n)
+pkgconf_bytecode_eval_append_slice(pkgconf_bytecode_eval_ctx_t *ctx, pkgconf_buffer_t *out, const char *p, size_t n)
 {
 	size_t cur = pkgconf_buffer_len(out);
-
 	if (cur >= PKGCONF_EVAL_MAX_OUTPUT)
 		return false;
 
 	if (n > PKGCONF_EVAL_MAX_OUTPUT - cur)
 	{
-		pkgconf_warn(ctx->client,
-			"warning: truncating very long variable to 64KB\n");
+		pkgconf_warn(ctx->client, "warning: truncating very long variable to 64KB\n");
 
 		n = PKGCONF_EVAL_MAX_OUTPUT - cur;
-		pkgconf_buffer_append_slice(out, p, n);
+		if (!pkgconf_buffer_append_slice(out, p, n))
+			pkgconf_error(ctx->client, "pkgconf_bytecode_eval_append_slice: failed to append to slice");
+
 		return false;
 	}
 
-	pkgconf_buffer_append_slice(out, p, n);
-	return true;
+	return pkgconf_buffer_append_slice(out, p, n);
 }
 
 static bool
-pkgconf_bytecode_eval_append(pkgconf_bytecode_eval_ctx_t *ctx,
-	pkgconf_buffer_t *out,
-	const char *s)
+pkgconf_bytecode_eval_append(pkgconf_bytecode_eval_ctx_t *ctx, pkgconf_buffer_t *out, const char *s)
 {
 	if (s == NULL || *s == '\0')
 		return true;
@@ -66,16 +60,10 @@ pkgconf_bytecode_eval_append(pkgconf_bytecode_eval_ctx_t *ctx,
 }
 
 static bool
-pkgconf_bytecode_eval_internal(pkgconf_bytecode_eval_ctx_t *ctx,
-	const pkgconf_bytecode_t *bc,
-	pkgconf_buffer_t *out,
-	bool *saw_sysroot);
+pkgconf_bytecode_eval_internal(pkgconf_bytecode_eval_ctx_t *ctx, const pkgconf_bytecode_t *bc, pkgconf_buffer_t *out, bool *saw_sysroot);
 
 static pkgconf_variable_t *
-pkgconf_bytecode_eval_scan(const pkgconf_list_t *vars,
-	const char *name, size_t nlen,
-	unsigned int require_flags,
-	unsigned int forbid_flags)
+pkgconf_bytecode_eval_scan(const pkgconf_list_t *vars, const char *name, size_t nlen, unsigned int require_flags, unsigned int forbid_flags)
 {
 	const pkgconf_node_t *node;
 
@@ -97,8 +85,7 @@ pkgconf_bytecode_eval_scan(const pkgconf_list_t *vars,
 }
 
 pkgconf_variable_t *
-pkgconf_bytecode_eval_lookup_var(pkgconf_bytecode_eval_ctx_t *ctx,
-	const char *name, size_t nlen)
+pkgconf_bytecode_eval_lookup_var(pkgconf_bytecode_eval_ctx_t *ctx, const char *name, size_t nlen)
 {
 	pkgconf_variable_t *v;
 
@@ -115,10 +102,7 @@ pkgconf_bytecode_eval_lookup_var(pkgconf_bytecode_eval_ctx_t *ctx,
 }
 
 static bool
-pkgconf_bytecode_eval_var(pkgconf_bytecode_eval_ctx_t *ctx,
-	const char *name, size_t nlen,
-	pkgconf_buffer_t *out,
-	bool *saw_sysroot)
+pkgconf_bytecode_eval_var(pkgconf_bytecode_eval_ctx_t *ctx, const char *name, size_t nlen, pkgconf_buffer_t *out, bool *saw_sysroot)
 {
 	pkgconf_variable_t *v;
 
@@ -146,10 +130,7 @@ pkgconf_bytecode_eval_var(pkgconf_bytecode_eval_ctx_t *ctx,
 }
 
 static bool
-pkgconf_bytecode_eval_internal(pkgconf_bytecode_eval_ctx_t *ctx,
-	const pkgconf_bytecode_t *bc,
-	pkgconf_buffer_t *out,
-	bool *saw_sysroot)
+pkgconf_bytecode_eval_internal(pkgconf_bytecode_eval_ctx_t *ctx, const pkgconf_bytecode_t *bc, pkgconf_buffer_t *out, bool *saw_sysroot)
 {
 	(void) ctx;
 
@@ -209,10 +190,8 @@ pkgconf_bytecode_eval_internal(pkgconf_bytecode_eval_ctx_t *ctx,
 	return true;
 }
 
-static void
-pkgconf_bytecode_eval_ctx_init(pkgconf_bytecode_eval_ctx_t *ctx,
-	const pkgconf_client_t *client,
-	const pkgconf_list_t *vars)
+static bool
+pkgconf_bytecode_eval_ctx_init(pkgconf_bytecode_eval_ctx_t *ctx, const pkgconf_client_t *client, const pkgconf_list_t *vars)
 {
 	memset(ctx, 0, sizeof(*ctx));
 
@@ -223,30 +202,35 @@ pkgconf_bytecode_eval_ctx_init(pkgconf_bytecode_eval_ctx_t *ctx,
 
 	/* disabled sysroot cases */
 	if (raw == NULL || *raw == '\0')
-		return;
+		return true;
 
 	if (raw[0] == '.' && raw[1] == '\0')
-		return;
+		return true;
 
 	if (raw[0] == '/' && raw[1] == '\0')
-		return;
+		return true;
 
-	pkgconf_buffer_append(&ctx->sysroot, raw);
+	if (!pkgconf_buffer_append(&ctx->sysroot, raw))
+		return false;
 
 	while (pkgconf_buffer_len(&ctx->sysroot) > 1 && ctx->sysroot.end[-1] == '/')
-		pkgconf_buffer_trim_byte(&ctx->sysroot);
+	{
+		if (!pkgconf_buffer_trim_byte(&ctx->sysroot))
+			return false;
+	}
 
 	/* if normalization yields "/", disable by making buffer empty */
 	if (pkgconf_buffer_len(&ctx->sysroot) == 1 && ctx->sysroot.base[0] == '/')
-		pkgconf_buffer_trim_byte(&ctx->sysroot);
+	{
+		if (!pkgconf_buffer_trim_byte(&ctx->sysroot))
+			return false;
+	}
+
+	return true;
 }
 
 bool
-pkgconf_bytecode_eval(const pkgconf_client_t *client,
-	const pkgconf_list_t *vars,
-	const pkgconf_bytecode_t *bc,
-	pkgconf_buffer_t *out,
-	bool *saw_sysroot)
+pkgconf_bytecode_eval(const pkgconf_client_t *client, const pkgconf_list_t *vars, const pkgconf_bytecode_t *bc, pkgconf_buffer_t *out, bool *saw_sysroot)
 {
 	bool ret;
 
@@ -254,7 +238,8 @@ pkgconf_bytecode_eval(const pkgconf_client_t *client,
 		return false;
 
 	pkgconf_bytecode_eval_ctx_t ctx;
-	pkgconf_bytecode_eval_ctx_init(&ctx, client, vars);
+	if (!pkgconf_bytecode_eval_ctx_init(&ctx, client, vars))
+		return false;
 
 	if (saw_sysroot != NULL)
 		*saw_sysroot = false;
@@ -266,45 +251,48 @@ pkgconf_bytecode_eval(const pkgconf_client_t *client,
 	return ret;
 }
 
-void
-pkgconf_bytecode_emit(pkgconf_buffer_t *buf,
-	enum pkgconf_bytecode_op tag,
-	const void *data,
-	uint32_t size)
+bool
+pkgconf_bytecode_emit(pkgconf_buffer_t *buf, enum pkgconf_bytecode_op tag, const void *data, uint32_t size)
 {
 	pkgconf_bytecode_op_t op = {
 		.tag = tag,
 		.size = size,
 	};
 
-	pkgconf_buffer_append_slice(buf, (const char *) &op, sizeof(op));
+	if (!pkgconf_buffer_append_slice(buf, (const char *) &op, sizeof(op)))
+		return false;
 
 	if (size != 0)
-		pkgconf_buffer_append_slice(buf, (const char *) data, (size_t) size);
+	{
+		if (!pkgconf_buffer_append_slice(buf, (const char *) data, (size_t) size))
+			return false;
+	}
+
+	return true;
 }
 
-void
+bool
 pkgconf_bytecode_emit_text(pkgconf_buffer_t *buf, const char *p, size_t n)
 {
 	if (p == NULL || n == 0)
-		return;
+		return true;
 
-	pkgconf_bytecode_emit(buf, PKGCONF_BYTECODE_OP_TEXT, p, (uint32_t) n);
+	return pkgconf_bytecode_emit(buf, PKGCONF_BYTECODE_OP_TEXT, p, (uint32_t) n);
 }
 
-void
+bool
 pkgconf_bytecode_emit_var(pkgconf_buffer_t *buf, const char *name, size_t nlen)
 {
 	if (name == NULL || nlen == 0)
-		return;
+		return true;
 
-	pkgconf_bytecode_emit(buf, PKGCONF_BYTECODE_OP_VAR, name, (uint32_t) nlen);
+	return pkgconf_bytecode_emit(buf, PKGCONF_BYTECODE_OP_VAR, name, (uint32_t) nlen);
 }
 
-void
+bool
 pkgconf_bytecode_emit_sysroot(pkgconf_buffer_t *buf)
 {
-	pkgconf_bytecode_emit(buf, PKGCONF_BYTECODE_OP_SYSROOT, NULL, 0);
+	return pkgconf_bytecode_emit(buf, PKGCONF_BYTECODE_OP_SYSROOT, NULL, 0);
 }
 
 void
@@ -314,13 +302,13 @@ pkgconf_bytecode_from_buffer(pkgconf_bytecode_t *bc, const pkgconf_buffer_t *buf
 	bc->len = (size_t)(buf->end - buf->base);
 }
 
-void
+bool
 pkgconf_bytecode_compile(pkgconf_buffer_t *out, const char *value)
 {
 	const char *p, *text_start;
 
 	if (out == NULL || value == NULL)
-		return;
+		return false;
 
 	p = value;
 	text_start = value;
@@ -336,9 +324,13 @@ pkgconf_bytecode_compile(pkgconf_buffer_t *out, const char *value)
 		if (p[1] == '$')
 		{
 			if (p > text_start)
-				pkgconf_bytecode_emit_text(out, text_start, (size_t)(p - text_start));
+			{
+				if (!pkgconf_bytecode_emit_text(out, text_start, (size_t)(p - text_start)))
+					return false;
+			}
 
-			pkgconf_bytecode_emit_text(out, "$", 1);
+			if (!pkgconf_bytecode_emit_text(out, "$", 1))
+				return false;
 
 			p++;
 			text_start = p + 1;
@@ -349,7 +341,10 @@ pkgconf_bytecode_compile(pkgconf_buffer_t *out, const char *value)
 			continue;
 
 		if (p > text_start)
-			pkgconf_bytecode_emit_text(out, text_start, (size_t)(p - text_start));
+		{
+			if (!pkgconf_bytecode_emit_text(out, text_start, (size_t)(p - text_start)))
+				return false;
+		}
 
 		name = p + 2;
 		q = name;
@@ -368,7 +363,9 @@ pkgconf_bytecode_compile(pkgconf_buffer_t *out, const char *value)
 		size_t nlen = (size_t)(q - name);
 		if (nlen == 0 || nlen >= PKGCONF_ITEM_SIZE)
 		{
-			pkgconf_bytecode_emit_text(out, p, (size_t)((q + 1) - p));
+			if (!pkgconf_bytecode_emit_text(out, p, (size_t)((q + 1) - p)))
+				return false;
+
 			p = q;
 			text_start = p + 1;
 			continue;
@@ -376,16 +373,27 @@ pkgconf_bytecode_compile(pkgconf_buffer_t *out, const char *value)
 
 		/* we need to special-case ${pc_sysrootdir} and emit OP_SYSROOT instead... */
 		if (nlen == strlen("pc_sysrootdir") && !memcmp(name, "pc_sysrootdir", nlen))
-			pkgconf_bytecode_emit_sysroot(out);
+		{
+			if (!pkgconf_bytecode_emit_sysroot(out))
+				return false;
+		}
 		else
-			pkgconf_bytecode_emit_var(out, name, nlen);
+		{
+			if (!pkgconf_bytecode_emit_var(out, name, nlen))
+				return false;
+		}
 
 		p = q;
 		text_start = p + 1;
 	}
 
 	if (p > text_start)
-		pkgconf_bytecode_emit_text(out, text_start, (size_t)(p - text_start));
+	{
+		if (!pkgconf_bytecode_emit_text(out, text_start, (size_t)(p - text_start)))
+			return false;
+	}
+
+	return true;
 }
 
 bool
@@ -395,7 +403,12 @@ pkgconf_bytecode_eval_str_to_buf(const pkgconf_client_t *client, const pkgconf_l
 	pkgconf_bytecode_t bc;
 	bool ret = false;
 
-	pkgconf_bytecode_compile(&bcbuf, input);
+	if (!pkgconf_bytecode_compile(&bcbuf, input))
+	{
+		pkgconf_buffer_finalize(&bcbuf);
+		return false;
+	}
+
 	pkgconf_bytecode_from_buffer(&bc, &bcbuf);
 
 	ret = pkgconf_bytecode_eval(client, vars, &bc, out, saw_sysroot);
@@ -477,13 +490,13 @@ pkgconf_bytecode_op_is_selfref(const pkgconf_bytecode_op_t *op, const char *key)
 	return pkgconf_str_eq_slice(op->data, key, klen);
 }
 
-static void
+static bool
 pkgconf_bytecode_append_stream(pkgconf_buffer_t *dst, const pkgconf_buffer_t *bcbuf)
 {
 	if (dst == NULL || bcbuf == NULL || pkgconf_buffer_str(bcbuf) == NULL)
-		return;
+		return true;
 
-	pkgconf_buffer_append_slice(dst, pkgconf_buffer_str(bcbuf), pkgconf_buffer_len(bcbuf));
+	return pkgconf_buffer_append_slice(dst, pkgconf_buffer_str(bcbuf), pkgconf_buffer_len(bcbuf));
 }
 
 bool
@@ -503,9 +516,15 @@ pkgconf_bytecode_rewrite_selfrefs(pkgconf_buffer_t *out, const pkgconf_buffer_t 
 			return false;
 
 		if (pkgconf_bytecode_op_is_selfref(op, key))
-			pkgconf_bytecode_append_stream(out, prev);
+		{
+			if (!pkgconf_bytecode_append_stream(out, prev))
+				return false;
+		}
 		else
-			pkgconf_buffer_append_slice(out, (const char *) op, sizeof(*op) + op->size);
+		{
+			if (!pkgconf_buffer_append_slice(out, (const char *) op, sizeof(*op) + op->size))
+				return false;
+		}
 
 		p += sizeof(*op) + op->size;
 	}

--- a/libpkgconf/client.c
+++ b/libpkgconf/client.c
@@ -48,16 +48,17 @@ trace_path_list(const pkgconf_client_t *client, const char *desc, pkgconf_list_t
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_client_dir_list_build(pkgconf_client_t *client)
+ * .. c:function:: bool pkgconf_client_dir_list_build(pkgconf_client_t *client, const pkgconf_cross_personality_t *personality)
  *
  *    Bootstraps the package search paths.  If the ``PKGCONF_PKG_PKGF_ENV_ONLY`` `flag` is set on the client,
  *    then only the ``PKG_CONFIG_PATH`` environment variable will be used, otherwise both the
  *    ``PKG_CONFIG_PATH`` and ``PKG_CONFIG_LIBDIR`` environment variables will be used.
  *
  *    :param pkgconf_client_t* client: The pkgconf client object to bootstrap.
- *    :return: nothing
+ *    :param pkgconf_cross_personality_t* personality: the cross-compile personality to use for defaults.
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_client_dir_list_build(pkgconf_client_t *client, const pkgconf_cross_personality_t *personality)
 {
 	pkgconf_path_build_from_environ(client, "PKG_CONFIG_PATH", NULL, &client->dir_list, true);
@@ -79,15 +80,20 @@ pkgconf_client_dir_list_build(pkgconf_client_t *client, const pkgconf_cross_pers
 			prepend_list = &dir_list;
 		}
 
-		pkgconf_path_copy_list(&client->dir_list, prepend_list);
+		bool ok = pkgconf_path_copy_list(&client->dir_list, prepend_list);
 		pkgconf_path_free(&dir_list);
+
+		if (!ok)
+			return false;
 	}
+
+	return true;
 }
 
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_client_init(pkgconf_client_t *client, pkgconf_error_handler_func_t error_handler, void *error_handler_data, const pkgconf_cross_personality_t *personality, void *client_data, pkgconf_environ_lookup_handler_func_t environ_lookup_handler)
+ * .. c:function:: bool pkgconf_client_init(pkgconf_client_t *client, pkgconf_error_handler_func_t error_handler, void *error_handler_data, const pkgconf_cross_personality_t *personality, void *client_data, pkgconf_environ_lookup_handler_func_t environ_lookup_handler)
  *
  *    Initialise a pkgconf client object.
  *
@@ -97,9 +103,9 @@ pkgconf_client_dir_list_build(pkgconf_client_t *client, const pkgconf_cross_pers
  *    :param pkgconf_cross_personality_t* personality: the cross-compile personality to use for defaults
  *    :param void* client_data: user data associated with the client
  *    :param pkgconf_environ_lookup_handler_func_t environ_lookup_handler: the lookup handler to use for environment variables
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_client_init(pkgconf_client_t *client, pkgconf_error_handler_func_t error_handler, void *error_handler_data, const pkgconf_cross_personality_t *personality, void *client_data, pkgconf_environ_lookup_handler_func_t environ_lookup_handler)
 {
 	client->personality = personality;
@@ -122,17 +128,26 @@ pkgconf_client_init(pkgconf_client_t *client, pkgconf_error_handler_func_t error
 	pkgconf_client_set_error_handler(client, error_handler, error_handler_data);
 	pkgconf_client_set_warn_handler(client, NULL, NULL);
 
-	pkgconf_client_set_sysroot_dir(client, personality->sysroot_dir);
-	pkgconf_client_set_buildroot_dir(client, NULL);
-	pkgconf_client_set_prefix_varname(client, NULL);
+	if (!pkgconf_client_set_sysroot_dir(client, personality->sysroot_dir))
+		return false;
+	if (!pkgconf_client_set_buildroot_dir(client, NULL))
+		return false;
+	if (!pkgconf_client_set_prefix_varname(client, NULL))
+		return false;
 
-	if(pkgconf_client_getenv(client, "PKG_CONFIG_SYSTEM_LIBRARY_PATH") == NULL)
-		pkgconf_path_copy_list(&client->filter_libdirs, &personality->filter_libdirs);
+	if (pkgconf_client_getenv(client, "PKG_CONFIG_SYSTEM_LIBRARY_PATH") == NULL)
+	{
+		if (!pkgconf_path_copy_list(&client->filter_libdirs, &personality->filter_libdirs))
+			return false;
+	}
 	else
 		pkgconf_path_build_from_environ(client, "PKG_CONFIG_SYSTEM_LIBRARY_PATH", NULL, &client->filter_libdirs, false);
 
-	if(pkgconf_client_getenv(client, "PKG_CONFIG_SYSTEM_INCLUDE_PATH") == NULL)
-		pkgconf_path_copy_list(&client->filter_includedirs, &personality->filter_includedirs);
+	if (pkgconf_client_getenv(client, "PKG_CONFIG_SYSTEM_INCLUDE_PATH") == NULL)
+	{
+		if (!pkgconf_path_copy_list(&client->filter_includedirs, &personality->filter_includedirs))
+			return false;
+	}
 	else
 		pkgconf_path_build_from_environ(client, "PKG_CONFIG_SYSTEM_INCLUDE_PATH", NULL, &client->filter_includedirs, false);
 
@@ -158,6 +173,8 @@ pkgconf_client_init(pkgconf_client_t *client, pkgconf_error_handler_func_t error
 	trace_path_list(client, "filtered include paths", &client->filter_includedirs);
 
 	client->output = pkgconf_output_default();
+
+	return true;
 }
 
 /*
@@ -182,7 +199,13 @@ pkgconf_client_new(pkgconf_error_handler_func_t error_handler, void *error_handl
 	if (out == NULL)
 		return NULL;
 
-	pkgconf_client_init(out, error_handler, error_handler_data, personality, client_data, environ_lookup_handler);
+	if (!pkgconf_client_init(out, error_handler, error_handler_data, personality, client_data, environ_lookup_handler))
+	{
+		pkgconf_client_deinit(out);
+		free(out);
+		return NULL;
+	}
+
 	return out;
 }
 
@@ -273,7 +296,7 @@ pkgconf_client_get_sysroot_dir(const pkgconf_client_t *client)
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_client_set_sysroot_dir(pkgconf_client_t *client, const char *sysroot_dir)
+ * .. c:function:: bool pkgconf_client_set_sysroot_dir(pkgconf_client_t *client, const char *sysroot_dir)
  *
  *    Sets or clears the sysroot directory on a client object.  Any previous sysroot directory setting is
  *    automatically released if one was previously set.
@@ -282,9 +305,9 @@ pkgconf_client_get_sysroot_dir(const pkgconf_client_t *client)
  *
  *    :param pkgconf_client_t* client: The client object being modified.
  *    :param char* sysroot_dir: The sysroot directory to set or NULL to unset.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_client_set_sysroot_dir(pkgconf_client_t *client, const char *sysroot_dir)
 {
 	if (sysroot_dir != NULL && (!strcmp(sysroot_dir, "/") || !strcmp(sysroot_dir, ".")))
@@ -293,14 +316,24 @@ pkgconf_client_set_sysroot_dir(pkgconf_client_t *client, const char *sysroot_dir
 		sysroot_dir = NULL;
 	}
 
+	char *new_dir = NULL;
+	if (sysroot_dir != NULL)
+	{
+		new_dir = strdup(sysroot_dir);
+		if (new_dir == NULL)
+			return false;
+	}
+
 	if (client->sysroot_dir != NULL)
 		free(client->sysroot_dir);
 
-	client->sysroot_dir = sysroot_dir != NULL ? strdup(sysroot_dir) : NULL;
+	client->sysroot_dir = new_dir;
 
 	PKGCONF_TRACE(client, "set sysroot_dir to: %s", client->sysroot_dir != NULL ? client->sysroot_dir : "<default>");
 
 	pkgconf_tuple_add_global(client, "pc_sysrootdir", client->sysroot_dir != NULL ? client->sysroot_dir : "");
+
+	return true;
 }
 
 /*
@@ -323,7 +356,7 @@ pkgconf_client_get_buildroot_dir(const pkgconf_client_t *client)
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_client_set_buildroot_dir(pkgconf_client_t *client, const char *buildroot_dir)
+ * .. c:function:: bool pkgconf_client_set_buildroot_dir(pkgconf_client_t *client, const char *buildroot_dir)
  *
  *    Sets or clears the buildroot directory on a client object.  Any previous buildroot directory setting is
  *    automatically released if one was previously set.
@@ -332,19 +365,30 @@ pkgconf_client_get_buildroot_dir(const pkgconf_client_t *client)
  *
  *    :param pkgconf_client_t* client: The client object being modified.
  *    :param char* buildroot_dir: The buildroot directory to set or NULL to unset.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
+ *    :rtype: bool
  */
-void
+bool
 pkgconf_client_set_buildroot_dir(pkgconf_client_t *client, const char *buildroot_dir)
 {
+	char *new_dir = NULL;
+	if (buildroot_dir != NULL)
+	{
+		new_dir = strdup(buildroot_dir);
+		if (new_dir == NULL)
+			return false;
+	}
+
 	if (client->buildroot_dir != NULL)
 		free(client->buildroot_dir);
 
-	client->buildroot_dir = buildroot_dir != NULL ? strdup(buildroot_dir) : NULL;
+	client->buildroot_dir = new_dir;
 
 	PKGCONF_TRACE(client, "set buildroot_dir to: %s", client->buildroot_dir != NULL ? client->buildroot_dir : "<default>");
 
 	pkgconf_tuple_add_global(client, "pc_top_builddir", client->buildroot_dir != NULL ? client->buildroot_dir : "$(top_builddir)");
+
+	return true;
 }
 
 /*
@@ -588,27 +632,34 @@ pkgconf_client_get_prefix_varname(const pkgconf_client_t *client)
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_client_set_prefix_varname(pkgconf_client_t *client, const char *prefix_varname)
+ * .. c:function:: bool pkgconf_client_set_prefix_varname(pkgconf_client_t *client, const char *prefix_varname)
  *
  *    Sets the name of the variable that should contain a module's prefix.
  *    If the variable name is ``NULL``, then the default variable name (``prefix``) is used.
  *
  *    :param pkgconf_client_t* client: The client object to set the prefix variable name on.
  *    :param char* prefix_varname: The prefix variable name to set.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
+ *    :rtype: bool
  */
-void
+bool
 pkgconf_client_set_prefix_varname(pkgconf_client_t *client, const char *prefix_varname)
 {
 	if (prefix_varname == NULL)
 		prefix_varname = "prefix";
 
+	char *new_name = strdup(prefix_varname);
+	if (new_name == NULL)
+		return false;
+
 	if (client->prefix_varname != NULL)
 		free(client->prefix_varname);
 
-	client->prefix_varname = strdup(prefix_varname);
+	client->prefix_varname = new_name;
 
 	PKGCONF_TRACE(client, "set prefix_varname to: %s", client->prefix_varname);
+
+	return true;
 }
 
 /*

--- a/libpkgconf/client.c
+++ b/libpkgconf/client.c
@@ -331,7 +331,8 @@ pkgconf_client_set_sysroot_dir(pkgconf_client_t *client, const char *sysroot_dir
 
 	PKGCONF_TRACE(client, "set sysroot_dir to: %s", client->sysroot_dir != NULL ? client->sysroot_dir : "<default>");
 
-	pkgconf_tuple_add_global(client, "pc_sysrootdir", client->sysroot_dir != NULL ? client->sysroot_dir : "");
+	if (!pkgconf_tuple_add_global(client, "pc_sysrootdir", client->sysroot_dir != NULL ? client->sysroot_dir : ""))
+		return false;
 
 	return true;
 }
@@ -386,7 +387,8 @@ pkgconf_client_set_buildroot_dir(pkgconf_client_t *client, const char *buildroot
 
 	PKGCONF_TRACE(client, "set buildroot_dir to: %s", client->buildroot_dir != NULL ? client->buildroot_dir : "<default>");
 
-	pkgconf_tuple_add_global(client, "pc_top_builddir", client->buildroot_dir != NULL ? client->buildroot_dir : "$(top_builddir)");
+	if (!pkgconf_tuple_add_global(client, "pc_top_builddir", client->buildroot_dir != NULL ? client->buildroot_dir : "$(top_builddir)"))
+		return false;
 
 	return true;
 }

--- a/libpkgconf/dependency.c
+++ b/libpkgconf/dependency.c
@@ -41,10 +41,15 @@ static inline const char *
 dependency_to_buf(const pkgconf_dependency_t *dep, pkgconf_buffer_t *buf)
 {
 	pkgconf_buffer_reset(buf);
-	pkgconf_buffer_append(buf, dep->package);
+
+	if (!pkgconf_buffer_append(buf, dep->package))
+		return "";
 
 	if (dep->version != NULL)
-		pkgconf_buffer_append_fmt(buf, " %s %s", pkgconf_pkg_get_comparator(dep), dep->version);
+	{
+		if (!pkgconf_buffer_append_fmt(buf, " %s %s", pkgconf_pkg_get_comparator(dep), dep->version))
+			return "";
+	}
 
 	return pkgconf_buffer_str(buf);
 }
@@ -83,7 +88,7 @@ add_or_replace_dependency_node(pkgconf_client_t *client, pkgconf_dependency_t *d
 		const char *depstr2 = dependency_to_buf(dep2, &depbuf2);
 
 		PKGCONF_TRACE(client, "dependency collision: [%s/%x] -- [%s/%x]",
-			      depstr, dep->flags, depstr2, dep2->flags);
+			depstr, dep->flags, depstr2, dep2->flags);
 
 		/* prefer the uncoloured node, either dep or dep2 */
 		if (dep->flags && dep2->flags == 0)
@@ -326,8 +331,11 @@ pkgconf_dependency_parse_str(pkgconf_client_t *client, pkgconf_list_t *deplist_h
 	if (depends == NULL || *depends == '\0')
 		return;
 
-	pkgconf_buffer_append(&buf, depends);
-	pkgconf_buffer_append(&buf, " ");
+	if (!pkgconf_buffer_append(&buf, depends))
+		goto out;
+
+	if (!pkgconf_buffer_append(&buf, " "))
+		goto out;
 
 	if (buf.base == NULL)
 		goto out;
@@ -405,7 +413,8 @@ pkgconf_dependency_parse_str(pkgconf_client_t *client, pkgconf_list_t *deplist_h
 				break;
 
 			pkgconf_buffer_reset(&cmpname);
-			pkgconf_buffer_append_slice(&cmpname, opstart, ptr - opstart);
+			if (!pkgconf_buffer_append_slice(&cmpname, opstart, ptr - opstart))
+				goto out;
 			compare = pkgconf_pkg_comparator_lookup_by_name(pkgconf_buffer_str(&cmpname));
 			state = AFTER_OPERATOR;
 			// fallthrough

--- a/libpkgconf/fileio.c
+++ b/libpkgconf/fileio.c
@@ -22,17 +22,13 @@ pkgconf_fgetline(pkgconf_buffer_t *buffer, FILE *stream)
 	bool quoted = false;
 	bool got_data = false;
 	char in[PKGCONF_ITEM_SIZE];
-
 	while (fgets(in, sizeof in, stream) != NULL)
 	{
 		char *p = in;
-
 		got_data = true;
-
 		while (*p != '\0')
 		{
 			unsigned char c = (unsigned char) *p++;
-
 			if (c == '\\' && !quoted)
 			{
 				quoted = true;
@@ -46,34 +42,35 @@ pkgconf_fgetline(pkgconf_buffer_t *buffer, FILE *stream)
 					continue;
 				}
 				else
-					pkgconf_buffer_push_byte(buffer, (char) c);
-
+				{
+					if (!pkgconf_buffer_push_byte(buffer, (char) c))
+						return false;
+				}
 				goto done;
 			}
 			else if (c == '\r')
 			{
-				pkgconf_buffer_push_byte(buffer, '\n');
-
+				if (!pkgconf_buffer_push_byte(buffer, '\n'))
+					return false;
 				if (*p == '\n')
 					p++;
-
 				if (quoted)
 				{
 					quoted = false;
 					continue;
 				}
-
 				goto done;
 			}
 			else
 			{
 				if (quoted)
 				{
-					pkgconf_buffer_push_byte(buffer, '\\');
+					if (!pkgconf_buffer_push_byte(buffer, '\\'))
+						return false;
 					quoted = false;
 				}
-
-				pkgconf_buffer_push_byte(buffer, (char) c);
+				if (!pkgconf_buffer_push_byte(buffer, (char) c))
+					return false;
 			}
 		}
 	}
@@ -81,10 +78,16 @@ pkgconf_fgetline(pkgconf_buffer_t *buffer, FILE *stream)
 done:
 	/* Remove newline character. */
 	if (pkgconf_buffer_lastc(buffer) == '\n')
-		pkgconf_buffer_trim_byte(buffer);
+	{
+		if (!pkgconf_buffer_trim_byte(buffer))
+			return false;
+	}
 
 	if (pkgconf_buffer_lastc(buffer) == '\r')
-		pkgconf_buffer_trim_byte(buffer);
+	{
+		if (!pkgconf_buffer_trim_byte(buffer))
+			return false;
+	}
 
 	if (!got_data)
 		return false;

--- a/libpkgconf/fragment.c
+++ b/libpkgconf/fragment.c
@@ -237,7 +237,7 @@ should_inject_sysroot(const pkgconf_client_t *client, const char *string, bool s
 		return false;
 
 	if (!strncmp(string + 2, client->sysroot_dir, strlen(client->sysroot_dir)) &&
-            *(string + 2 + strlen(client->sysroot_dir)) == '/')
+			*(string + 2 + strlen(client->sysroot_dir)) == '/')
 		return false;
 
 	return true;
@@ -271,8 +271,10 @@ should_inject_sysroot_child(const pkgconf_client_t *client, const pkgconf_fragme
 		return false;
 
 	if (!strncmp(string, client->sysroot_dir, strlen(client->sysroot_dir)) &&
-            *(string + 1 + strlen(client->sysroot_dir)) == '/')
+			*(string + 1 + strlen(client->sysroot_dir)) == '/')
+	{
 		return false;
+	}
 
 	return true;
 }
@@ -333,14 +335,14 @@ pkgconf_fragment_add(pkgconf_client_t *client, pkgconf_list_t *list, pkgconf_lis
 	}
 
 	if (list->tail != NULL && list->tail->data != NULL &&
-	    !(client->flags & PKGCONF_PKG_PKGF_DONT_MERGE_SPECIAL_FRAGMENTS))
+		!(client->flags & PKGCONF_PKG_PKGF_DONT_MERGE_SPECIAL_FRAGMENTS))
 	{
 		pkgconf_fragment_t *parent = list->tail->data;
 
 		/* only attempt to merge 'special' fragments together */
 		if (!parent->type && parent->data != NULL &&
-		    pkgconf_fragment_is_unmergeable(parent->data) &&
-		    !(parent->flags & PKGCONF_PKG_FRAGF_TERMINATED))
+			pkgconf_fragment_is_unmergeable(parent->data) &&
+			!(parent->flags & PKGCONF_PKG_FRAGF_TERMINATED))
 		{
 			if (pkgconf_fragment_is_groupable(parent->data))
 				target = &parent->children;
@@ -623,11 +625,11 @@ pkgconf_fragment_filter(const pkgconf_client_t *client, pkgconf_list_t *dest, pk
 	}
 }
 
-static void
+static bool
 fragment_quote(pkgconf_buffer_t *out, const pkgconf_fragment_t *frag)
 {
 	if (frag->data == NULL)
-		return;
+		return true;
 
 	const pkgconf_buffer_t *src = PKGCONF_BUFFER_FROM_STR(frag->data);
 	const pkgconf_span_t quote_spans[] = {
@@ -643,30 +645,52 @@ fragment_quote(pkgconf_buffer_t *out, const pkgconf_fragment_t *frag)
 		{ 0x7f, 0xff },
 	};
 
-	pkgconf_buffer_escape(out, src, quote_spans, PKGCONF_ARRAY_SIZE(quote_spans));
+	return pkgconf_buffer_escape(out, src, quote_spans, PKGCONF_ARRAY_SIZE(quote_spans));
 }
 
-static void
+static bool
 fragment_render(const pkgconf_fragment_render_ctx_t *ctx, const pkgconf_fragment_t *frag, pkgconf_buffer_t *buf)
 {
 	const pkgconf_node_t *iter;
 	pkgconf_buffer_t quoted = PKGCONF_BUFFER_INITIALIZER;
 
-	fragment_quote(&quoted, frag);
+	if (!fragment_quote(&quoted, frag))
+	{
+		pkgconf_buffer_finalize(&quoted);
+		return false;
+	}
 
 	if (frag->type)
-		pkgconf_buffer_append_fmt(buf, "-%c", frag->type);
+	{
+		if (!pkgconf_buffer_append_fmt(buf, "-%c", frag->type))
+		{
+			pkgconf_buffer_finalize(&quoted);
+			return false;
+		}
+	}
 
-	pkgconf_buffer_append(buf, pkgconf_buffer_str_or_empty(&quoted));
+	if (!pkgconf_buffer_append(buf, pkgconf_buffer_str_or_empty(&quoted)))
+	{
+		pkgconf_buffer_finalize(&quoted);
+		return false;
+	}
+
 	pkgconf_buffer_finalize(&quoted);
 
 	PKGCONF_FOREACH_LIST_ENTRY(frag->children.head, iter)
 	{
 		const pkgconf_fragment_t *child_frag = iter->data;
+		if (!child_frag)
+			return false;
 
-		pkgconf_buffer_push_byte(buf, ctx->delim);
-		fragment_render(ctx, child_frag, buf);
+		if (!pkgconf_buffer_push_byte(buf, ctx->delim))
+			return false;
+
+		if (!fragment_render(ctx, child_frag, buf))
+			return false;
 	}
+
+	return true;
 }
 
 static const pkgconf_fragment_render_ops_t default_render_ops = {
@@ -676,7 +700,7 @@ static const pkgconf_fragment_render_ops_t default_render_ops = {
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_fragment_render_buf(const pkgconf_list_t *list, char *buf, size_t buflen, bool escape, const pkgconf_fragment_render_ops_t *ops, char delim)
+ * .. c:function:: bool pkgconf_fragment_render_buf(const pkgconf_list_t *list, char *buf, size_t buflen, bool escape, const pkgconf_fragment_render_ops_t *ops, char delim)
  *
  *    Renders a `fragment list` into a buffer.
  *
@@ -685,9 +709,9 @@ static const pkgconf_fragment_render_ops_t default_render_ops = {
  *    :param bool escape: Whether or not to escape special shell characters (deprecated).
  *    :param pkgconf_fragment_render_ops_t* ops: An optional ops structure to use for custom renderers, else ``NULL``.
  *    :param char delim: The delimiter to use between fragments.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_fragment_render_buf(const pkgconf_list_t *list, pkgconf_buffer_t *buf, bool escape, const pkgconf_fragment_render_ops_t *ops, char delim)
 {
 	pkgconf_node_t *node;
@@ -701,11 +725,20 @@ pkgconf_fragment_render_buf(const pkgconf_list_t *list, pkgconf_buffer_t *buf, b
 	PKGCONF_FOREACH_LIST_ENTRY(list->head, node)
 	{
 		const pkgconf_fragment_t *frag = node->data;
-		ops->render(&ctx, frag, buf);
+		if (!frag)
+			return false;
+
+		if (!ops->render(&ctx, frag, buf))
+			return false;
 
 		if (node->next != NULL)
-			pkgconf_buffer_push_byte(buf, ctx.delim);
+		{
+			if (!pkgconf_buffer_push_byte(buf, ctx.delim))
+				return false;
+		}
 	}
+
+	return true;
 }
 
 /*

--- a/libpkgconf/fragment.c
+++ b/libpkgconf/fragment.c
@@ -181,7 +181,7 @@ pkgconf_fragment_is_special(const char *string)
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_fragment_insert(const pkgconf_client_t *client, pkgconf_list_t *list, char type, const char *data, bool tail)
+ * .. c:function:: bool pkgconf_fragment_insert(const pkgconf_client_t *client, pkgconf_list_t *list, char type, const char *data, bool tail)
  *
  *    Adds a `fragment` of text to a `fragment list` directly without interpreting it.
  *
@@ -190,9 +190,9 @@ pkgconf_fragment_is_special(const char *string)
  *    :param char type: The type of the fragment.
  *    :param char* data: The data of the fragment.
  *    :param bool tail: Whether to place the fragment at the beginning of the list or the end.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_fragment_insert(pkgconf_client_t *client, pkgconf_list_t *list, char type, const char *data, bool tail)
 {
 	(void) client;
@@ -200,16 +200,25 @@ pkgconf_fragment_insert(pkgconf_client_t *client, pkgconf_list_t *list, char typ
 	pkgconf_fragment_t *frag;
 
 	frag = calloc(1, sizeof(pkgconf_fragment_t));
+	if (frag == NULL)
+		return false;
+
 	frag->type = type;
 	frag->data = strdup(data);
+	if (frag->data == NULL)
+	{
+	   free(frag);
+	   return false;
+	}
 
 	if (tail)
 	{
 		pkgconf_node_insert_tail(&frag->iter, frag, list);
-		return;
+		return true;
 	}
 
 	pkgconf_node_insert(&frag->iter, frag, list);
+	return true;
 }
 
 static bool
@@ -301,17 +310,18 @@ fragment_is_unquoted_var(const char *value)
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_fragment_add(const pkgconf_client_t *client, pkgconf_list_t *list, const char *string, unsigned int flags)
+ * .. c:function:: bool pkgconf_fragment_add(pkgconf_client_t *client, pkgconf_list_t *list, pkgconf_list_t *vars, const char *value, unsigned int flags)
  *
  *    Adds a `fragment` of text to a `fragment list`, possibly modifying the fragment if a sysroot is set.
  *
  *    :param pkgconf_client_t* client: The pkgconf client being accessed.
  *    :param pkgconf_list_t* list: The fragment list.
- *    :param char* string: The string of text to add as a fragment to the fragment list.
- *    :param uint flags: Parsing-related flags for the package.
- *    :return: nothing
+ *    :param pkgconf_list_t* vars: The variable list to use for evaluation.
+ *    :param char* value: The string of text to add as a fragment to the fragment list.
+ *    :param unsigned int flags: Parsing-related flags for the package.
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_fragment_add(pkgconf_client_t *client, pkgconf_list_t *list, pkgconf_list_t *vars, const char *value, unsigned int flags)
 {
 	pkgconf_list_t *target = list;
@@ -320,18 +330,24 @@ pkgconf_fragment_add(pkgconf_client_t *client, pkgconf_list_t *list, pkgconf_lis
 	bool saw_sysroot = false;
 	char *string;
 
+	if (value == NULL || *value == '\0')
+		return true;  // nothing to add
+
 	if (!pkgconf_bytecode_eval_str_to_buf(client, vars, value, &saw_sysroot, &evalbuf))
-		return;
+	{
+		pkgconf_buffer_finalize(&evalbuf);
+		return false;
+	}
 
 	string = pkgconf_buffer_freeze(&evalbuf);
 	if (string == NULL)
-		return;
+		return true; // XXX - can't differentiate between OOM and empty string
 
 	if (fragment_is_unquoted_var(value))
 	{
-		pkgconf_fragment_parse(client, list, vars, string, flags);
+		bool ret = pkgconf_fragment_parse(client, list, vars, string, flags);
 		free(string);
-		return;
+		return ret;
 	}
 
 	if (list->tail != NULL && list->tail->data != NULL &&
@@ -339,7 +355,6 @@ pkgconf_fragment_add(pkgconf_client_t *client, pkgconf_list_t *list, pkgconf_lis
 	{
 		pkgconf_fragment_t *parent = list->tail->data;
 
-		/* only attempt to merge 'special' fragments together */
 		if (!parent->type && parent->data != NULL &&
 			pkgconf_fragment_is_unmergeable(parent->data) &&
 			!(parent->flags & PKGCONF_PKG_FRAGF_TERMINATED))
@@ -359,7 +374,7 @@ pkgconf_fragment_add(pkgconf_client_t *client, pkgconf_list_t *list, pkgconf_lis
 	{
 		PKGCONF_TRACE(client, "failed to add new fragment due to allocation failure to list @%p", target);
 		free(string);
-		return;
+		return false;
 	}
 
 	if (strlen(string) > 1 && !pkgconf_fragment_is_special(string))
@@ -370,13 +385,26 @@ pkgconf_fragment_add(pkgconf_client_t *client, pkgconf_list_t *list, pkgconf_lis
 		{
 			pkgconf_buffer_t sysroot_buf = PKGCONF_BUFFER_INITIALIZER;
 
-			pkgconf_buffer_append(&sysroot_buf, client->sysroot_dir);
-			pkgconf_buffer_append(&sysroot_buf, string + 2);
-
-			frag->data = pkgconf_buffer_freeze(&sysroot_buf);
+			if (pkgconf_buffer_append(&sysroot_buf, client->sysroot_dir) &&
+				pkgconf_buffer_append(&sysroot_buf, string + 2))
+			{
+				frag->data = pkgconf_buffer_freeze(&sysroot_buf);
+			}
+			else
+			{
+				pkgconf_buffer_finalize(&sysroot_buf);
+				frag->data = strdup(string + 2);
+			}
 		}
 		else
 			frag->data = strdup(string + 2);
+
+		if (frag->data == NULL)
+		{
+			free(frag);
+			free(string);
+			return false;
+		}
 
 		PKGCONF_TRACE(client, "added fragment {%c, '%s'} to list @%p", frag->type, frag->data, list);
 	}
@@ -390,22 +418,37 @@ pkgconf_fragment_add(pkgconf_client_t *client, pkgconf_list_t *list, pkgconf_lis
 			{
 				pkgconf_buffer_t sysroot_buf = PKGCONF_BUFFER_INITIALIZER;
 
-				pkgconf_buffer_append(&sysroot_buf, client->sysroot_dir);
-				pkgconf_buffer_append(&sysroot_buf, string);
-
-				free(string);
-				string = pkgconf_buffer_freeze(&sysroot_buf);
+				if (pkgconf_buffer_append(&sysroot_buf, client->sysroot_dir) &&
+					pkgconf_buffer_append(&sysroot_buf, string))
+				{
+					free(string);
+					string = pkgconf_buffer_freeze(&sysroot_buf);
+					if (string == NULL)
+					{
+						free(frag);
+						return false;
+					}
+				}
+				else
+					pkgconf_buffer_finalize(&sysroot_buf);
 			}
 		}
 
 		frag->type = 0;
 		frag->data = strdup(string);
+		if (frag->data == NULL)
+		{
+			free(frag);
+			free(string);
+			return false;
+		}
 
 		PKGCONF_TRACE(client, "created special fragment {'%s'} in list @%p", frag->data, target);
 	}
 
 	pkgconf_node_insert_tail(&frag->iter, frag, target);
 	free(string);
+	return true;
 }
 
 static inline pkgconf_fragment_t *
@@ -537,7 +580,7 @@ pkgconf_fragment_has_system_dir(const pkgconf_client_t *client, const pkgconf_fr
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_fragment_copy(const pkgconf_client_t *client, pkgconf_list_t *list, const pkgconf_fragment_t *base, bool is_private)
+ * .. c:function:: bool pkgconf_fragment_copy(const pkgconf_client_t *client, pkgconf_list_t *list, const pkgconf_fragment_t *base, bool is_private)
  *
  *    Copies a `fragment` to another `fragment list`, possibly removing a previous copy of the `fragment`
  *    in a process known as `mergeback`.
@@ -546,9 +589,10 @@ pkgconf_fragment_has_system_dir(const pkgconf_client_t *client, const pkgconf_fr
  *    :param pkgconf_list_t* list: The list the fragment is being added to.
  *    :param pkgconf_fragment_t* base: The fragment being copied.
  *    :param bool is_private: Whether the fragment list is a `private` fragment list (static linking).
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
+ *    :rtype: bool
  */
-void
+bool
 pkgconf_fragment_copy(const pkgconf_client_t *client, pkgconf_list_t *list, const pkgconf_fragment_t *base, bool is_private)
 {
 	pkgconf_fragment_t *frag;
@@ -559,22 +603,41 @@ pkgconf_fragment_copy(const pkgconf_client_t *client, pkgconf_list_t *list, cons
 			pkgconf_fragment_delete(list, frag);
 	}
 	else if (!is_private && !pkgconf_fragment_can_merge_back(base, client->flags, is_private) && (pkgconf_fragment_lookup(list, base) != NULL))
-		return;
+		return true;
 
 	frag = calloc(1, sizeof(pkgconf_fragment_t));
+	if (frag == NULL)
+		return false;
 
 	frag->type = base->type;
-	pkgconf_fragment_copy_list(client, &frag->children, &base->children);
+
+	if (!pkgconf_fragment_copy_list(client, &frag->children, &base->children))
+	{
+		pkgconf_fragment_free(&frag->children);
+		free(frag);
+		return false;
+	}
+
 	if (base->data != NULL)
+	{
 		frag->data = strdup(base->data);
+		if (frag->data == NULL)
+		{
+			pkgconf_fragment_free(&frag->children);
+			free(frag);
+			return false;
+		}
+	}
 
 	pkgconf_node_insert_tail(&frag->iter, frag, list);
+
+	return true;
 }
 
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_fragment_copy_list(const pkgconf_client_t *client, pkgconf_list_t *list, const pkgconf_list_t *base)
+ * .. c:function:: bool pkgconf_fragment_copy_list(const pkgconf_client_t *client, pkgconf_list_t *list, const pkgconf_list_t *base)
  *
  *    Copies a `fragment list` to another `fragment list`, possibly removing a previous copy of the fragments
  *    in a process known as `mergeback`.
@@ -582,9 +645,9 @@ pkgconf_fragment_copy(const pkgconf_client_t *client, pkgconf_list_t *list, cons
  *    :param pkgconf_client_t* client: The pkgconf client being accessed.
  *    :param pkgconf_list_t* list: The list the fragments are being added to.
  *    :param pkgconf_list_t* base: The list the fragments are being copied from.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_fragment_copy_list(const pkgconf_client_t *client, pkgconf_list_t *list, const pkgconf_list_t *base)
 {
 	pkgconf_node_t *node;
@@ -593,14 +656,17 @@ pkgconf_fragment_copy_list(const pkgconf_client_t *client, pkgconf_list_t *list,
 	{
 		pkgconf_fragment_t *frag = node->data;
 
-		pkgconf_fragment_copy(client, list, frag, true);
+		if (!pkgconf_fragment_copy(client, list, frag, true))
+			return false;
 	}
+
+	return true;
 }
 
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_fragment_filter(const pkgconf_client_t *client, pkgconf_list_t *dest, pkgconf_list_t *src, pkgconf_fragment_filter_func_t filter_func)
+ * .. c:function:: bool pkgconf_fragment_filter(const pkgconf_client_t *client, pkgconf_list_t *dest, pkgconf_list_t *src, pkgconf_fragment_filter_func_t filter_func, void *data)
  *
  *    Copies a `fragment list` to another `fragment list` which match a user-specified filtering function.
  *
@@ -609,9 +675,10 @@ pkgconf_fragment_copy_list(const pkgconf_client_t *client, pkgconf_list_t *list,
  *    :param pkgconf_list_t* src: The source list.
  *    :param pkgconf_fragment_filter_func_t filter_func: The filter function to use.
  *    :param void* data: Optional data to pass to the filter function.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
+ *    :rtype: bool
  */
-void
+bool
 pkgconf_fragment_filter(const pkgconf_client_t *client, pkgconf_list_t *dest, pkgconf_list_t *src, pkgconf_fragment_filter_func_t filter_func, void *data)
 {
 	pkgconf_node_t *node;
@@ -621,8 +688,13 @@ pkgconf_fragment_filter(const pkgconf_client_t *client, pkgconf_list_t *dest, pk
 		pkgconf_fragment_t *frag = node->data;
 
 		if (filter_func(client, frag, data))
-			pkgconf_fragment_copy(client, dest, frag, true);
+		{
+			if (!pkgconf_fragment_copy(client, dest, frag, true))
+				return false;
+		}
 	}
+
+	return true;
 }
 
 static bool
@@ -830,16 +902,34 @@ pkgconf_fragment_parse(pkgconf_client_t *client, pkgconf_list_t *list, pkgconf_l
 		{
 			pkgconf_buffer_t greedybuf = PKGCONF_BUFFER_INITIALIZER;
 
-			pkgconf_buffer_append(&greedybuf, argv[i]);
-			pkgconf_buffer_append(&greedybuf, argv[i + 1]);
-			pkgconf_fragment_add(client, list, vars, pkgconf_buffer_str(&greedybuf), flags);
+			if (!pkgconf_buffer_append(&greedybuf, argv[i]) ||
+				!pkgconf_buffer_append(&greedybuf, argv[i + 1]))
+			{
+				pkgconf_buffer_finalize(&greedybuf);
+				pkgconf_argv_free(argv);
+				return false;
+			}
+
+			bool added = pkgconf_fragment_add(client, list, vars, pkgconf_buffer_str(&greedybuf), flags);
 			pkgconf_buffer_finalize(&greedybuf);
+
+			if (!added)
+			{
+				pkgconf_argv_free(argv);
+				return false;
+			}
 
 			/* skip over next arg as we combined them */
 			i++;
 		}
 		else
-			pkgconf_fragment_add(client, list, vars, argv[i], flags);
+		{
+			if (!pkgconf_fragment_add(client, list, vars, argv[i], flags))
+			{
+				pkgconf_argv_free(argv);
+				return false;
+			}
+		}
 	}
 
 	pkgconf_argv_free(argv);

--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -531,14 +531,14 @@ PKGCONF_API pkgconf_tuple_t *pkgconf_tuple_add(const pkgconf_client_t *client, p
 PKGCONF_API const char *pkgconf_tuple_find(pkgconf_client_t *client, pkgconf_list_t *list, const char *key);
 PKGCONF_API void pkgconf_tuple_free(pkgconf_list_t *list);
 PKGCONF_API void pkgconf_tuple_free_entry(pkgconf_tuple_t *tuple, pkgconf_list_t *list);
-PKGCONF_API void pkgconf_tuple_add_global(pkgconf_client_t *client, const char *key, const char *value);
+PKGCONF_API bool pkgconf_tuple_add_global(pkgconf_client_t *client, const char *key, const char *value);
 PKGCONF_API const char *pkgconf_tuple_find_global(pkgconf_client_t *client, const char *key);
 PKGCONF_API void pkgconf_tuple_free_global(pkgconf_client_t *client);
-PKGCONF_API void pkgconf_tuple_define_global(pkgconf_client_t *client, const char *kv);
+PKGCONF_API bool pkgconf_tuple_define_global(pkgconf_client_t *client, const char *kv);
 
 /* queue.c */
-PKGCONF_API void pkgconf_queue_push(pkgconf_list_t *list, const char *package);
-PKGCONF_API void pkgconf_queue_push_dependency(pkgconf_list_t *list, const pkgconf_dependency_t *dep);
+PKGCONF_API bool pkgconf_queue_push(pkgconf_list_t *list, const char *package);
+PKGCONF_API bool pkgconf_queue_push_dependency(pkgconf_list_t *list, const pkgconf_dependency_t *dep);
 PKGCONF_API bool pkgconf_queue_compile(pkgconf_client_t *client, pkgconf_pkg_t *world, pkgconf_list_t *list);
 PKGCONF_API bool pkgconf_queue_solve(pkgconf_client_t *client, pkgconf_list_t *list, pkgconf_pkg_t *world, int maxdepth);
 PKGCONF_API void pkgconf_queue_free(pkgconf_list_t *list);

--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -251,7 +251,7 @@ struct pkgconf_pkg_ {
 };
 
 typedef bool (*pkgconf_pkg_iteration_func_t)(const pkgconf_pkg_t *pkg, void *data);
-typedef void (*pkgconf_pkg_traverse_func_t)(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *data);
+typedef bool (*pkgconf_pkg_traverse_func_t)(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *data);
 typedef bool (*pkgconf_queue_apply_func_t)(pkgconf_client_t *client, pkgconf_pkg_t *world, void *data, int maxdepth);
 typedef bool (*pkgconf_error_handler_func_t)(const char *msg, const pkgconf_client_t *client, void *data);
 typedef void (*pkgconf_unveil_handler_func_t)(const pkgconf_client_t *client, const char *path, const char *permissions);
@@ -359,18 +359,18 @@ PKGCONF_API bool pkgconf_variable_eval(pkgconf_client_t *client, const pkgconf_l
 PKGCONF_API char *pkgconf_variable_eval_str(pkgconf_client_t *client, const pkgconf_list_t *tuples, const pkgconf_variable_t *v, bool *saw_sysroot);
 
 /* client.c */
-PKGCONF_API void pkgconf_client_init(pkgconf_client_t *client, pkgconf_error_handler_func_t error_handler, void *error_handler_data, const pkgconf_cross_personality_t *personality, void *client_data, pkgconf_environ_lookup_handler_func_t environ_lookup_handler);
+PKGCONF_API bool pkgconf_client_init(pkgconf_client_t *client, pkgconf_error_handler_func_t error_handler, void *error_handler_data, const pkgconf_cross_personality_t *personality, void *client_data, pkgconf_environ_lookup_handler_func_t environ_lookup_handler);
 PKGCONF_API pkgconf_client_t * pkgconf_client_new(pkgconf_error_handler_func_t error_handler, void *error_handler_data, const pkgconf_cross_personality_t *personality, void *client_data, pkgconf_environ_lookup_handler_func_t environ_lookup_handler);
 PKGCONF_API void pkgconf_client_deinit(pkgconf_client_t *client);
 PKGCONF_API void pkgconf_client_free(pkgconf_client_t *client);
 PKGCONF_API const char *pkgconf_client_get_sysroot_dir(const pkgconf_client_t *client);
-PKGCONF_API void pkgconf_client_set_sysroot_dir(pkgconf_client_t *client, const char *sysroot_dir);
+PKGCONF_API bool pkgconf_client_set_sysroot_dir(pkgconf_client_t *client, const char *sysroot_dir);
 PKGCONF_API const char *pkgconf_client_get_buildroot_dir(const pkgconf_client_t *client);
-PKGCONF_API void pkgconf_client_set_buildroot_dir(pkgconf_client_t *client, const char *buildroot_dir);
+PKGCONF_API bool pkgconf_client_set_buildroot_dir(pkgconf_client_t *client, const char *buildroot_dir);
 PKGCONF_API unsigned int pkgconf_client_get_flags(const pkgconf_client_t *client);
 PKGCONF_API void pkgconf_client_set_flags(pkgconf_client_t *client, unsigned int flags);
 PKGCONF_API const char *pkgconf_client_get_prefix_varname(const pkgconf_client_t *client);
-PKGCONF_API void pkgconf_client_set_prefix_varname(pkgconf_client_t *client, const char *prefix_varname);
+PKGCONF_API bool pkgconf_client_set_prefix_varname(pkgconf_client_t *client, const char *prefix_varname);
 PKGCONF_API pkgconf_error_handler_func_t pkgconf_client_get_warn_handler(const pkgconf_client_t *client);
 PKGCONF_API void pkgconf_client_set_warn_handler(pkgconf_client_t *client, pkgconf_error_handler_func_t warn_handler, void *warn_handler_data);
 PKGCONF_API pkgconf_error_handler_func_t pkgconf_client_get_error_handler(const pkgconf_client_t *client);
@@ -379,7 +379,7 @@ PKGCONF_API pkgconf_error_handler_func_t pkgconf_client_get_trace_handler(const 
 PKGCONF_API void pkgconf_client_set_trace_handler(pkgconf_client_t *client, pkgconf_error_handler_func_t trace_handler, void *trace_handler_data);
 PKGCONF_API pkgconf_unveil_handler_func_t pkgconf_client_get_unveil_handler(const pkgconf_client_t *client);
 PKGCONF_API void pkgconf_client_set_unveil_handler(pkgconf_client_t *client, pkgconf_unveil_handler_func_t unveil_handler);
-PKGCONF_API void pkgconf_client_dir_list_build(pkgconf_client_t *client, const pkgconf_cross_personality_t *personality);
+PKGCONF_API bool pkgconf_client_dir_list_build(pkgconf_client_t *client, const pkgconf_cross_personality_t *personality);
 PKGCONF_API bool pkgconf_client_preload_one(pkgconf_client_t *client, pkgconf_pkg_t *pkg);
 PKGCONF_API bool pkgconf_client_preload_path(pkgconf_client_t *client, const char *path);
 PKGCONF_API bool pkgconf_client_preload_from_environ(pkgconf_client_t *client, const char *env);
@@ -424,6 +424,7 @@ PKGCONF_API void pkgconf_cross_personality_deinit(pkgconf_cross_personality_t *p
 #define PKGCONF_PKG_ERRF_PACKAGE_VER_MISMATCH	0x2
 #define PKGCONF_PKG_ERRF_PACKAGE_CONFLICT	0x4
 #define PKGCONF_PKG_ERRF_DEPGRAPH_BREAK		0x8
+#define PKGCONF_PKG_ERRF_OUTPUT_FAILURE		0x10
 
 #if __GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4)
 # define PRINTFLIKE(fmtarg, firstvararg) \
@@ -507,13 +508,13 @@ typedef struct pkgconf_fragment_render_ops_ {
 
 typedef bool (*pkgconf_fragment_filter_func_t)(const pkgconf_client_t *client, const pkgconf_fragment_t *frag, void *data);
 PKGCONF_API bool pkgconf_fragment_parse(pkgconf_client_t *client, pkgconf_list_t *list, pkgconf_list_t *vars, const char *value, unsigned int flags);
-PKGCONF_API void pkgconf_fragment_insert(pkgconf_client_t *client, pkgconf_list_t *list, char type, const char *data, bool tail);
-PKGCONF_API void pkgconf_fragment_add(pkgconf_client_t *client, pkgconf_list_t *list, pkgconf_list_t *vars, const char *string, unsigned int flags);
-PKGCONF_API void pkgconf_fragment_copy(const pkgconf_client_t *client, pkgconf_list_t *list, const pkgconf_fragment_t *base, bool is_private);
-PKGCONF_API void pkgconf_fragment_copy_list(const pkgconf_client_t *client, pkgconf_list_t *list, const pkgconf_list_t *base);
+PKGCONF_API bool pkgconf_fragment_insert(pkgconf_client_t *client, pkgconf_list_t *list, char type, const char *data, bool tail);
+PKGCONF_API bool pkgconf_fragment_add(pkgconf_client_t *client, pkgconf_list_t *list, pkgconf_list_t *vars, const char *string, unsigned int flags);
+PKGCONF_API bool pkgconf_fragment_copy(const pkgconf_client_t *client, pkgconf_list_t *list, const pkgconf_fragment_t *base, bool is_private);
+PKGCONF_API bool pkgconf_fragment_copy_list(const pkgconf_client_t *client, pkgconf_list_t *list, const pkgconf_list_t *base);
 PKGCONF_API void pkgconf_fragment_delete(pkgconf_list_t *list, pkgconf_fragment_t *node);
 PKGCONF_API void pkgconf_fragment_free(pkgconf_list_t *list);
-PKGCONF_API void pkgconf_fragment_filter(const pkgconf_client_t *client, pkgconf_list_t *dest, pkgconf_list_t *src, pkgconf_fragment_filter_func_t filter_func, void *data);
+PKGCONF_API bool pkgconf_fragment_filter(const pkgconf_client_t *client, pkgconf_list_t *dest, pkgconf_list_t *src, pkgconf_fragment_filter_func_t filter_func, void *data);
 PKGCONF_API bool pkgconf_fragment_render_buf(const pkgconf_list_t *list, pkgconf_buffer_t *buf, bool escape, const pkgconf_fragment_render_ops_t *ops, char delim);
 PKGCONF_API bool pkgconf_fragment_has_system_dir(const pkgconf_client_t *client, const pkgconf_fragment_t *frag);
 
@@ -557,8 +558,8 @@ PKGCONF_API void pkgconf_audit_log(pkgconf_client_t *client, const char *format,
 PKGCONF_API void pkgconf_audit_log_dependency(pkgconf_client_t *client, const pkgconf_pkg_t *dep, const pkgconf_dependency_t *depnode);
 
 /* path.c */
-PKGCONF_API void pkgconf_path_add(const char *text, pkgconf_list_t *dirlist, bool filter);
-PKGCONF_API void pkgconf_path_prepend(const char *text, pkgconf_list_t *dirlist, bool filter);
+PKGCONF_API bool pkgconf_path_add(const char *text, pkgconf_list_t *dirlist, bool filter);
+PKGCONF_API bool pkgconf_path_prepend(const char *text, pkgconf_list_t *dirlist, bool filter);
 PKGCONF_API size_t pkgconf_path_split(const char *text, pkgconf_list_t *dirlist, bool filter);
 PKGCONF_API size_t pkgconf_path_build_from_environ(const pkgconf_client_t *client, const char *envvarname, const char *fallback, pkgconf_list_t *dirlist, bool filter);
 #ifdef _WIN32
@@ -567,8 +568,8 @@ PKGCONF_API size_t pkgconf_path_build_from_registry(/* HKEY -> HANDLE -> PVOID *
 PKGCONF_API bool pkgconf_path_match_list(const char *path, const pkgconf_list_t *dirlist);
 PKGCONF_API void pkgconf_path_free(pkgconf_list_t *dirlist);
 PKGCONF_API bool pkgconf_path_relocate(pkgconf_buffer_t *buf);
-PKGCONF_API void pkgconf_path_copy_list(pkgconf_list_t *dst, const pkgconf_list_t *src);
-PKGCONF_API void pkgconf_path_prepend_list(pkgconf_list_t *dst, const pkgconf_list_t *src);
+PKGCONF_API bool pkgconf_path_copy_list(pkgconf_list_t *dst, const pkgconf_list_t *src);
+PKGCONF_API bool pkgconf_path_prepend_list(pkgconf_list_t *dst, const pkgconf_list_t *src);
 PKGCONF_API bool pkgconf_path_is_plausible(const pkgconf_buffer_t *buf);
 
 /* buffer.c */

--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -336,12 +336,12 @@ typedef struct pkgconf_bytecode_eval_ctx_ {
 } pkgconf_bytecode_eval_ctx_t;
 
 PKGCONF_API bool pkgconf_bytecode_eval(const pkgconf_client_t *client, const pkgconf_list_t *tuples, const pkgconf_bytecode_t *bc, pkgconf_buffer_t *out, bool *saw_sysroot);
-PKGCONF_API void pkgconf_bytecode_emit(pkgconf_buffer_t *buf, enum pkgconf_bytecode_op tag, const void *data, uint32_t size);
-PKGCONF_API void pkgconf_bytecode_emit_text(pkgconf_buffer_t *buf, const char *p, size_t n);
-PKGCONF_API void pkgconf_bytecode_emit_var(pkgconf_buffer_t *buf, const char *name, size_t nlen);
-PKGCONF_API void pkgconf_bytecode_emit_sysroot(pkgconf_buffer_t *buf);
+PKGCONF_API bool pkgconf_bytecode_emit(pkgconf_buffer_t *buf, enum pkgconf_bytecode_op tag, const void *data, uint32_t size);
+PKGCONF_API bool pkgconf_bytecode_emit_text(pkgconf_buffer_t *buf, const char *p, size_t n);
+PKGCONF_API bool pkgconf_bytecode_emit_var(pkgconf_buffer_t *buf, const char *name, size_t nlen);
+PKGCONF_API bool pkgconf_bytecode_emit_sysroot(pkgconf_buffer_t *buf);
 PKGCONF_API void pkgconf_bytecode_from_buffer(pkgconf_bytecode_t *bc, const pkgconf_buffer_t *buf);
-PKGCONF_API void pkgconf_bytecode_compile(pkgconf_buffer_t *out, const char *value);
+PKGCONF_API bool pkgconf_bytecode_compile(pkgconf_buffer_t *out, const char *value);
 PKGCONF_API bool pkgconf_bytecode_eval_str_to_buf(const pkgconf_client_t *client, const pkgconf_list_t *vars, const char *input, bool *saw_sysroot, pkgconf_buffer_t *out);
 PKGCONF_API char *pkgconf_bytecode_eval_str(const pkgconf_client_t *client, const pkgconf_list_t *vars, const char *input, bool *saw_sysroot);
 PKGCONF_API pkgconf_variable_t *pkgconf_bytecode_eval_lookup_var(pkgconf_bytecode_eval_ctx_t *ctx, const char *name, size_t nlen);

--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -502,7 +502,7 @@ typedef struct pkgconf_fragment_render_ctx_ {
 } pkgconf_fragment_render_ctx_t;
 
 typedef struct pkgconf_fragment_render_ops_ {
-	void (*render)(const pkgconf_fragment_render_ctx_t *ctx, const pkgconf_fragment_t *frag, pkgconf_buffer_t *buf);
+	bool (*render)(const pkgconf_fragment_render_ctx_t *ctx, const pkgconf_fragment_t *frag, pkgconf_buffer_t *buf);
 } pkgconf_fragment_render_ops_t;
 
 typedef bool (*pkgconf_fragment_filter_func_t)(const pkgconf_client_t *client, const pkgconf_fragment_t *frag, void *data);
@@ -514,16 +514,16 @@ PKGCONF_API void pkgconf_fragment_copy_list(const pkgconf_client_t *client, pkgc
 PKGCONF_API void pkgconf_fragment_delete(pkgconf_list_t *list, pkgconf_fragment_t *node);
 PKGCONF_API void pkgconf_fragment_free(pkgconf_list_t *list);
 PKGCONF_API void pkgconf_fragment_filter(const pkgconf_client_t *client, pkgconf_list_t *dest, pkgconf_list_t *src, pkgconf_fragment_filter_func_t filter_func, void *data);
-PKGCONF_API void pkgconf_fragment_render_buf(const pkgconf_list_t *list, pkgconf_buffer_t *buf, bool escape, const pkgconf_fragment_render_ops_t *ops, char delim);
+PKGCONF_API bool pkgconf_fragment_render_buf(const pkgconf_list_t *list, pkgconf_buffer_t *buf, bool escape, const pkgconf_fragment_render_ops_t *ops, char delim);
 PKGCONF_API bool pkgconf_fragment_has_system_dir(const pkgconf_client_t *client, const pkgconf_fragment_t *frag);
 
 /* license.c */
-PKGCONF_API void pkgconf_license_copy_list(const pkgconf_client_t *client, pkgconf_list_t *list, const pkgconf_list_t *base);
-PKGCONF_API void pkgconf_license_evaluate_str(pkgconf_client_t *client, pkgconf_list_t *deplist_head, const char *expression, unsigned int flags);
-PKGCONF_API void pkgconf_license_evaluate(pkgconf_client_t *client, pkgconf_pkg_t *pkg, pkgconf_list_t *deplist, const char *depends, unsigned int flags);
+PKGCONF_API bool pkgconf_license_copy_list(const pkgconf_client_t *client, pkgconf_list_t *list, const pkgconf_list_t *base);
+PKGCONF_API bool pkgconf_license_evaluate_str(pkgconf_client_t *client, pkgconf_list_t *deplist_head, const char *expression, unsigned int flags);
+PKGCONF_API bool pkgconf_license_evaluate(pkgconf_client_t *client, pkgconf_pkg_t *pkg, pkgconf_list_t *deplist, const char *depends, unsigned int flags);
 PKGCONF_API void pkgconf_license_free(pkgconf_list_t *list);
-PKGCONF_API void pkgconf_license_insert(pkgconf_client_t *client, pkgconf_list_t *list, unsigned char type, const char *data);
-PKGCONF_API void pkgconf_license_render(pkgconf_client_t *client, const pkgconf_list_t *list, pkgconf_buffer_t *buf);
+PKGCONF_API bool pkgconf_license_insert(pkgconf_client_t *client, pkgconf_list_t *list, unsigned char type, const char *data);
+PKGCONF_API bool pkgconf_license_render(pkgconf_client_t *client, const pkgconf_list_t *list, pkgconf_buffer_t *buf);
 
 /* tuple.c */
 PKGCONF_API pkgconf_tuple_t *pkgconf_tuple_add(const pkgconf_client_t *client, pkgconf_list_t *parent, const char *key, const char *value, bool parse, unsigned int flags);

--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -602,19 +602,64 @@ PKGCONF_API bool pkgconf_buffer_contains_byte(const pkgconf_buffer_t *haystack, 
 PKGCONF_API bool pkgconf_buffer_match(const pkgconf_buffer_t *haystack, const pkgconf_buffer_t *needle);
 PKGCONF_API bool pkgconf_buffer_subst(pkgconf_buffer_t *dest, const pkgconf_buffer_t *src, const char *pattern, const char *value);
 PKGCONF_API bool pkgconf_buffer_escape(pkgconf_buffer_t *dest, const pkgconf_buffer_t *src, const pkgconf_span_t *spans, size_t nspans);
-static inline const char *pkgconf_buffer_str(const pkgconf_buffer_t *buffer) {
+
+/*
+ * !doc
+ *
+ * .. c:function:: static inline const char *pkgconf_buffer_str(const pkgconf_buffer_t *buffer)
+ *
+ *    Get the underlying string from the buffer. This may return :code:`NULL`.
+ *
+ *    :param const pkgconf_buffer_t *buffer: The buffer to get the string from.
+ *    :return: The underlying string.
+ */
+static inline const char *pkgconf_buffer_str(const pkgconf_buffer_t *buffer)
+{
 	return buffer->base;
 }
 
-static inline const char *pkgconf_buffer_str_or_empty(const pkgconf_buffer_t *buffer) {
+/*
+ * !doc
+ *
+ * .. c:function:: static inline const char *pkgconf_buffer_str_or_empty(const pkgconf_buffer_t *buffer)
+ *
+ *    Get the underlying string from the buffer, or the empty string if :code:`NULL`.
+ *
+ *    :param const pkgconf_buffer_t *buffer: The buffer to get the string from.
+ *    :return: The underlying string, or the empty string.
+ */
+static inline const char *pkgconf_buffer_str_or_empty(const pkgconf_buffer_t *buffer)
+{
 	return buffer->base != NULL ? buffer->base : "";
 }
 
-static inline size_t pkgconf_buffer_len(const pkgconf_buffer_t *buffer) {
+/*
+ * !doc
+ *
+ * .. c:function:: static inline size_t *pkgconf_buffer_len(const pkgconf_buffer_t *buffer)
+ *
+ *    Get the underlying raw buffer length.
+ *
+ *    :param const pkgconf_buffer_t *buffer: The buffer to check the length of.
+ *    :return: The size of the underlying buffer.
+ */
+static inline size_t pkgconf_buffer_len(const pkgconf_buffer_t *buffer)
+{
 	return (size_t)(ptrdiff_t)(buffer->end - buffer->base);
 }
 
-static inline char pkgconf_buffer_lastc(const pkgconf_buffer_t *buffer) {
+/*
+ * !doc
+ *
+ * .. c:function:: static inline const char *pkgconf_buffer_lastc(const pkgconf_buffer_t *buffer)
+ *
+ *    Get the last character from the buffer. If the buffer is empty, return :code:`'\0'`.
+ *
+ *    :param pkgconf_buffer_t *buffer: The buffer to get the last character from.
+ *    :return: The last character, or '\0' if the string is empty.
+ */
+static inline char pkgconf_buffer_lastc(const pkgconf_buffer_t *buffer)
+{
 	if (buffer->base == buffer->end)
 		return '\0';
 
@@ -625,12 +670,35 @@ static inline char pkgconf_buffer_lastc(const pkgconf_buffer_t *buffer) {
 #define PKGCONF_BUFFER_FROM_STR(str) &(const pkgconf_buffer_t){ .base = str, .end = ((str) ? &(str)[strlen(str)] : (str)) }
 #define PKGCONF_BUFFER_FROM_STR_NONNULL(str) &(const pkgconf_buffer_t){ .base = str, .end = &(str)[strlen(str)] }
 
-static inline void pkgconf_buffer_reset(pkgconf_buffer_t *buffer) {
+/*
+ * !doc
+ *
+ * .. c:function:: static inline void pkgconf_buffer_reset(const pkgconf_buffer_t *buffer)
+ *
+ *    Reset the underlying buffer, freeing any existing string.
+ *
+ *    :param pkgconf_buffer_t *buffer: The buffer to reset.
+ *    :return: nothing
+ */
+static inline void pkgconf_buffer_reset(pkgconf_buffer_t *buffer)
+{
 	pkgconf_buffer_finalize(buffer);
 	buffer->base = buffer->end = NULL;
 }
 
-static inline char *pkgconf_buffer_freeze(pkgconf_buffer_t *buffer) {
+/*
+ * !doc
+ *
+ * .. c:function:: static inline char *pkgconf_buffer_freeze(pkgconf_buffer_t *buffer)
+ *
+ *    Free the underlying buffer, copying the underlying string.
+ *    The string must be freed by the caller.
+ *
+ *    :param pkgconf_buffer_t *buffer: The buffer to freeze.
+ *    :return: The underlying string, copied.
+ */
+static inline char *pkgconf_buffer_freeze(pkgconf_buffer_t *buffer)
+{
 	if (buffer->base == NULL)
 		return NULL;
 
@@ -639,12 +707,35 @@ static inline char *pkgconf_buffer_freeze(pkgconf_buffer_t *buffer) {
 	return out;
 }
 
-static inline void pkgconf_buffer_copy(pkgconf_buffer_t *buffer, pkgconf_buffer_t *newptr)
+/*
+ * !doc
+ *
+ * .. c:function:: static inline bool pkgconf_buffer_copy(pkgconf_buffer_t *buffer, pkgconf_buffer_t *newptr)
+ *
+ *    Copy the contents of one buffer to another, erasing the contents of the buffer in :code:`newptr`.
+ *
+ *    :param pkgconf_buffer_t *buffer: The buffer to copy from.
+ *    :param pkgconf_buffer_t *buffer: The buffer to copy to.
+ *    :return: :code:`true` on success, :code:`false` on failure.
+ */
+static inline bool pkgconf_buffer_copy(pkgconf_buffer_t *buffer, pkgconf_buffer_t *newptr)
 {
 	pkgconf_buffer_reset(newptr);
-	pkgconf_buffer_append_slice(newptr, pkgconf_buffer_str(buffer), pkgconf_buffer_len(buffer));
+	return pkgconf_buffer_append_slice(newptr, pkgconf_buffer_str(buffer), pkgconf_buffer_len(buffer));
 }
 
+/*
+ * !doc
+ *
+ * .. c:function:: static inline bool pkgconf_str_eq_slice(const char *s, const char *p, size_t n)
+ *
+ *    Compare :code:`s` to :code:`p`, which must be :code:`n` size long.
+ *
+ *    :param const char *s: string to search
+ *    :param const char *p: string to search for
+ *    :param size_t n: length of :code:`s`
+ *    :return: :code:`true` if equal, :code:`false` if not.
+ */
 static inline bool pkgconf_str_eq_slice(const char *s, const char *p, size_t n)
 {
 	return s != NULL &&

--- a/libpkgconf/license.c
+++ b/libpkgconf/license.c
@@ -16,7 +16,8 @@
 #include <libpkgconf/stdinc.h>
 #include <libpkgconf/libpkgconf.h>
 
-static void license_sanitize_string(const char *s, pkgconf_buffer_t *buf)
+static bool
+license_sanitize_string(const char *s, pkgconf_buffer_t *buf)
 {
 	unsigned int i = 0;
 	/*
@@ -29,24 +30,27 @@ static void license_sanitize_string(const char *s, pkgconf_buffer_t *buf)
 	{
 		if (isalnum(s[i]) || s[i] == '-' || s[i] == '+' || s[i] == '(' || s[i] == ')' || s[i] == '.' || s[i] == ':')
 		{
-			pkgconf_buffer_push_byte(buf, s[i]);
+			if (!pkgconf_buffer_push_byte(buf, s[i]))
+				return false;
 		}
 	}
+
+	return true;
 }
 
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_license_copy_list(const pkgconf_client_t *client, pkgconf_list_t *list, const pkgconf_list_t *base)
+ * .. c:function:: bool pkgconf_license_copy_list(const pkgconf_client_t *client, pkgconf_list_t *list, const pkgconf_list_t *base)
  *
  *    Copies a `license list` to another `license list`
  *
  *    :param pkgconf_client_t* client: The pkgconf client being accessed.
  *    :param pkgconf_list_t* list: The list the fragments are being added to.
  *    :param pkgconf_list_t* base: The list the fragments are being copied from.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_license_copy_list(const pkgconf_client_t *client, pkgconf_list_t *list, const pkgconf_list_t *base)
 {
 	pkgconf_node_t *node;
@@ -55,17 +59,33 @@ pkgconf_license_copy_list(const pkgconf_client_t *client, pkgconf_list_t *list, 
 	PKGCONF_FOREACH_LIST_ENTRY(base->head, node)
 	{
 		pkgconf_license_t *license = node->data;
+		if (!license)
+		{
+			pkgconf_error(client, "license list corrupted");
+			return false;
+		}
+
 		pkgconf_license_t *cpy_license = calloc(1, sizeof(pkgconf_license_t));
+
+		if (cpy_license == NULL)
+			return false;
 
 		cpy_license->type = license->type;
 
 		if (license->data != NULL)
 		{
 			cpy_license->data = strdup(license->data);
+			if (cpy_license->data == NULL)
+			{
+				free(cpy_license);
+				return false;
+			}
 		}
 
 		pkgconf_node_insert_tail(&cpy_license->iter, cpy_license, list);
 	}
+
+	return true;
 }
 
 /*
@@ -89,6 +109,9 @@ pkgconf_license_free(pkgconf_list_t *list)
 	PKGCONF_FOREACH_LIST_ENTRY_SAFE(list->head, next, node)
 	{
 		pkgconf_license_t *license = node->data;
+		if (!license)
+			continue;
+
 		free(license->data);
 		free(license);
 	}
@@ -105,9 +128,9 @@ pkgconf_license_free(pkgconf_list_t *list)
  *    :param pkgconf_list_t* list: The fragment list.
  *    :param char type: The type of the license.
  *    :param char* data: The data of the license
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_license_insert(pkgconf_client_t *client, pkgconf_list_t *list, unsigned char type, const char *data)
 {
 	(void) client;
@@ -118,39 +141,48 @@ pkgconf_license_insert(pkgconf_client_t *client, pkgconf_list_t *list, unsigned 
 	if (!license)
 	{
 		pkgconf_error(client, "pkgconf_license_insert: out of memory");
-		return;
+		return false;
 	}
 	license->type = type;
 	license->data = strdup(data);
+	if (license->data == NULL)
+	{
+		free(license);
+		return false;
+	}
 
 	pkgconf_node_insert_tail(&license->iter, license, list);
+
+	return true;
 }
 
 /*
  * !doc
  *
- * .. c:function:: pkgconf_license_evaluate_str(pkgconf_client_t *client, pkgconf_list_t *license_list, const char *expression, unsigned int flags)
+ * .. c:function:: bool pkgconf_license_evaluate_str(pkgconf_client_t *client, pkgconf_list_t *license_list, const char *expression, unsigned int flags)
  *
- * Evaluates SPDX expression strings like:
- * - BSD-3-Clause
- * - LGPL-2.1-only OR MIT
- * - LGPL-2.1-only OR MIT OR BSD-3-Clause
- * - ISC AND (BSD-3-Clause AND BSD-2-Clause)
+ *    Evaluates SPDX expression strings like:
  *
- * Function parses and sanitizes license strings. Also adding multiple
- * 'License:'-keys is supported like:
- * License: BSD-3-Clause
- * License: BSD-2-Clause
+ *    - BSD-3-Clause
+ *    - LGPL-2.1-only OR MIT
+ *    - LGPL-2.1-only OR MIT OR BSD-3-Clause
+ *    - ISC AND (BSD-3-Clause AND BSD-2-Clause)
  *
- * Which will evaluate to: BSD-3-Clause AND BSD-2-Clause
+ *    Function parses and sanitizes license strings. Also adding multiple
+ *    'License:'-keys is supported like:
  *
- * :param pkgconf_client_t* client: The client object that owns the package this dependency list belongs to.
- * :param pkgconf_list_t* license_list: The dependency list to populate with dependency nodes.
- * :param char* expression: The dependency data to parse.
- * :param uint flags: Any flags to attach to the dependency nodes.
- * :return: nothing
+ *    | License: BSD-3-Clause
+ *    | License: BSD-2-Clause
+ *
+ *    Which will evaluate to: BSD-3-Clause AND BSD-2-Clause
+ *
+ *    :param pkgconf_client_t *client: The client object that owns the package this license list belongs to.
+ *    :param pkgconf_list_t *license_list: The license list to populate with license nodes.
+ *    :param char *expression: The SPDX expression string to parse.
+ *    :param unsigned int flags: Any flags to attach to the license nodes.
+ *    :return: :code:`true` on success, :code:`false` on parse or allocation failure.
  */
-void
+bool
 pkgconf_license_evaluate_str(pkgconf_client_t *client, pkgconf_list_t *license_list, const char *expression, unsigned int flags)
 {
 	pkgconf_buffer_t out_buffer = PKGCONF_BUFFER_INITIALIZER;
@@ -159,132 +191,127 @@ pkgconf_license_evaluate_str(pkgconf_client_t *client, pkgconf_list_t *license_l
 	int i, ret, argc;
 	char **argv;
 	size_t string_len = 0;
+	bool success = true;
 
 	(void)flags;
 
 	buf_size = strlen(expression) + 1;
 	ret = pkgconf_argv_split(expression, &argc, &argv);
-	if (!ret)
+	if (ret)
+		return false;
+
+	if (license_list->head)
 	{
-		/* This is not the first License:
-		 * so add AND
-		 */
-		if (license_list->head)
+		if (!pkgconf_license_insert(client, license_list, PKGCONF_LICENSE_AND, "AND"))
 		{
-			pkgconf_license_insert(client, license_list, PKGCONF_LICENSE_AND, "AND");
-		}
-
-		i = 0;
-		while (i < argc)
-		{
-			string_len = strnlen(argv[i], buf_size);
-			cur_word = argv[i];
-			if (string_len >= 1)
-			{
-				license_sanitize_string(cur_word, &out_buffer);
-				cur_word = (char *)pkgconf_buffer_str_or_empty(&out_buffer);
-				if (!strnlen(cur_word, buf_size))
-				{
-					i ++;
-					pkgconf_buffer_finalize(&out_buffer);
-					continue;
-				}
-
-				if (cur_word[0] == '(')
-				{
-					pkgconf_license_insert(client, license_list, PKGCONF_LICENSE_BRACKET_OPEN, "(");
-					/* If there is more after '(' like '(BSD-2-Clause'
-					 * Then append rest to fragments as license.
-					 * This is expression like GPL-2.0-only OR (BSD-2-Clause AND ISC)
-					 */
-					if (string_len >= 2)
-					{
-						cur_word ++;
-						pkgconf_license_insert(client, license_list, PKGCONF_LICENSE_EXPRESSION, cur_word);
-					}
-				}
-				else if (cur_word[string_len - 1] == ')')
-				{
-					if (string_len >= 2)
-					{
-						argv[i][string_len - 1] = 0x00;
-						pkgconf_license_insert(client, license_list, PKGCONF_LICENSE_EXPRESSION, argv[i]);
-					}
-					pkgconf_license_insert(client, license_list, PKGCONF_LICENSE_BRACKET_CLOSE, ")");
-				}
-				else if (!strncasecmp(cur_word, "and", 3))
-				{
-					pkgconf_license_insert(client, license_list, PKGCONF_LICENSE_AND, "AND");
-				}
-				else if (!strncasecmp(cur_word, "or", 2))
-				{
-					pkgconf_license_insert(client, license_list, PKGCONF_LICENSE_OR, "OR");
-				}
-				else if (!strncasecmp(cur_word, "with", 2))
-				{
-					pkgconf_license_insert(client, license_list, PKGCONF_LICENSE_WITH, "WITH");
-				}
-				else
-				{
-					pkgconf_license_insert(client, license_list, PKGCONF_LICENSE_EXPRESSION, cur_word);
-				}
-				pkgconf_buffer_finalize(&out_buffer);
-			}
-			i++;
+			success = false;
+			goto out;
 		}
 	}
 
+	for (i = 0; i < argc; i++)
+	{
+		string_len = strnlen(argv[i], buf_size);
+		cur_word = argv[i];
+
+		if (string_len < 1)
+			continue;
+
+		pkgconf_buffer_reset(&out_buffer);
+		if (!license_sanitize_string(cur_word, &out_buffer))
+		{
+			success = false;
+			goto out;
+		}
+
+		cur_word = (char *)pkgconf_buffer_str_or_empty(&out_buffer);
+		if (!strnlen(cur_word, buf_size))
+			continue;
+
+		bool inserted = true;
+
+		if (cur_word[0] == '(')
+		{
+			inserted = pkgconf_license_insert(client, license_list, PKGCONF_LICENSE_BRACKET_OPEN, "(");
+			if (inserted && string_len >= 2)
+			{
+				cur_word++;
+				inserted = pkgconf_license_insert(client, license_list, PKGCONF_LICENSE_EXPRESSION, cur_word);
+			}
+		}
+		else if (cur_word[string_len - 1] == ')')
+		{
+			if (string_len >= 2)
+			{
+				argv[i][string_len - 1] = 0x00;
+				inserted = pkgconf_license_insert(client, license_list, PKGCONF_LICENSE_EXPRESSION, argv[i]);
+			}
+			if (inserted)
+				inserted = pkgconf_license_insert(client, license_list, PKGCONF_LICENSE_BRACKET_CLOSE, ")");
+		}
+		else if (!strncasecmp(cur_word, "and", 3))
+			inserted = pkgconf_license_insert(client, license_list, PKGCONF_LICENSE_AND, "AND");
+		else if (!strncasecmp(cur_word, "or", 2))
+			inserted = pkgconf_license_insert(client, license_list, PKGCONF_LICENSE_OR, "OR");
+		else if (!strncasecmp(cur_word, "with", 2))
+			inserted = pkgconf_license_insert(client, license_list, PKGCONF_LICENSE_WITH, "WITH");
+		else
+			inserted = pkgconf_license_insert(client, license_list, PKGCONF_LICENSE_EXPRESSION, cur_word);
+
+		if (!inserted)
+		{
+			success = false;
+			goto out;
+		}
+	}
+
+out:
+	pkgconf_buffer_finalize(&out_buffer);
 	pkgconf_argv_free(argv);
+
+	return success;
 }
 
 /*
  * !doc
  *
- * .. c:function:: pkgconf_license_evaluate_str(pkgconf_client_t *client, pkgconf_list_t *license_list, const char *expression, unsigned int flags)
+ * .. c:function:: bool pkgconf_license_evaluate(pkgconf_client_t *client, pkgconf_pkg_t *pkg, pkgconf_list_t *license_list, const char *license_str, unsigned int flags)
  *
- * Evaluates SPDX expression strings like:
- * - BSD-3-Clause
- * - LGPL-2.1-only OR MIT
- * - LGPL-2.1-only OR MIT OR BSD-3-Clause
- * - ISC AND (BSD-3-Clause AND BSD-2-Clause)
+ *    Evaluates a license expression in the context of a package, performing variable
+ *    substitution before parsing the SPDX expression.
  *
- * Function parses and sanitizes license strings. Also adding multiple
- * 'License:'-keys is supported like:
- * License: BSD-3-Clause
- * License: BSD-2-Clause
- *
- * Which will evaluate to: BSD-3-Clause AND BSD-2-Clause
- *
- * :param pkgconf_client_t* client: The client object that owns the package this dependency list belongs to.
- * :param pkgconf_list_t* license_list: The dependency list to populate with dependency nodes.
- * :param char* expression: The dependency data to parse.
- * :param uint flags: Any flags to attach to the dependency nodes.
- * :return: nothing
+ *    :param pkgconf_client_t *client: The client object that owns the package this license list belongs to.
+ *    :param pkgconf_pkg_t *pkg: The package object that owns this license list.
+ *    :param pkgconf_list_t *license_list: The license list to populate with license nodes.
+ *    :param char *license_str: The license string to parse, possibly containing variable references.
+ *    :param unsigned int flags: Any flags to attach to the license nodes.
+ *    :return: :code:`true` on success, :code:`false` on parse or allocation failure.
  */
-void
+bool
 pkgconf_license_evaluate(pkgconf_client_t *client, pkgconf_pkg_t *pkg, pkgconf_list_t *license_list, const char *license_str, unsigned int flags)
 {
 	char *license_expression = pkgconf_bytecode_eval_str(client, &pkg->vars, license_str, NULL);
 
-	pkgconf_license_evaluate_str(client, license_list, license_expression, flags);
+	bool ret = pkgconf_license_evaluate_str(client, license_list, license_expression, flags);
 	free(license_expression);
+
+	return ret;
 }
 
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_dependency_parse_str(pkgconf_list_t *deplist_head, const char *depends)
+ * .. c:function:: bool pkgconf_license_render(pkgconf_client_t *client, const pkgconf_list_t *list, pkgconf_buffer_t *buf)
  *
- * Renders license fragments back to SPDX expression string. Tries
- * to keep output as close as possible to original input
+ *    Renders license fragments back to an SPDX expression string. Tries
+ *    to keep output as close as possible to the original input.
  *
- * :param pkgconf_client_t* client: The client object that owns the package this dependency list belongs to.
- * :param pkgconf_list_t* deplist_head: The dependency list to populate with dependency nodes.
- * :param char* depends: The dependency data to parse.
- * :param uint flags: Any flags to attach to the dependency nodes.
- * :return: nothing
+ *    :param pkgconf_client_t *client: The client object that owns the package this license list belongs to.
+ *    :param pkgconf_list_t *list: The license list to render.
+ *    :param pkgconf_buffer_t *buf: The buffer to render the license expression into.
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_license_render(pkgconf_client_t *client, const pkgconf_list_t *list, pkgconf_buffer_t *buf)
 {
 	const pkgconf_buffer_t *frag_string = NULL;
@@ -298,16 +325,19 @@ pkgconf_license_render(pkgconf_client_t *client, const pkgconf_list_t *list, pkg
 		pkgconf_license_t *license = node->data;
 		is_delim = true;
 		frag_string = PKGCONF_BUFFER_FROM_STR(license->data);
-		pkgconf_buffer_append(buf, pkgconf_buffer_str_or_empty(frag_string));
+
+		if (!pkgconf_buffer_append(buf, pkgconf_buffer_str_or_empty(frag_string)))
+			return false;
 
 		if (license->type == PKGCONF_LICENSE_BRACKET_OPEN || (node->next != NULL && ((const pkgconf_license_t *)node->next)->type == PKGCONF_LICENSE_BRACKET_CLOSE))
-		{
 			is_delim = false;
-		}
 
 		if (node->next != NULL && is_delim)
 		{
-			pkgconf_buffer_push_byte(buf, ' ');
+			if (!pkgconf_buffer_push_byte(buf, ' '))
+				return false;
 		}
 	}
+
+	return true;
 }

--- a/libpkgconf/output.c
+++ b/libpkgconf/output.c
@@ -23,14 +23,25 @@ pkgconf_output_putbuf(pkgconf_output_t *output, pkgconf_output_stream_t stream, 
 	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
 
 	if (pkgconf_buffer_len(buffer) != 0)
-		pkgconf_buffer_append(&buf, pkgconf_buffer_str(buffer));
+	{
+		if (!pkgconf_buffer_append(&buf, pkgconf_buffer_str(buffer)))
+		{
+			pkgconf_buffer_finalize(&buf);
+			return false;
+		}
+	}
 
 	if (newline)
-		pkgconf_buffer_push_byte(&buf, '\n');
+	{
+		if (!pkgconf_buffer_push_byte(&buf, '\n'))
+		{
+			pkgconf_buffer_finalize(&buf);
+			return false;
+		}
+	}
 
 	ret = output->write(output, stream, &buf);
 	pkgconf_buffer_finalize(&buf);
-
 	return ret;
 }
 
@@ -40,11 +51,15 @@ pkgconf_output_puts(pkgconf_output_t *output, pkgconf_output_stream_t stream, co
 	bool ret;
 	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
 
-	pkgconf_buffer_append(&buf, str);
-	pkgconf_buffer_push_byte(&buf, '\n');
+	if (!pkgconf_buffer_append(&buf, str) ||
+	    !pkgconf_buffer_push_byte(&buf, '\n'))
+	{
+		pkgconf_buffer_finalize(&buf);
+		return false;
+	}
+
 	ret = output->write(output, stream, &buf);
 	pkgconf_buffer_finalize(&buf);
-
 	return ret;
 }
 
@@ -69,12 +84,16 @@ pkgconf_output_vfmt(pkgconf_output_t *output, pkgconf_output_stream_t stream, co
 	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
 
 	va_copy(va, src_va);
-	pkgconf_buffer_append_vfmt(&buf, fmt, va);
+	if (!pkgconf_buffer_append_vfmt(&buf, fmt, va))
+	{
+		va_end(va);
+		pkgconf_buffer_finalize(&buf);
+		return false;
+	}
 	va_end(va);
 
 	ret = output->write(output, stream, &buf);
 	pkgconf_buffer_finalize(&buf);
-
 	return ret;
 }
 
@@ -82,19 +101,16 @@ static bool
 pkgconf_output_stdio_write(pkgconf_output_t *output, pkgconf_output_stream_t stream, const pkgconf_buffer_t *buffer)
 {
 	(void) output;
-
 	FILE *target = stream == PKGCONF_OUTPUT_STDERR ? stderr : stdout;
-
 	if (buffer != NULL)
 	{
 		const char *str = pkgconf_buffer_str(buffer);
 		size_t size = pkgconf_buffer_len(buffer);
-
 		if (size > 0 && !fwrite(str, size, 1, target))
 			return false;
 	}
-
-	fflush(target);
+	if (fflush(target) != 0)
+		return false;
 	return true;
 }
 

--- a/libpkgconf/path.c
+++ b/libpkgconf/path.c
@@ -60,13 +60,29 @@ path_list_contains_entry(const pkgconf_buffer_t *text, pkgconf_list_t *dirlist)
  */
 
 static pkgconf_path_t *
-prepare_path_node(const char *text, pkgconf_list_t *dirlist, bool filter)
+prepare_path_node(const char *text, pkgconf_list_t *dirlist, bool filter, bool *err)
 {
 	pkgconf_path_t *node;
 	pkgconf_buffer_t pathbuf = PKGCONF_BUFFER_INITIALIZER;
 
-	pkgconf_buffer_append(&pathbuf, text);
-	pkgconf_path_relocate(&pathbuf);
+	if (err != NULL)
+		*err = false;
+
+	if (!pkgconf_buffer_append(&pathbuf, text))
+	{
+		pkgconf_buffer_finalize(&pathbuf);
+		if (err != NULL)
+			*err = true;
+		return NULL;
+	}
+
+	if (!pkgconf_path_relocate(&pathbuf))
+	{
+		pkgconf_buffer_finalize(&pathbuf);
+		if (err != NULL)
+			*err = true;
+		return NULL;
+	}
 
 #ifdef PKGCONF_CACHE_INODES
 	struct stat st;
@@ -109,10 +125,19 @@ prepare_path_node(const char *text, pkgconf_list_t *dirlist, bool filter)
 	if (node == NULL)
 	{
 		pkgconf_buffer_finalize(&pathbuf);
+		if (err != NULL)
+			*err = true;
 		return NULL;
 	}
 
 	node->path = pkgconf_buffer_freeze(&pathbuf);
+	if (node->path == NULL)
+	{
+		free(node);
+		if (err != NULL)
+			*err = true;
+		return NULL;
+	}
 
 #ifdef PKGCONF_CACHE_INODES
 	if (filter)
@@ -128,45 +153,49 @@ prepare_path_node(const char *text, pkgconf_list_t *dirlist, bool filter)
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_path_add(const char *text, pkgconf_list_t *dirlist)
+ * .. c:function:: bool pkgconf_path_add(const char *text, pkgconf_list_t *dirlist, bool filter)
  *
  *    Adds a path node to a path list.  If the path is already in the list, do nothing.
  *
  *    :param char* text: The path text to add as a path node.
  *    :param pkgconf_list_t* dirlist: The path list to add the path node to.
  *    :param bool filter: Whether to perform duplicate filtering.
- *    :return: nothing
+ *    :return: :code:`true` on success or duplicate skip, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_path_add(const char *text, pkgconf_list_t *dirlist, bool filter)
 {
-	pkgconf_path_t *node = prepare_path_node(text, dirlist, filter);
+	bool err = false;
+	pkgconf_path_t *node = prepare_path_node(text, dirlist, filter, &err);
 	if (node == NULL)
-		return;
+		return !err;
 
 	pkgconf_node_insert_tail(&node->lnode, node, dirlist);
+	return true;
 }
 
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_path_prepend(const char *text, pkgconf_list_t *dirlist)
+ * .. c:function:: bool pkgconf_path_prepend(const char *text, pkgconf_list_t *dirlist, bool filter)
  *
  *    Prepends a path node to a path list.  If the path is already in the list, do nothing.
  *
  *    :param char* text: The path text to add as a path node.
  *    :param pkgconf_list_t* dirlist: The path list to add the path node to.
  *    :param bool filter: Whether to perform duplicate filtering.
- *    :return: nothing
+ *    :return: :code:`true` on success or duplicate skip, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_path_prepend(const char *text, pkgconf_list_t *dirlist, bool filter)
 {
-	pkgconf_path_t *node = prepare_path_node(text, dirlist, filter);
+	bool err = false;
+	pkgconf_path_t *node = prepare_path_node(text, dirlist, filter, &err);
 	if (node == NULL)
-		return;
+		return !err;
 
 	pkgconf_node_insert(&node->lnode, node, dirlist);
+	return true;
 }
 
 /*
@@ -194,9 +223,10 @@ pkgconf_path_split(const char *text, pkgconf_list_t *dirlist, bool filter)
 	iter = workbuf = strdup(text);
 	while ((p = strtok(iter, PKG_CONFIG_PATH_SEP_S)) != NULL)
 	{
-		pkgconf_path_add(p, dirlist, filter);
+		if (pkgconf_path_add(p, dirlist, filter))
+			count++;
 
-		count++, iter = NULL;
+		iter = NULL;
 	}
 	free(workbuf);
 
@@ -254,7 +284,11 @@ pkgconf_path_match_list(const char *path, const pkgconf_list_t *dirlist)
 	pkgconf_buffer_t relocated = PKGCONF_BUFFER_INITIALIZER;
 	const char *cpath = path;
 
-	pkgconf_buffer_append(&relocated, path);
+	if (!pkgconf_buffer_append(&relocated, path))
+	{
+		pkgconf_buffer_finalize(&relocated);
+		return false;
+	}
 	cpath = pkgconf_buffer_str(&relocated);
 
 	if (pkgconf_path_relocate(&relocated))
@@ -278,50 +312,54 @@ pkgconf_path_match_list(const char *path, const pkgconf_list_t *dirlist)
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_path_copy_list(pkgconf_list_t *dst, const pkgconf_list_t *src)
+ * .. c:function:: bool pkgconf_path_copy_list(pkgconf_list_t *dst, const pkgconf_list_t *src)
  *
  *    Copies a path list to another path list.
  *
  *    :param pkgconf_list_t* dst: The path list to copy to.
  *    :param pkgconf_list_t* src: The path list to copy from.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_path_copy_list(pkgconf_list_t *dst, const pkgconf_list_t *src)
 {
 	pkgconf_node_t *n;
-
 	PKGCONF_FOREACH_LIST_ENTRY(src->head, n)
 	{
 		pkgconf_path_t *srcpath = n->data, *path;
-
 		path = calloc(1, sizeof(pkgconf_path_t));
 		if (path == NULL)
-			continue;
-
+			goto oom;
 		path->path = strdup(srcpath->path);
-
+		if (path->path == NULL)
+		{
+			free(path);
+			goto oom;
+		}
 #ifdef PKGCONF_CACHE_INODES
 		path->handle_path = srcpath->handle_path;
 		path->handle_device = srcpath->handle_device;
 #endif
-
 		pkgconf_node_insert_tail(&path->lnode, path, dst);
 	}
+	return true;
+oom:
+	pkgconf_path_free(dst);
+	return false;
 }
 
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_path_prepend_list(pkgconf_list_t *dst, const pkgconf_list_t *src)
+ * .. c:function:: bool pkgconf_path_prepend_list(pkgconf_list_t *dst, const pkgconf_list_t *src)
  *
  *    Copies a path list to another path list.
  *
  *    :param pkgconf_list_t* dst: The path list to copy to.
  *    :param pkgconf_list_t* src: The path list to copy from.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on allocation failure.
  */
-void
+bool
 pkgconf_path_prepend_list(pkgconf_list_t *dst, const pkgconf_list_t *src)
 {
 	pkgconf_node_t *n;
@@ -332,9 +370,14 @@ pkgconf_path_prepend_list(pkgconf_list_t *dst, const pkgconf_list_t *src)
 
 		path = calloc(1, sizeof(pkgconf_path_t));
 		if (path == NULL)
-			continue;
+			goto oom;
 
 		path->path = strdup(srcpath->path);
+		if (path->path == NULL)
+		{
+			free(path);
+			goto oom;
+		}
 
 #ifdef PKGCONF_CACHE_INODES
 		path->handle_path = srcpath->handle_path;
@@ -343,6 +386,12 @@ pkgconf_path_prepend_list(pkgconf_list_t *dst, const pkgconf_list_t *src)
 
 		pkgconf_node_insert(&path->lnode, path, dst);
 	}
+
+	return true;
+
+oom:
+	pkgconf_path_free(dst);
+	return false;
 }
 
 /*
@@ -379,7 +428,7 @@ normpath(const pkgconf_buffer_t *pathbuf)
 
 	const char *path = pkgconf_buffer_str(pathbuf);
 	char *copy = strdup(path);
-	if (NULL == copy)
+	if (!copy)
 		return NULL;
 	char *ptr = copy;
 
@@ -418,8 +467,9 @@ pkgconf_path_relocate(pkgconf_buffer_t *buf)
 	if ((tmpbuf = normpath(buf)) != NULL)
 	{
 		pkgconf_buffer_reset(buf);
-		pkgconf_buffer_append(buf, tmpbuf);
+		bool ok = pkgconf_buffer_append(buf, tmpbuf);
 		free(tmpbuf);
+		return ok;
 	}
 
 	return true;
@@ -495,7 +545,7 @@ pkgconf_path_find_basename(const char *path)
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_path_build_from_registry(HKEY hKey, pkgconf_list_t *dir_list, bool filter)
+ * .. c:function:: size_t pkgconf_path_build_from_registry(HKEY hKey, pkgconf_list_t *dir_list, bool filter)
  *
  *    Adds paths to a directory list discovered from a given registry key.
  *
@@ -524,12 +574,11 @@ pkgconf_path_build_from_registry(void *hKey, pkgconf_list_t *dir_list, bool filt
 		char pathbuf[PKGCONF_ITEM_SIZE];
 		DWORD type;
 		DWORD pathbuflen = sizeof pathbuf;
-
 		if (RegQueryValueEx(key, buf, NULL, &type, (LPBYTE) pathbuf, &pathbuflen)
 				== ERROR_SUCCESS && type == REG_SZ)
 		{
-			pkgconf_path_add(pathbuf, dir_list, filter);
-			added++;
+			if (pkgconf_path_add(pathbuf, dir_list, filter))
+				added++;
 		}
 
 		bufsize = sizeof buf;

--- a/libpkgconf/personality.c
+++ b/libpkgconf/personality.c
@@ -35,6 +35,7 @@ static pkgconf_cross_personality_t default_personality = {
 	.name = "default",
 };
 
+// NOTE: this function is best-effort
 static inline void
 build_default_search_path(pkgconf_list_t* dirlist)
 {
@@ -52,28 +53,31 @@ build_default_search_path(pkgconf_list_t* dirlist)
 
 	p = strrchr(namebuf, '/');
 	if (p == NULL)
+	{
 		pkgconf_path_split(PKG_DEFAULT_PATH, dirlist, true);
+		return;
+	}
 	*p = '\0';
 
-	pkgconf_buffer_append_fmt(&pathbuf, "%s/../lib/pkgconfig", namebuf);
-	pkgconf_path_add(pkgconf_buffer_str(&pathbuf), dirlist, true);
+	if (pkgconf_buffer_append_fmt(&pathbuf, "%s/../lib/pkgconfig", namebuf))
+		(void) pkgconf_path_add(pkgconf_buffer_str(&pathbuf), dirlist, true);
 	pkgconf_buffer_reset(&pathbuf);
 
-	pkgconf_buffer_append_fmt(&pathbuf, "%s/../share/pkgconfig", namebuf);
-	pkgconf_path_add(pkgconf_buffer_str(&pathbuf), dirlist, true);
+	if (pkgconf_buffer_append_fmt(&pathbuf, "%s/../share/pkgconfig", namebuf))
+		(void) pkgconf_path_add(pkgconf_buffer_str(&pathbuf), dirlist, true);
 	pkgconf_buffer_finalize(&pathbuf);
 #elif __HAIKU__
 	char **paths;
 	size_t count;
 	if (find_paths(B_FIND_PATH_DEVELOP_LIB_DIRECTORY, "pkgconfig", &paths, &count) == B_OK) {
 		for (size_t i = 0; i < count; i++)
-			pkgconf_path_add(paths[i], dirlist, true);
+			(void) pkgconf_path_add(paths[i], dirlist, true);
 		free(paths);
 		paths = NULL;
 	}
 	if (find_paths(B_FIND_PATH_DATA_DIRECTORY, "pkgconfig", &paths, &count) == B_OK) {
 		for (size_t i = 0; i < count; i++)
-			pkgconf_path_add(paths[i], dirlist, true);
+			(void) pkgconf_path_add(paths[i], dirlist, true);
 		free(paths);
 		paths = NULL;
 	}
@@ -187,6 +191,7 @@ personality_copy_func(pkgconf_cross_personality_t *p, const char *keyword, const
 	(void) warnprefix;
 
 	char **dest = (char **)((char *) p + offset);
+	free(*dest); // free any previous value
 	*dest = strdup(value);
 }
 
@@ -256,14 +261,21 @@ load_personality_with_path(const char *path, const char *triplet, bool datadir)
 	pkgconf_buffer_t pathbuf = PKGCONF_BUFFER_INITIALIZER;
 	FILE *f;
 	pkgconf_cross_personality_t *p;
+	bool ok;
 
 	/* if triplet is null, assume that path is a direct path to the personality file */
 	if (triplet == NULL)
-		pkgconf_buffer_append(&pathbuf, path);
+		ok = pkgconf_buffer_append(&pathbuf, path);
 	else if (datadir)
-		pkgconf_buffer_append_fmt(&pathbuf, "%s/pkgconfig/personality.d/%s.personality", path, triplet);
+		ok = pkgconf_buffer_append_fmt(&pathbuf, "%s/pkgconfig/personality.d/%s.personality", path, triplet);
 	else
-		pkgconf_buffer_append_fmt(&pathbuf, "%s/%s.personality", path, triplet);
+		ok = pkgconf_buffer_append_fmt(&pathbuf, "%s/%s.personality", path, triplet);
+
+	if (!ok)
+	{
+		pkgconf_buffer_finalize(&pathbuf);
+		return NULL;
+	}
 
 	p = calloc(1, sizeof(pkgconf_cross_personality_t));
 	if (p == NULL)
@@ -273,7 +285,15 @@ load_personality_with_path(const char *path, const char *triplet, bool datadir)
 	}
 
 	if (triplet != NULL)
+	{
 		p->name = strdup(triplet);
+		if (p->name == NULL)
+		{
+			pkgconf_buffer_finalize(&pathbuf);
+			pkgconf_cross_personality_deinit(p);
+			return NULL;
+		}
+	}
 
 	f = fopen(pkgconf_buffer_str(&pathbuf), "r");
 	if (f == NULL)
@@ -285,6 +305,7 @@ load_personality_with_path(const char *path, const char *triplet, bool datadir)
 
 	pkgconf_parser_parse(f, p, personality_parser_ops, personality_warn_func, pkgconf_buffer_str(&pathbuf));
 	pkgconf_buffer_finalize(&pathbuf);
+	fclose(f);
 
 	return p;
 }
@@ -319,7 +340,10 @@ pkgconf_cross_personality_find(const char *triplet)
 #if ! defined(_WIN32) && ! defined(__HAIKU__)
 	envvar = getenv("XDG_DATA_HOME");
 	if (envvar != NULL)
-		pkgconf_path_add(envvar, &plist, true);
+	{
+		if (!pkgconf_path_add(envvar, &plist, true))
+			goto finish; // failed to add path, fall back to default
+	}
 	else
 	{
 		envvar = getenv("HOME");
@@ -327,9 +351,11 @@ pkgconf_cross_personality_find(const char *triplet)
 		{
 			pkgconf_buffer_t pathbuf = PKGCONF_BUFFER_INITIALIZER;
 
-			pkgconf_buffer_append_fmt(&pathbuf, "%s/.local/share", envvar);
-			pkgconf_path_add(pkgconf_buffer_str(&pathbuf), &plist, true);
+			bool ok = pkgconf_buffer_append_fmt(&pathbuf, "%s/.local/share", envvar)
+				&& pkgconf_path_add(pkgconf_buffer_str(&pathbuf), &plist, true);
 			pkgconf_buffer_finalize(&pathbuf);
+			if (!ok)
+				goto finish; // Failed to create buffer, fall back to default
 		}
 	}
 
@@ -338,6 +364,8 @@ pkgconf_cross_personality_find(const char *triplet)
 	PKGCONF_FOREACH_LIST_ENTRY(plist.head, n)
 	{
 		pkgconf_path_t *pn = n->data;
+		if (!pn)
+			goto finish; // malformed list, fall back to default
 
 		out = load_personality_with_path(pn->path, triplet, true);
 		if (out != NULL)

--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -56,7 +56,8 @@ pkg_get_parent_dir(pkgconf_pkg_t *pkg)
 	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
 	pkgconf_buffer_t pathbuf = PKGCONF_BUFFER_INITIALIZER;
 
-	pkgconf_buffer_append(&buf, pkg->filename);
+	if (!pkgconf_buffer_append(&buf, pkg->filename))
+		goto err;
 
 #ifndef _WIN32
 	struct stat path_stat;
@@ -69,7 +70,8 @@ pkg_get_parent_dir(pkgconf_pkg_t *pkg)
 		char *targetfilename, *targetdir;
 
 		pkgconf_buffer_reset(&pathbuf);
-		pkgconf_buffer_append(&pathbuf, buf.base);
+		if (!pkgconf_buffer_append(&pathbuf, buf.base))
+			goto err;
 
 		targetfilename = strrchr(pathbuf.base, '/');
 		if (targetfilename != NULL)
@@ -114,9 +116,13 @@ pkg_get_parent_dir(pkgconf_pkg_t *pkg)
 		 *   ../bar (relative)  |  /foo/link (absolute)  |  /foo/../bar (relative)
 		 */
 		if ((sourcebuf[0] != '/') && strcmp(targetdir, "."))
-			pkgconf_buffer_append_fmt(&buf, "%s/", targetdir);
+		{
+			if (!pkgconf_buffer_append_fmt(&buf, "%s/", targetdir))
+				goto err;
+		}
 
-		pkgconf_buffer_append(&buf, sourcebuf);
+		if (!pkgconf_buffer_append(&buf, sourcebuf))
+			goto err;
 	}
 #endif
 
@@ -126,6 +132,11 @@ pkg_get_parent_dir(pkgconf_pkg_t *pkg)
 		pkgconf_path_trim_basename(&buf);
 
 	return pkgconf_buffer_freeze(&buf);
+
+err:
+	pkgconf_buffer_finalize(&pathbuf);
+	pkgconf_buffer_finalize(&buf);
+	return NULL;
 }
 
 typedef void (*pkgconf_pkg_parser_keyword_func_t)(pkgconf_client_t *client, pkgconf_pkg_t *pkg, const char *keyword, const char *warnprefix, const ptrdiff_t offset, const char *value);
@@ -148,11 +159,15 @@ pkgconf_pkg_parser_tuple_func(pkgconf_client_t *client, pkgconf_pkg_t *pkg, cons
 	(void) warnprefix;
 
 	char **dest = (char **)((char *) pkg + offset);
+	char *new_value = pkgconf_bytecode_eval_str(client, &pkg->vars, value, NULL);
+
+	if (new_value == NULL)
+		return;
 
 	if (*dest != NULL)
 		free(*dest);
 
-	*dest = pkgconf_bytecode_eval_str(client, &pkg->vars, value, NULL);
+	*dest = new_value;
 }
 
 static void
@@ -164,8 +179,9 @@ pkgconf_pkg_parser_bufferset_func(pkgconf_client_t *client, pkgconf_pkg_t *pkg, 
 	pkgconf_list_t *dest = (pkgconf_list_t *)((char *) pkg + offset);
 	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
 
-	pkgconf_bytecode_eval_str_to_buf(client, &pkg->vars, value, NULL, &buf);
-	pkgconf_bufferset_extend(dest, &buf);
+	if (pkgconf_bytecode_eval_str_to_buf(client, &pkg->vars, value, NULL, &buf))
+		pkgconf_bufferset_extend(dest, &buf);
+
 	pkgconf_buffer_finalize(&buf);
 }
 
@@ -322,8 +338,11 @@ pkgconf_pkg_parser_keyword_set(void *opaque, const char *warnprefix, const char 
 static bool
 determine_prefix(const pkgconf_pkg_t *pkg, pkgconf_buffer_t *pathbuf)
 {
-	pkgconf_buffer_append(pathbuf, pkg->filename);
-	pkgconf_path_relocate(pathbuf);
+	if (!pkgconf_buffer_append(pathbuf, pkg->filename))
+		return false;
+
+	if (!pkgconf_path_relocate(pathbuf))
+		return false;
 
 	pkgconf_path_trim_basename(pathbuf);
 
@@ -358,17 +377,28 @@ convert_path_to_value(const char *path)
 	for (i = path; *i != '\0'; i++)
 	{
 		if (*i == PKG_DIR_SEP_S)
-			pkgconf_buffer_push_byte(&buf, '/');
+		{
+			if (!pkgconf_buffer_push_byte(&buf, '/'))
+				goto err;
+		}
 		else if (*i == ' ')
 		{
-			pkgconf_buffer_push_byte(&buf, '\\');
-			pkgconf_buffer_push_byte(&buf, ' ');
+			if (!pkgconf_buffer_push_byte(&buf, '\\') ||
+			    !pkgconf_buffer_push_byte(&buf, ' '))
+				goto err;
 		}
 		else
-			pkgconf_buffer_push_byte(&buf, *i);
+		{
+			if (!pkgconf_buffer_push_byte(&buf, *i))
+				goto err;
+		}
 	}
 
 	return pkgconf_buffer_freeze(&buf);
+
+err:
+	pkgconf_buffer_finalize(&buf);
+	return NULL;
 }
 
 static void
@@ -443,7 +473,8 @@ pkgconf_pkg_parser_value_set(void *opaque, const char *warnprefix, const char *k
 		value = env_content;
 	}
 
-	pkgconf_buffer_append(&canonicalized_value, value);
+	if (!pkgconf_buffer_append(&canonicalized_value, value))
+		goto out;
 	canonicalize_path(canonicalized_value.base);
 
 	if (!(pkg->owner->flags & PKGCONF_PKG_PKGF_REDEFINE_PREFIX))
@@ -467,10 +498,11 @@ pkgconf_pkg_parser_value_set(void *opaque, const char *warnprefix, const char *k
 			{
 				pkgconf_buffer_t newvalue = PKGCONF_BUFFER_INITIALIZER;
 
-				pkgconf_buffer_append(&newvalue, pkgconf_buffer_str_or_empty(&pkg->calculated_prefix));
-				pkgconf_buffer_append(&newvalue, pkgconf_buffer_str(&canonicalized_value) + oplen);
-
-				pkgconf_tuple_add(pkg->owner, &pkg->vars, keyword, pkgconf_buffer_str(&newvalue), false, pkg->flags);
+				if (pkgconf_buffer_append(&newvalue, pkgconf_buffer_str_or_empty(&pkg->calculated_prefix)) &&
+				    pkgconf_buffer_append(&newvalue, pkgconf_buffer_str(&canonicalized_value) + oplen))
+				{
+					pkgconf_tuple_add(pkg->owner, &pkg->vars, keyword, pkgconf_buffer_str(&newvalue), false, pkg->flags);
+				}
 				pkgconf_buffer_finalize(&newvalue);
 
 				goto out;
@@ -488,10 +520,14 @@ pkgconf_pkg_parser_value_set(void *opaque, const char *warnprefix, const char *k
 			const char *relvalue = pkgconf_buffer_str(&pathbuf);
 			char *prefix_value = convert_path_to_value(relvalue);
 
-			pkgconf_buffer_append(&pkg->orig_prefix, pkgconf_buffer_str(&canonicalized_value));
-			pkgconf_buffer_append(&pkg->calculated_prefix, prefix_value);
-
-			pkgconf_tuple_add(pkg->owner, &pkg->vars, keyword, prefix_value, false, pkg->flags);
+			if (prefix_value != NULL &&
+			    pkgconf_buffer_append(&pkg->orig_prefix, pkgconf_buffer_str(&canonicalized_value)) &&
+			    pkgconf_buffer_append(&pkg->calculated_prefix, prefix_value))
+			{
+				pkgconf_tuple_add(pkg->owner, &pkg->vars, keyword, prefix_value, false, pkg->flags);
+			}
+			else
+				pkgconf_tuple_add(pkg->owner, &pkg->vars, keyword, value, true, pkg->flags);
 			free(prefix_value);
 		}
 		else
@@ -643,7 +679,6 @@ pkgconf_pkg_new_from_path(pkgconf_client_t *client, const char *filename, unsign
 	char *idptr;
 	FILE *f;
 
-	/* make sure we only load .pc files */
 	if (!str_has_suffix(filename, PKG_CONFIG_EXT))
 		return NULL;
 
@@ -678,18 +713,16 @@ pkgconf_pkg_new_from_path(pkgconf_client_t *client, const char *filename, unsign
 	}
 
 	char *pc_filedir_value = convert_path_to_value(pkg->pc_filedir);
-	pkgconf_tuple_add(client, &pkg->vars, "pcfiledir", pc_filedir_value, true, pkg->flags);
-	free(pc_filedir_value);
+	if (pc_filedir_value != NULL)
+	{
+		pkgconf_tuple_add(client, &pkg->vars, "pcfiledir", pc_filedir_value, true, pkg->flags);
+		free(pc_filedir_value);
+	}
 
-	/* If pc_filedir is outside of sysroot_dir, override sysroot_dir for this
-	 * package.
-	 * See https://github.com/pkgconf/pkgconf/issues/213
-	 */
 	if (client->sysroot_dir != NULL && strncmp(pkg->pc_filedir, client->sysroot_dir, strlen(client->sysroot_dir)) &&
 		!(client->flags & PKGCONF_PKG_PKGF_PKGCONF1_SYSROOT_RULES))
 		pkgconf_tuple_add(client, &pkg->vars, "pc_sysrootdir", "", false, pkg->flags);
 
-	/* make module id */
 	pkg->id = strdup(pkgconf_path_find_basename(pkg->filename));
 	if (pkg->id == NULL)
 	{
@@ -721,6 +754,11 @@ pkgconf_pkg_new_from_path(pkgconf_client_t *client, const char *filename, unsign
 	}
 
 	pkgconf_dependency_t *dep = pkgconf_dependency_add(client, &pkg->provides, pkg->id, pkg->version, PKGCONF_CMP_EQUAL, 0);
+	if (dep == NULL)
+	{
+		pkgconf_pkg_free(client, pkg);
+		return NULL;
+	}
 	pkgconf_dependency_unref(dep->owner, dep);
 
 	return pkgconf_pkg_ref(client, pkg);
@@ -851,7 +889,11 @@ pkgconf_pkg_scan_dir(pkgconf_client_t *client, const char *path, void *data, pkg
 		pkgconf_buffer_t filebuf = PKGCONF_BUFFER_INITIALIZER;
 		pkgconf_pkg_t *pkg;
 
-		pkgconf_buffer_join(&filebuf, '/', path, dirent->d_name, NULL);
+		if (!pkgconf_buffer_join(&filebuf, '/', path, dirent->d_name, NULL))
+		{
+			pkgconf_buffer_finalize(&filebuf);
+			continue;
+		}
 
 		if (!str_has_suffix(pkgconf_buffer_str(&filebuf), PKG_CONFIG_EXT))
 		{
@@ -984,7 +1026,7 @@ pkgconf_pkg_find(pkgconf_client_t *client, const char *name)
 			if (client->unveil_handler != NULL)
 				client->unveil_handler(client, pkg->pc_filedir, "r");
 
-			pkgconf_path_add(pkg->pc_filedir, &client->dir_list, true);
+			(void) pkgconf_path_add(pkg->pc_filedir, &client->dir_list, true);
 			goto out;
 		}
 	}
@@ -1367,7 +1409,16 @@ pkgconf_pkg_verify_dependency(pkgconf_client_t *client, pkgconf_dependency_t *pk
 	else
 	{
 		if (pkg->id == NULL)
+		{
 			pkg->id = strdup(pkgdep->package);
+			if (pkg->id == NULL)
+			{
+				pkgconf_pkg_unref(client, pkg);
+				if (eflags != NULL)
+					*eflags |= PKGCONF_PKG_ERRF_PACKAGE_NOT_FOUND;
+				return NULL;
+			}
+		}
 
 		if (pkgconf_pkg_comparator_impls[pkgdep->compare](pkg->version, pkgdep->version) != true)
 		{
@@ -1379,6 +1430,7 @@ pkgconf_pkg_verify_dependency(pkgconf_client_t *client, pkgconf_dependency_t *pk
 	}
 
 	if (pkg != NULL && pkg->why == NULL)
+		// failure here is non-critical as pkg->why being NULL is handled by callers
 		pkg->why = strdup(pkgdep->package);
 
 	return pkg;
@@ -1529,10 +1581,9 @@ next:
 }
 
 unsigned int
-pkgconf_pkg_walk_conflicts_list(pkgconf_client_t *client,
-	pkgconf_pkg_t *root, pkgconf_list_t *deplist)
+pkgconf_pkg_walk_conflicts_list(pkgconf_client_t *client, pkgconf_pkg_t *root, pkgconf_list_t *deplist)
 {
-	unsigned int eflags;
+	unsigned int eflags = PKGCONF_PKG_ERRF_OK;
 	pkgconf_node_t *node, *childnode;
 
 	PKGCONF_FOREACH_LIST_ENTRY(deplist->head, node)
@@ -1604,8 +1655,7 @@ pkgconf_pkg_traverse_main(pkgconf_client_t *client,
 	if (maxdepth == 0)
 		return eflags;
 
-	/* Short-circuit if we have already visited this node.
-	 */
+	// Short-circuit if we have already visited this node.
 	if (root->serial == client->serial)
 		return eflags;
 
@@ -1618,8 +1668,8 @@ pkgconf_pkg_traverse_main(pkgconf_client_t *client,
 
 	if ((root->flags & PKGCONF_PKG_PROPF_VIRTUAL) != PKGCONF_PKG_PROPF_VIRTUAL || (client->flags & PKGCONF_PKG_PKGF_SKIP_ROOT_VIRTUAL) != PKGCONF_PKG_PKGF_SKIP_ROOT_VIRTUAL)
 	{
-		if (func != NULL)
-			func(client, root, data);
+		if (func != NULL && !func(client, root, data))
+			return PKGCONF_PKG_ERRF_OUTPUT_FAILURE;
 	}
 
 	if (!(client->flags & PKGCONF_PKG_PKGF_SKIP_CONFLICTS) && root->conflicts.head != NULL)
@@ -1670,9 +1720,7 @@ pkgconf_pkg_traverse(pkgconf_client_t *client,
 		client->serial++;
 
 	if ((client->flags & PKGCONF_PKG_PKGF_SEARCH_PRIVATE) == 0)
-	{
 		skip_flags |= PKGCONF_PKG_DEPF_PRIVATE;
-	}
 
 	if (client->flags & PKGCONF_PKG_PKGF_MERGE_PRIVATE_FRAGMENTS)
 		// Skip shared deps in static mode
@@ -1681,7 +1729,7 @@ pkgconf_pkg_traverse(pkgconf_client_t *client,
 	return pkgconf_pkg_traverse_main(client, root, func, data, maxdepth, skip_flags);
 }
 
-static void
+static bool
 pkgconf_pkg_cflags_collect(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *data)
 {
 	pkgconf_list_t *list = data;
@@ -1690,11 +1738,20 @@ pkgconf_pkg_cflags_collect(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *d
 	PKGCONF_FOREACH_LIST_ENTRY(pkg->cflags.head, node)
 	{
 		pkgconf_fragment_t *frag = node->data;
-		pkgconf_fragment_copy(client, list, frag, false);
+		if (!frag)
+		{
+			pkgconf_error(client, "package cflags corrupted");
+			return false;
+		}
+
+		if (!pkgconf_fragment_copy(client, list, frag, false))
+			return false;
 	}
+
+	return true;
 }
 
-static void
+static bool
 pkgconf_pkg_cflags_private_collect(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *data)
 {
 	pkgconf_list_t *list = data;
@@ -1703,11 +1760,20 @@ pkgconf_pkg_cflags_private_collect(pkgconf_client_t *client, pkgconf_pkg_t *pkg,
 	PKGCONF_FOREACH_LIST_ENTRY(pkg->cflags_private.head, node)
 	{
 		pkgconf_fragment_t *frag = node->data;
-		pkgconf_fragment_copy(client, list, frag, true);
+		if (!frag)
+		{
+			pkgconf_error(client, "package cflags_private corrupted");
+			return false;
+		}
+
+		if (!pkgconf_fragment_copy(client, list, frag, true))
+			return false;
 	}
+
+	return true;
 }
 
-static void
+static bool
 pkgconf_pkg_cflags_shared_collect(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *data)
 {
 	pkgconf_list_t *list = data;
@@ -1716,8 +1782,17 @@ pkgconf_pkg_cflags_shared_collect(pkgconf_client_t *client, pkgconf_pkg_t *pkg, 
 	PKGCONF_FOREACH_LIST_ENTRY(pkg->cflags_shared.head, node)
 	{
 		pkgconf_fragment_t *frag = node->data;
-		pkgconf_fragment_copy(client, list, frag, true);
+		if (!frag)
+		{
+			pkgconf_error(client, "package cflags_shared corrupted");
+			return false;
+		}
+
+		if (!pkgconf_fragment_copy(client, list, frag, true))
+			return false;
 	}
+
+	return true;
 }
 
 /*
@@ -1746,13 +1821,9 @@ pkgconf_pkg_cflags(pkgconf_client_t *client, pkgconf_pkg_t *root, pkgconf_list_t
 	if (eflag == PKGCONF_PKG_ERRF_OK)
 	{
 		if (client->flags & PKGCONF_PKG_PKGF_MERGE_PRIVATE_FRAGMENTS)
-		{
 			eflag = pkgconf_pkg_traverse(client, root, pkgconf_pkg_cflags_private_collect, &frags, maxdepth, skip_flags);
-		}
 		else
-		{
 			eflag = pkgconf_pkg_traverse(client, root, pkgconf_pkg_cflags_shared_collect, &frags, maxdepth, skip_flags);
-		}
 	}
 
 	if (eflag != PKGCONF_PKG_ERRF_OK)
@@ -1761,25 +1832,37 @@ pkgconf_pkg_cflags(pkgconf_client_t *client, pkgconf_pkg_t *root, pkgconf_list_t
 		return eflag;
 	}
 
-	pkgconf_fragment_copy_list(client, list, &frags);
+	if (!pkgconf_fragment_copy_list(client, list, &frags))
+	{
+		pkgconf_fragment_free(&frags);
+		return PKGCONF_PKG_ERRF_OUTPUT_FAILURE;
+	}
+
 	pkgconf_fragment_free(&frags);
 
 	return eflag;
 }
 
-static void
+static bool
 pkgconf_pkg_libs_collect(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *data)
 {
 	pkgconf_list_t *list = data;
 	pkgconf_node_t *node;
 
 	if (!(client->flags & PKGCONF_PKG_PKGF_SEARCH_PRIVATE) && pkg->flags & PKGCONF_PKG_PROPF_VISITED_PRIVATE)
-		return;
+		return true;
 
 	PKGCONF_FOREACH_LIST_ENTRY(pkg->libs.head, node)
 	{
 		pkgconf_fragment_t *frag = node->data;
-		pkgconf_fragment_copy(client, list, frag, (client->flags & PKGCONF_PKG_PKGF_ITER_PKG_IS_PRIVATE) != 0);
+		if (!frag)
+		{
+			pkgconf_error(client, "package libs corrupted");
+			return false;
+		}
+
+		if (!pkgconf_fragment_copy(client, list, frag, (client->flags & PKGCONF_PKG_PKGF_ITER_PKG_IS_PRIVATE) != 0))
+			return false;
 	}
 
 	if (client->flags & PKGCONF_PKG_PKGF_MERGE_PRIVATE_FRAGMENTS)
@@ -1787,9 +1870,18 @@ pkgconf_pkg_libs_collect(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *dat
 		PKGCONF_FOREACH_LIST_ENTRY(pkg->libs_private.head, node)
 		{
 			pkgconf_fragment_t *frag = node->data;
-			pkgconf_fragment_copy(client, list, frag, true);
+			if (!frag)
+			{
+				pkgconf_error(client, "package libs_private corrupted");
+				return false;
+			}
+
+			if (!pkgconf_fragment_copy(client, list, frag, true))
+				return false;
 		}
 	}
+
+	return true;
 }
 
 /*

--- a/libpkgconf/queue.c
+++ b/libpkgconf/queue.c
@@ -128,7 +128,7 @@ pkgconf_queue_free(pkgconf_list_t *list)
 	}
 }
 
-static void
+static bool
 pkgconf_queue_mark_public(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *data)
 {
 	if (pkg->flags & PKGCONF_PKG_PROPF_VISITED_PRIVATE)
@@ -139,6 +139,8 @@ pkgconf_queue_mark_public(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *da
 		PKGCONF_FOREACH_LIST_ENTRY(list->head, node)
 		{
 			pkgconf_dependency_t *dep = node->data;
+			if (!dep)
+				return false;
 			if (dep->match == pkg)
 				dep->flags &= ~PKGCONF_PKG_DEPF_PRIVATE;
 		}
@@ -147,6 +149,8 @@ pkgconf_queue_mark_public(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *da
 
 		PKGCONF_TRACE(client, "%s: updated, public", pkg->id);
 	}
+
+	return true;
 }
 
 static unsigned int

--- a/libpkgconf/queue.c
+++ b/libpkgconf/queue.c
@@ -32,47 +32,74 @@
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_queue_push_dependency(pkgconf_list_t *list, const pkgconf_dependency_t *dep)
+ * .. c:function:: bool pkgconf_queue_push_dependency(pkgconf_list_t *list, const pkgconf_dependency_t *dep)
  *
  *    Pushes a requested dependency onto the dependency resolver's queue which is described by
  *    a pkgconf_dependency_t node.
  *
  *    :param pkgconf_list_t* list: the dependency resolution queue to add the package request to.
  *    :param pkgconf_dependency_t* dep: the dependency requested
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on failure.
  */
-void
+bool
 pkgconf_queue_push_dependency(pkgconf_list_t *list, const pkgconf_dependency_t *dep)
 {
 	pkgconf_buffer_t depbuf = PKGCONF_BUFFER_INITIALIZER;
-	pkgconf_queue_t *pkgq = calloc(1, sizeof(pkgconf_queue_t));
+	pkgconf_queue_t *pkgq;
 
-	pkgconf_buffer_append(&depbuf, dep->package);
-	if (dep->version != NULL)
-		pkgconf_buffer_append_fmt(&depbuf, " %s %s", pkgconf_pkg_get_comparator(dep), dep->version);
+	if (!pkgconf_buffer_append(&depbuf, dep->package))
+		goto oom;
+
+	if (dep->version != NULL &&
+		!pkgconf_buffer_append_fmt(&depbuf, " %s %s", pkgconf_pkg_get_comparator(dep), dep->version))
+		goto oom;
+
+	pkgq = calloc(1, sizeof(pkgconf_queue_t));
+	if (pkgq == NULL)
+		goto oom;
 
 	pkgq->package = pkgconf_buffer_freeze(&depbuf);
+	if (pkgq->package == NULL)
+	{
+		free(pkgq);
+		return false;
+	}
+
 	pkgconf_node_insert_tail(&pkgq->iter, pkgq, list);
+	return true;
+
+oom:
+	pkgconf_buffer_finalize(&depbuf);
+	return false;
 }
 
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_queue_push(pkgconf_list_t *list, const char *package)
+ * .. c:function:: bool pkgconf_queue_push(pkgconf_list_t *list, const char *package)
  *
  *    Pushes a requested dependency onto the dependency resolver's queue.
  *
  *    :param pkgconf_list_t* list: the dependency resolution queue to add the package request to.
  *    :param char* package: the dependency atom requested
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on failure.
  */
-void
+bool
 pkgconf_queue_push(pkgconf_list_t *list, const char *package)
 {
 	pkgconf_queue_t *pkgq = calloc(1, sizeof(pkgconf_queue_t));
+	if (pkgq == NULL)
+		return false;
 
 	pkgq->package = strdup(package);
+	if (pkgq->package == NULL)
+	{
+		free(pkgq);
+		return false;
+	}
+
 	pkgconf_node_insert_tail(&pkgq->iter, pkgq, list);
+	return true;
 }
 
 /*
@@ -95,9 +122,12 @@ pkgconf_queue_compile(pkgconf_client_t *client, pkgconf_pkg_t *world, pkgconf_li
 
 	PKGCONF_FOREACH_LIST_ENTRY(list->head, iter)
 	{
-		pkgconf_queue_t *pkgq;
-
-		pkgq = iter->data;
+		pkgconf_queue_t *pkgq = iter->data;
+		if (!pkgq)
+		{
+			pkgconf_error(client, "dependency list corrupt");
+			return false;
+		}
 		pkgconf_dependency_parse(client, world, &world->required, pkgq->package, PKGCONF_PKG_DEPF_QUERY);
 	}
 
@@ -212,8 +242,7 @@ pkgconf_queue_collect_dependencies_main(pkgconf_client_t *client,
 	if (maxdepth == 0)
 		return eflags;
 
-	/* Short-circuit if we have already visited this node.
-	 */
+	// Short-circuit if we have already visited this node.
 	if (root->serial == client->serial)
 		return eflags;
 
@@ -290,6 +319,7 @@ pkgconf_queue_collect_conflicts(pkgconf_client_t *client,
 			pkgconf_dependency_t *conflict = cnode->data;
 			pkgconf_dependency_t *flattened_conflict = pkgconf_dependency_copy(client, conflict);
 
+			// NOTE: conflict_why being NULL is handled by callers
 			flattened_conflict->why = strdup(pkg->id);
 			pkgconf_node_insert(&flattened_conflict->iter, flattened_conflict, &world->conflicts);
 		}

--- a/libpkgconf/tuple.c
+++ b/libpkgconf/tuple.c
@@ -33,19 +33,19 @@
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_tuple_add_global(pkgconf_client_t *client, const char *key, const char *value)
+ * .. c:function:: bool pkgconf_tuple_add_global(pkgconf_client_t *client, const char *key, const char *value)
  *
  *    Defines a global variable, replacing the previous declaration if one was set.
  *
  *    :param pkgconf_client_t* client: The pkgconf client object to modify.
  *    :param char* key: The key for the mapping (variable name).
  *    :param char* value: The value for the mapped entry.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on failure.
  */
-void
+bool
 pkgconf_tuple_add_global(pkgconf_client_t *client, const char *key, const char *value)
 {
-	pkgconf_tuple_add(client, &client->global_vars, key, value, false, 0);
+	return pkgconf_tuple_add(client, &client->global_vars, key, value, false, 0) != NULL;
 }
 
 /*
@@ -96,23 +96,24 @@ pkgconf_tuple_free_global(pkgconf_client_t *client)
 /*
  * !doc
  *
- * .. c:function:: void pkgconf_tuple_define_global(pkgconf_client_t *client, const char *kv)
+ * .. c:function:: bool pkgconf_tuple_define_global(pkgconf_client_t *client, const char *kv)
  *
  *    Parse and define a global variable.
  *
  *    :param pkgconf_client_t* client: The pkgconf client object to modify.
  *    :param char* kv: The variable in the form of ``key=value``.
- *    :return: nothing
+ *    :return: :code:`true` on success, :code:`false` on failure.
  */
-void
+bool
 pkgconf_tuple_define_global(pkgconf_client_t *client, const char *kv)
 {
+	bool ret = false;
 	char *workbuf = strdup(kv);
 	char *value;
 	pkgconf_tuple_t *tuple;
 
 	if (workbuf == NULL)
-		goto out;
+		return false;
 
 	value = strchr(workbuf, '=');
 	if (value == NULL)
@@ -121,11 +122,15 @@ pkgconf_tuple_define_global(pkgconf_client_t *client, const char *kv)
 	*value++ = '\0';
 
 	tuple = pkgconf_tuple_add(client, &client->global_vars, workbuf, value, false, 0);
-	if (tuple != NULL)
-		tuple->flags = PKGCONF_PKG_TUPLEF_OVERRIDE;
+	if (tuple == NULL)
+		goto out;
+
+	tuple->flags = PKGCONF_PKG_TUPLEF_OVERRIDE;
+	ret = true;
 
 out:
 	free(workbuf);
+	return ret;
 }
 
 static char *
@@ -176,6 +181,7 @@ pkgconf_tuple_add(const pkgconf_client_t *client, pkgconf_list_t *list, const ch
 {
 	char *dequote_value;
 	pkgconf_buffer_t rhs_bcbuf = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_variable_t *v;
 
 	(void) client;
 
@@ -186,7 +192,11 @@ pkgconf_tuple_add(const pkgconf_client_t *client, pkgconf_list_t *list, const ch
 	if (dequote_value == NULL)
 		return NULL;
 
-	pkgconf_variable_t *v = pkgconf_variable_get_or_create(list, key);
+    /* TODO: if v was newly created here, a subsequent failure leaves it
+	 * in the list with stale or empty bytecode. Caller sees NULL but the
+	 * variable persists. Fixing this requires distinguishing get-vs-create
+	 * so we can roll back creation on failure. */
+	v = pkgconf_variable_get_or_create(list, key);
 	if (v == NULL)
 	{
 		free(dequote_value);
@@ -198,13 +208,22 @@ pkgconf_tuple_add(const pkgconf_client_t *client, pkgconf_list_t *list, const ch
 	if (!parse)
 	{
 		pkgconf_buffer_reset(&v->bcbuf);
-		pkgconf_bytecode_emit_text(&v->bcbuf, dequote_value, strlen(dequote_value));
+		if (!pkgconf_bytecode_emit_text(&v->bcbuf, dequote_value, strlen(dequote_value)))
+		{
+			free(dequote_value);
+			return NULL;
+		}
 		pkgconf_bytecode_from_buffer(&v->bc, &v->bcbuf);
 		free(dequote_value);
 		return (pkgconf_tuple_t *) v;
 	}
 
-	pkgconf_bytecode_compile(&rhs_bcbuf, dequote_value);
+	if (!pkgconf_bytecode_compile(&rhs_bcbuf, dequote_value))
+	{
+		pkgconf_buffer_finalize(&rhs_bcbuf);
+		free(dequote_value);
+		return NULL;
+	}
 	free(dequote_value);
 
 	/* ugh, we are doing var=${var}/foo stuff */
@@ -214,7 +233,12 @@ pkgconf_tuple_add(const pkgconf_client_t *client, pkgconf_list_t *list, const ch
 		pkgconf_buffer_t new_bcbuf = PKGCONF_BUFFER_INITIALIZER;
 
 		/* preserve the old bytecode */
-		pkgconf_buffer_copy(&v->bcbuf, &old_bcbuf);
+		if (!pkgconf_buffer_copy(&v->bcbuf, &old_bcbuf))
+		{
+			pkgconf_buffer_finalize(&old_bcbuf);
+			pkgconf_buffer_finalize(&rhs_bcbuf);
+			return NULL;
+		}
 
 		/* splice the selfrefs, using the old bytecode instead of ${var} */
 		if (!pkgconf_bytecode_rewrite_selfrefs(&new_bcbuf, &rhs_bcbuf, key, &old_bcbuf))
@@ -222,18 +246,27 @@ pkgconf_tuple_add(const pkgconf_client_t *client, pkgconf_list_t *list, const ch
 			pkgconf_buffer_finalize(&old_bcbuf);
 			pkgconf_buffer_finalize(&new_bcbuf);
 			pkgconf_buffer_finalize(&rhs_bcbuf);
-
 			return NULL;
 		}
 
 		/* copy the spliced bytecode back to &rhs_bcbuf, replacing its contents */
-		pkgconf_buffer_copy(&new_bcbuf, &rhs_bcbuf);
+		if (!pkgconf_buffer_copy(&new_bcbuf, &rhs_bcbuf))
+		{
+			pkgconf_buffer_finalize(&old_bcbuf);
+			pkgconf_buffer_finalize(&new_bcbuf);
+			pkgconf_buffer_finalize(&rhs_bcbuf);
+			return NULL;
+		}
 
 		pkgconf_buffer_finalize(&old_bcbuf);
 		pkgconf_buffer_finalize(&new_bcbuf);
 	}
 
-	pkgconf_buffer_copy(&rhs_bcbuf, &v->bcbuf);
+	if (!pkgconf_buffer_copy(&rhs_bcbuf, &v->bcbuf))
+	{
+		pkgconf_buffer_finalize(&rhs_bcbuf);
+		return NULL;
+	}
 	pkgconf_bytecode_from_buffer(&v->bc, &v->bcbuf);
 	pkgconf_buffer_finalize(&rhs_bcbuf);
 

--- a/libpkgconf/variable.c
+++ b/libpkgconf/variable.c
@@ -70,6 +70,8 @@ pkgconf_variable_find(const pkgconf_list_t *vars, const char *key)
 	PKGCONF_FOREACH_LIST_ENTRY(vars->head, n)
 	{
 		pkgconf_variable_t *v = n->data;
+		if (!v)
+			return NULL;
 
 		if (!strcmp(v->key, key))
 			return v;

--- a/libpkgconf/version.c
+++ b/libpkgconf/version.c
@@ -159,7 +159,7 @@ static int
 pkgconf_version_compare_token(const pkgconf_version_token_t *a, const pkgconf_version_token_t *b)
 {
 	if (a->kind == PKGCONF_VERSION_TOKEN_TILDE || b->kind == PKGCONF_VERSION_TOKEN_TILDE)
-        {
+		{
 		if (a->kind != PKGCONF_VERSION_TOKEN_TILDE)
 			return 1;
 		if (b->kind != PKGCONF_VERSION_TOKEN_TILDE)
@@ -219,30 +219,32 @@ pkgconf_version_compare_token(const pkgconf_version_token_t *a, const pkgconf_ve
 int
 pkgconf_compare_version(const char *a, const char *b)
 {
-        pkgconf_version_iter_t ia, ib;
+	pkgconf_version_iter_t ia, ib;
 
-        if (a == NULL)
-                return -1;
-        if (b == NULL)
-                return 1;
+	if (a == NULL)
+		return -1;
+	if (b == NULL)
+		return 1;
 
-        if (!strcasecmp(a, b))
-                return 0;
+	if (!strcasecmp(a, b))
+		return 0;
 
-        ia.cur = a;
-        ib.cur = b;
+	ia.cur = a;
+	ib.cur = b;
 
-        for (;;)
-        {
-                pkgconf_version_token_t ta = pkgconf_version_next_token(&ia);
-                pkgconf_version_token_t tb = pkgconf_version_next_token(&ib);
-                int ret = pkgconf_version_compare_token(&ta, &tb);
+	for (;;)
+	{
+		pkgconf_version_token_t ta = pkgconf_version_next_token(&ia);
+		pkgconf_version_token_t tb = pkgconf_version_next_token(&ib);
+		int ret = pkgconf_version_compare_token(&ta, &tb);
 
-                if (ret != 0)
-                        return ret;
+		if (ret != 0)
+			return ret;
 
-                if (ta.kind == PKGCONF_VERSION_TOKEN_END &&
-                    tb.kind == PKGCONF_VERSION_TOKEN_END)
-                        return 0;
-        }
+		if (ta.kind == PKGCONF_VERSION_TOKEN_END &&
+			tb.kind == PKGCONF_VERSION_TOKEN_END)
+		{
+			return 0;
+		}
+	}
 }


### PR DESCRIPTION
This PR revamps the libpkgconf API to return failures from underlying functions. `pkgconf_buffer_*` functions are checked for failure throughout and many API functions now return `bool` to accommodate this.

This is a follow-up from #489.

Other changes made:
- The CLI using these APIs now more aggressively checks for failures and reports to the user.
- Several docstrings have been fixed, as well as some use-after-free bugs.
- Cleanup of handling of OOM conditions.
- Several potential use-after-free bugs fixed.