### PR TITLE
New file output wrappers and conversion

### DIFF
--- a/cli/bomtool/main.c
+++ b/cli/bomtool/main.c
@@ -35,6 +35,22 @@ static int maximum_traverse_depth = 2000;
 static FILE *error_msgout = NULL;
 static FILE *sbom_out = NULL;
 
+#define OUTPUT_OR_RET(client, f, fmt, ...) \
+    do { \
+        if (!pkgconf_output_file_fmt((f), (fmt), ##__VA_ARGS__)) { \
+            pkgconf_error((client), "bomtool: Could not output to file: %s", strerror(errno)); \
+            return; \
+        } \
+    } while (0)
+
+#define OUTPUT_OR_RET_FALSE(client, f, fmt, ...) \
+    do { \
+        if (!pkgconf_output_file_fmt((f), (fmt), ##__VA_ARGS__)) { \
+            pkgconf_error((client), "bomtool: Could not output to file: %s", strerror(errno)); \
+            return false; \
+        } \
+    } while (0)
+
 static const char *
 environ_lookup_handler(const pkgconf_client_t *client, const char *key)
 {
@@ -48,7 +64,7 @@ error_handler(const char *msg, const pkgconf_client_t *client, void *data)
 {
 	(void) client;
 	(void) data;
-	fprintf(error_msgout, "%s", msg);
+	OUTPUT_OR_RET_FALSE(client, error_msgout, "%s", msg);
 	return true;
 }
 
@@ -87,22 +103,22 @@ sbom_name(pkgconf_pkg_t *world)
 	return pkgconf_buffer_freeze(&name);
 }
 
-static void
+static bool
 write_sbom_header(pkgconf_client_t *client, pkgconf_pkg_t *world)
 {
 	(void) client;
 	char *docname = sbom_name(world);
 
-	fprintf(sbom_out, "SPDXVersion: %s\n", spdx_version);
-	fprintf(sbom_out, "DataLicense: %s\n", bom_license);
-	fprintf(sbom_out, "SPDXID: %s\n", document_ref);
-	fprintf(sbom_out, "DocumentName: %s\n", docname);
-	fprintf(sbom_out, "DocumentNamespace: https://spdx.org/spdxdocs/bomtool-%s\n", PACKAGE_VERSION);
-	fprintf(sbom_out, "Creator: Tool: bomtool %s\n", PACKAGE_VERSION);
-
-	fprintf(sbom_out, "\n\n");
+	OUTPUT_OR_RET_FALSE(client, sbom_out, "SPDXVersion: %s\n", spdx_version);
+	OUTPUT_OR_RET_FALSE(client, sbom_out, "DataLicense: %s\n", bom_license);
+	OUTPUT_OR_RET_FALSE(client, sbom_out, "SPDXID: %s\n", document_ref);
+	OUTPUT_OR_RET_FALSE(client, sbom_out, "DocumentName: %s\n", docname);
+	OUTPUT_OR_RET_FALSE(client, sbom_out, "DocumentNamespace: https://spdx.org/spdxdocs/bomtool-%s\n", PACKAGE_VERSION);
+	OUTPUT_OR_RET_FALSE(client, sbom_out, "Creator: Tool: bomtool %s\n", PACKAGE_VERSION);
+	OUTPUT_OR_RET_FALSE(client, sbom_out, "\n\n");
 
 	free(docname);
+	return true;
 }
 
 static const char *
@@ -115,23 +131,25 @@ sbom_identity(pkgconf_pkg_t *pkg)
 	return buf;
 }
 
-static void
-write_copyright_lines(const pkgconf_list_t *copyright_lines)
+static bool
+write_copyright_lines(pkgconf_client_t *client, const pkgconf_list_t *copyright_lines)
 {
 	const pkgconf_node_t *node;
 
 	if (copyright_lines->head == NULL)
-		return;
+		return true;
 
-	fprintf(sbom_out, "PackageCopyrightText: <text>");
+	OUTPUT_OR_RET_FALSE(client, sbom_out, "PackageCopyrightText: <text>");
 
 	PKGCONF_FOREACH_LIST_ENTRY(copyright_lines->head, node)
 	{
 		const pkgconf_bufferset_t *set = node->data;
-		fprintf(sbom_out, "%s%s", pkgconf_buffer_str_or_empty(&set->buffer), node->prev != NULL ? "\n" : "");
+		OUTPUT_OR_RET_FALSE(client, sbom_out, "%s%s", pkgconf_buffer_str_or_empty(&set->buffer), node->prev != NULL ? "\n" : "");
 	}
 
-	fprintf(sbom_out, "</text>\n");
+	OUTPUT_OR_RET_FALSE(client, sbom_out, "</text>\n");
+
+	return true;
 }
 
 static void
@@ -144,44 +162,45 @@ write_sbom_package(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *unused)
 	if (pkg->flags & PKGCONF_PKG_PROPF_VIRTUAL)
 		return;
 
-	fprintf(sbom_out, "##### Package: %s\n\n", sbom_identity(pkg));
-
-	fprintf(sbom_out, "PackageName: %s\n", pkg->id);
-	fprintf(sbom_out, "SPDXID: SPDXRef-Package-%s\n", sbom_spdx_identity(pkg));
-	fprintf(sbom_out, "PackageVersion: %s\n", pkg->version);
-	fprintf(sbom_out, "PackageVerificationCode: NOASSERTION\n");
+	OUTPUT_OR_RET(client, sbom_out, "##### Package: %s\n\n", sbom_identity(pkg));
+	OUTPUT_OR_RET(client, sbom_out, "PackageName: %s\n", pkg->id);
+	OUTPUT_OR_RET(client, sbom_out, "SPDXID: SPDXRef-Package-%s\n", sbom_spdx_identity(pkg));
+	OUTPUT_OR_RET(client, sbom_out, "PackageVersion: %s\n", pkg->version);
+	OUTPUT_OR_RET(client, sbom_out, "PackageVerificationCode: NOASSERTION\n");
 
 	/* XXX: What about projects? */
 	if (pkg->maintainer != NULL)
-		fprintf(sbom_out, "PackageSupplier: Person: %s\n", pkg->maintainer);
+		OUTPUT_OR_RET(client, sbom_out, "PackageSupplier: Person: %s\n", pkg->maintainer);
 
 	if (pkg->url != NULL)
-		fprintf(sbom_out, "PackageHomePage: %s\n", pkg->url);
+		OUTPUT_OR_RET(client, sbom_out, "PackageHomePage: %s\n", pkg->url);
 
 	if (pkg->license.head != NULL)
 	{
 		pkgconf_license_render(client, &pkg->license, &license_buf);
-		fprintf(sbom_out, "PackageLicenseDeclared: %s\n", pkgconf_buffer_str_or_empty(&license_buf));
+		bool ret = pkgconf_output_file_fmt(sbom_out, "PackageLicenseDeclared: %s\n", pkgconf_buffer_str_or_empty(&license_buf));
 		pkgconf_buffer_finalize(&license_buf);
+		if (!ret)
+		{
+			pkgconf_error(client, "bomtool: could not output to file: %s", strerror(errno));
+			return;
+		}
 	}
 	else
-	{
-		fprintf(sbom_out, "PackageLicenseDeclared: NOASSERTION\n");
-	}
+		OUTPUT_OR_RET(client, sbom_out, "PackageLicenseDeclared: NOASSERTION\n");
 
-
-	write_copyright_lines(&pkg->copyright);
+	if (!write_copyright_lines(client, &pkg->copyright))
+		return;
 
 	if (pkg->description != NULL)
-		fprintf(sbom_out, "PackageSummary: <text>%s</text>\n", pkg->description);
+		OUTPUT_OR_RET(client, sbom_out, "PackageSummary: <text>%s</text>\n", pkg->description);
 
 	if (pkg->source != NULL)
-		fprintf(sbom_out, "PackageDownloadLocation: %s\n", pkg->source);
+		OUTPUT_OR_RET(client, sbom_out, "PackageDownloadLocation: %s\n", pkg->source);
 	else
-		fprintf(sbom_out, "PackageDownloadLocation: NOASSERTION\n");
+		OUTPUT_OR_RET(client, sbom_out, "PackageDownloadLocation: NOASSERTION\n");
 
-
-	fprintf(sbom_out, "\n\n");
+	OUTPUT_OR_RET(client, sbom_out, "\n\n");
 }
 
 static void
@@ -206,8 +225,8 @@ write_sbom_relationships(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *unu
 		if (!dep->match)
 			continue;
 
-		fprintf(sbom_out, "Relationship: %s DEPENDS_ON SPDXRef-Package-%s\n", baseref, sbom_spdx_identity(match));
-		fprintf(sbom_out, "Relationship: SPDXRef-Package-%s DEPENDENCY_OF %s\n", sbom_spdx_identity(match), baseref);
+		OUTPUT_OR_RET(client, sbom_out, "Relationship: %s DEPENDS_ON SPDXRef-Package-%s\n", baseref, sbom_spdx_identity(match));
+		OUTPUT_OR_RET(client, sbom_out, "Relationship: SPDXRef-Package-%s DEPENDENCY_OF %s\n", sbom_spdx_identity(match), baseref);
 	}
 
 	PKGCONF_FOREACH_LIST_ENTRY(pkg->requires_private.head, node)
@@ -218,12 +237,12 @@ write_sbom_relationships(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *unu
 		if (!dep->match)
 			continue;
 
-		fprintf(sbom_out, "Relationship: %s DEPENDS_ON SPDXRef-Package-%s\n", baseref, sbom_spdx_identity(match));
-		fprintf(sbom_out, "Relationship: SPDXRef-Package-%s DEV_DEPENDENCY_OF %s\n", sbom_spdx_identity(match), baseref);
+		OUTPUT_OR_RET(client, sbom_out, "Relationship: %s DEPENDS_ON SPDXRef-Package-%s\n", baseref, sbom_spdx_identity(match));
+		OUTPUT_OR_RET(client, sbom_out, "Relationship: SPDXRef-Package-%s DEV_DEPENDENCY_OF %s\n", sbom_spdx_identity(match), baseref);
 	}
 
 	if (pkg->required.head != NULL || pkg->requires_private.head != NULL)
-		fprintf(sbom_out, "\n\n");
+		OUTPUT_OR_RET(client, sbom_out, "\n\n");
 }
 
 static bool
@@ -232,7 +251,8 @@ generate_sbom_from_world(pkgconf_client_t *client, pkgconf_pkg_t *world)
 	int eflag;
 	pkgconf_node_t *node;
 
-	write_sbom_header(client, world);
+	if (!write_sbom_header(client, world))
+		return false;
 
 	eflag = pkgconf_pkg_traverse(client, world, write_sbom_package, NULL, maximum_traverse_depth, 0);
 	if (eflag != PKGCONF_PKG_ERRF_OK)
@@ -250,7 +270,7 @@ generate_sbom_from_world(pkgconf_client_t *client, pkgconf_pkg_t *world)
 		if (!dep->match)
 			continue;
 
-		fprintf(sbom_out, "Relationship: %s DESCRIBES SPDXRef-Package-%s\n", document_ref, sbom_spdx_identity(match));
+		OUTPUT_OR_RET_FALSE(client, sbom_out, "Relationship: %s DESCRIBES SPDXRef-Package-%s\n", document_ref, sbom_spdx_identity(match));
 	}
 
 	return true;
@@ -326,7 +346,7 @@ main(int argc, char *argv[])
 			sbom_out = fopen(pkg_optarg, "w");
 			if (sbom_out == NULL)
 			{
-				fprintf(stderr, "unable to open %s: %s\n", pkg_optarg, strerror(errno));
+				pkgconf_output_file_fmt(stderr, "unable to open %s: %s\n", pkg_optarg, strerror(errno));
 				return EXIT_FAILURE;
 			}
 
@@ -396,7 +416,7 @@ main(int argc, char *argv[])
 
 	if (pkgq.head == NULL)
 	{
-		fprintf(stderr, "Please specify at least one package name on the command line.\n");
+		pkgconf_output_file_fmt(stderr, "Please specify at least one package name on the command line.\n");
 		ret = EXIT_FAILURE;
 		goto out;
 	}

--- a/cli/bomtool/main.c
+++ b/cli/bomtool/main.c
@@ -109,16 +109,20 @@ write_sbom_header(pkgconf_client_t *client, pkgconf_pkg_t *world)
 	(void) client;
 	char *docname = sbom_name(world);
 
-	OUTPUT_OR_RET_FALSE(client, sbom_out, "SPDXVersion: %s\n", spdx_version);
-	OUTPUT_OR_RET_FALSE(client, sbom_out, "DataLicense: %s\n", bom_license);
-	OUTPUT_OR_RET_FALSE(client, sbom_out, "SPDXID: %s\n", document_ref);
-	OUTPUT_OR_RET_FALSE(client, sbom_out, "DocumentName: %s\n", docname);
-	OUTPUT_OR_RET_FALSE(client, sbom_out, "DocumentNamespace: https://spdx.org/spdxdocs/bomtool-%s\n", PACKAGE_VERSION);
-	OUTPUT_OR_RET_FALSE(client, sbom_out, "Creator: Tool: bomtool %s\n", PACKAGE_VERSION);
-	OUTPUT_OR_RET_FALSE(client, sbom_out, "\n\n");
+	bool ret = pkgconf_output_file_fmt(sbom_out, "SPDXVersion: %s\n", spdx_version)
+		&& pkgconf_output_file_fmt(sbom_out, "DataLicense: %s\n", bom_license)
+		&& pkgconf_output_file_fmt(sbom_out, "SPDXID: %s\n", document_ref)
+		&& pkgconf_output_file_fmt(sbom_out, "DocumentName: %s\n", docname)
+		&& pkgconf_output_file_fmt(sbom_out, "DocumentNamespace: https://spdx.org/spdxdocs/bomtool-%s\n", PACKAGE_VERSION)
+		&& pkgconf_output_file_fmt(sbom_out, "Creator: Tool: bomtool %s\n", PACKAGE_VERSION)
+		&& pkgconf_output_file_fmt(sbom_out, "\n\n");
 
+	int errno_save = errno;
 	free(docname);
-	return true;
+
+	if (!ret)
+		pkgconf_error(client, "bomtool: Could not output to file: %s", strerror(errno_save));
+	return ret;
 }
 
 static const char *
@@ -179,10 +183,11 @@ write_sbom_package(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *unused)
 	{
 		pkgconf_license_render(client, &pkg->license, &license_buf);
 		bool ret = pkgconf_output_file_fmt(sbom_out, "PackageLicenseDeclared: %s\n", pkgconf_buffer_str_or_empty(&license_buf));
+		int errno_save = errno;
 		pkgconf_buffer_finalize(&license_buf);
 		if (!ret)
 		{
-			pkgconf_error(client, "bomtool: could not output to file: %s", strerror(errno));
+			pkgconf_error(client, "bomtool: could not output to file: %s", strerror(errno_save));
 			return;
 		}
 	}

--- a/cli/bomtool/main.c
+++ b/cli/bomtool/main.c
@@ -36,20 +36,20 @@ static FILE *error_msgout = NULL;
 static FILE *sbom_out = NULL;
 
 #define OUTPUT_OR_RET(client, f, fmt, ...) \
-    do { \
-        if (!pkgconf_output_file_fmt((f), (fmt), ##__VA_ARGS__)) { \
-            pkgconf_error((client), "bomtool: Could not output to file: %s", strerror(errno)); \
-            return; \
-        } \
-    } while (0)
+	do { \
+		if (!pkgconf_output_file_fmt((f), (fmt), ##__VA_ARGS__)) { \
+			pkgconf_error((client), "bomtool: Could not output to file: %s", strerror(errno)); \
+			return; \
+		} \
+	} while (0)
 
 #define OUTPUT_OR_RET_FALSE(client, f, fmt, ...) \
-    do { \
-        if (!pkgconf_output_file_fmt((f), (fmt), ##__VA_ARGS__)) { \
-            pkgconf_error((client), "bomtool: Could not output to file: %s", strerror(errno)); \
-            return false; \
-        } \
-    } while (0)
+	do { \
+		if (!pkgconf_output_file_fmt((f), (fmt), ##__VA_ARGS__)) { \
+			pkgconf_error((client), "bomtool: Could not output to file: %s", strerror(errno)); \
+			return false; \
+		} \
+	} while (0)
 
 static const char *
 environ_lookup_handler(const pkgconf_client_t *client, const char *key)
@@ -106,23 +106,24 @@ sbom_name(pkgconf_pkg_t *world)
 static bool
 write_sbom_header(pkgconf_client_t *client, pkgconf_pkg_t *world)
 {
-	(void) client;
-	char *docname = sbom_name(world);
+	char *tmp = sbom_name(world);
+	if (!tmp)
+	{
+		pkgconf_error(client, "write_sbom_header: out of memory");
+		return false;
+	}
+	char *docname = PKGCONF_LOCAL_COPY(tmp);
+	free(tmp);
 
-	bool ret = pkgconf_output_file_fmt(sbom_out, "SPDXVersion: %s\n", spdx_version)
-		&& pkgconf_output_file_fmt(sbom_out, "DataLicense: %s\n", bom_license)
-		&& pkgconf_output_file_fmt(sbom_out, "SPDXID: %s\n", document_ref)
-		&& pkgconf_output_file_fmt(sbom_out, "DocumentName: %s\n", docname)
-		&& pkgconf_output_file_fmt(sbom_out, "DocumentNamespace: https://spdx.org/spdxdocs/bomtool-%s\n", PACKAGE_VERSION)
-		&& pkgconf_output_file_fmt(sbom_out, "Creator: Tool: bomtool %s\n", PACKAGE_VERSION)
-		&& pkgconf_output_file_fmt(sbom_out, "\n\n");
+	OUTPUT_OR_RET_FALSE(client, sbom_out, "SPDXVersion: %s\n", spdx_version);
+	OUTPUT_OR_RET_FALSE(client, sbom_out, "DataLicense: %s\n", bom_license);
+	OUTPUT_OR_RET_FALSE(client, sbom_out, "SPDXID: %s\n", document_ref);
+	OUTPUT_OR_RET_FALSE(client, sbom_out, "DocumentName: %s\n", docname);
+	OUTPUT_OR_RET_FALSE(client, sbom_out, "DocumentNamespace: https://spdx.org/spdxdocs/bomtool-%s\n", PACKAGE_VERSION);
+	OUTPUT_OR_RET_FALSE(client, sbom_out, "Creator: Tool: bomtool %s\n", PACKAGE_VERSION);
+	OUTPUT_OR_RET_FALSE(client, sbom_out, "\n\n");
 
-	int errno_save = errno;
-	free(docname);
-
-	if (!ret)
-		pkgconf_error(client, "bomtool: Could not output to file: %s", strerror(errno_save));
-	return ret;
+	return true;
 }
 
 static const char *

--- a/cli/main.c
+++ b/cli/main.c
@@ -36,7 +36,7 @@ error_handler(const char *msg, const pkgconf_client_t *client, void *data)
 	if (state->error_msgout == NULL)
 		return true;
 
-	fprintf(state->error_msgout, "%s", msg);
+	pkgconf_output_file_fmt(state->error_msgout, "%s", msg);
 	return true;
 }
 
@@ -221,7 +221,7 @@ main(int argc, char *argv[])
 
 	if (pkgconf_pledge("stdio rpath wpath cpath unveil", NULL) == -1)
 	{
-		fprintf(stderr, "pkgconf: pledge failed: %s\n", strerror(errno));
+		pkgconf_output_file_fmt(stderr, "pkgconf: pledge failed: %s\n", strerror(errno));
 		return EXIT_FAILURE;
 	}
 
@@ -456,7 +456,7 @@ main(int argc, char *argv[])
 	{
 		if (pkgconf_unveil(logfile_arg, "rwc") == -1)
 		{
-			fprintf(stderr, "pkgconf: unveil failed: %s\n", strerror(errno));
+			pkgconf_output_file_fmt(stderr, "pkgconf: unveil failed: %s\n", strerror(errno));
 			return EXIT_FAILURE;
 		}
 

--- a/cli/spdxtool/main.c
+++ b/cli/spdxtool/main.c
@@ -48,7 +48,11 @@ error_handler(const char *msg, const pkgconf_client_t *client, void *data)
 {
 	(void) client;
 	(void) data;
-	fprintf(error_msgout, "%s", msg);
+	if (!pkgconf_output_file_fmt(error_msgout, "%s", msg))
+	{
+		pkgconf_error(client, "spdxtool: Could not output error message: %s", strerror(errno));
+		return false;
+	}
 	return true;
 }
 
@@ -202,13 +206,16 @@ generate_spdx(pkgconf_client_t *client, pkgconf_pkg_t *world, const char *creati
 	spdxtool_serialize_value_to_buf(&buffer, root, 0);
 	spdxtool_serialize_value_free(root);
 
-	fprintf(sbom_out, "%s\n", pkgconf_buffer_str(&buffer));
+	bool ret = pkgconf_output_file_fmt(sbom_out, "%s\n", pkgconf_buffer_str(&buffer));
 	pkgconf_buffer_finalize(&buffer);
 
 	spdxtool_core_spdx_document_free(document);
 	spdxtool_core_creation_info_free(creation);
 	spdxtool_core_agent_free(agent);
-	return true;
+
+	if (!ret)
+		pkgconf_error(client, "spdxtool: Could not output to file: %s", strerror(errno));
+	return ret;
 }
 
 static int
@@ -306,7 +313,7 @@ main(int argc, char *argv[])
 			sbom_out = fopen(pkg_optarg, "w");
 			if (sbom_out == NULL)
 			{
-				fprintf(stderr, "unable to open %s: %s\n", pkg_optarg, strerror(errno));
+				pkgconf_output_file_fmt(stderr, "unable to open %s: %s\n", pkg_optarg, strerror(errno));
 				return EXIT_FAILURE;
 			}
 			break;

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,7 @@ AX_CHECK_COMPILE_FLAG([-std=gnu99], [CFLAGS="$CFLAGS -std=gnu99"], [
 	AX_CHECK_COMPILE_FLAG([-std=c99], [CFLAGS="$CFLAGS -std=c99"])
 ])
 AC_CONFIG_HEADERS([libpkgconf/config.h])
+AC_CHECK_DECLS([strdupa], [], [], [[#include <string.h>]])
 AC_CHECK_DECLS([strndup], [], [], [[#include <string.h>]])
 AC_CHECK_DECLS([pledge, unveil], [], [], [[#include <unistd.h>]])
 AC_CHECK_DECLS([readlinkat], [], [], [[#include <unistd.h>]])

--- a/libpkgconf/audit.c
+++ b/libpkgconf/audit.c
@@ -14,6 +14,7 @@
  */
 
 #include <libpkgconf/libpkgconf.h>
+#include <errno.h>
 
 /*
  * !doc
@@ -66,7 +67,11 @@ pkgconf_audit_log(pkgconf_client_t *client, const char *format, ...)
 		return;
 
 	va_start(va, format);
-	vfprintf(client->auditf, format, va);
+	if (!pkgconf_output_file_vfmt(client->auditf, format, va))
+	{
+		// TODO: should probably return here
+		pkgconf_error(client, "Failed to output to file: %s", strerror(errno));
+	}
 	va_end(va);
 }
 
@@ -88,11 +93,24 @@ pkgconf_audit_log_dependency(pkgconf_client_t *client, const pkgconf_pkg_t *dep,
 	if (client->auditf == NULL)
 		return;
 
-	fprintf(client->auditf, "%s ", dep->id);
-	if (depnode->version != NULL && depnode->compare != PKGCONF_CMP_ANY)
+	if (!pkgconf_output_file_fmt(client->auditf, "%s ", dep->id))
 	{
-		fprintf(client->auditf, "%s %s ", pkgconf_pkg_get_comparator(depnode), depnode->version);
+		// TODO: should probably return here
+		pkgconf_error(client, "Failed to output to file: %s", strerror(errno));
 	}
 
-	fprintf(client->auditf, "[%s]\n", dep->version);
+	if (depnode->version != NULL && depnode->compare != PKGCONF_CMP_ANY)
+	{
+		if (!pkgconf_output_file_fmt(client->auditf, "%s %s ", pkgconf_pkg_get_comparator(depnode), depnode->version))
+		{
+			// TODO: should probably return here
+			pkgconf_error(client, "Failed to output to file: %s", strerror(errno));
+		}
+	}
+
+	if (!pkgconf_output_file_fmt(client->auditf, "[%s]\n", dep->version))
+	{
+		// TODO: should probably return here
+		pkgconf_error(client, "Failed to output to file: %s", strerror(errno));
+	}
 }

--- a/libpkgconf/buffer.c
+++ b/libpkgconf/buffer.c
@@ -38,7 +38,7 @@ buffer_debug(pkgconf_buffer_t *buffer)
 {
 	for (char *c = buffer->base; c <= buffer->end; c++)
 	{
-		pkgconf_output_file_fmt(stderr, "%02x ", (unsigned char) *c);
+		fprintf(stderr, "%02x ", (unsigned char) *c);
 	}
 
 	pkgconf_output_file_fmt(stderr, "\n");

--- a/libpkgconf/buffer.c
+++ b/libpkgconf/buffer.c
@@ -36,11 +36,12 @@ target_allocation_size(size_t target_size)
 static void
 buffer_debug(pkgconf_buffer_t *buffer)
 {
-	for (char *c = buffer->base; c <= buffer->end; c++) {
-		fprintf(stderr, "%02x ", (unsigned char) *c);
+	for (char *c = buffer->base; c <= buffer->end; c++)
+	{
+		pkgconf_output_file_fmt(stderr, "%02x ", (unsigned char) *c);
 	}
 
-	fprintf(stderr, "\n");
+	pkgconf_output_file_fmt(stderr, "\n");
 }
 #endif
 

--- a/libpkgconf/config.h.meson
+++ b/libpkgconf/config.h.meson
@@ -1,5 +1,8 @@
 /* libpkgconf/config.h.in.  Generated from configure.ac by autoheader.  */
 
+/* Define to 1 if you have the `strdupa` function. */
+#mesondefine HAVE_STRDUPA
+
 /* Define to 1 if you have the `strlcat' function. */
 #mesondefine HAVE_STRLCAT
 

--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -684,6 +684,9 @@ PKGCONF_API bool pkgconf_output_fmt(pkgconf_output_t *output, pkgconf_output_str
 PKGCONF_API bool pkgconf_output_vfmt(pkgconf_output_t *output, pkgconf_output_stream_t stream, const char *fmt, va_list va_src) PRINTFLIKE(3,0);
 PKGCONF_API pkgconf_output_t *pkgconf_output_default(void);
 
+PKGCONF_API bool pkgconf_output_file_vfmt(FILE *f, const char *fmt, va_list va) PRINTFLIKE(2,0);
+PKGCONF_API bool pkgconf_output_file_fmt(FILE *f, const char *fmt, ...) PRINTFLIKE(2,3);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -69,6 +69,14 @@ typedef struct pkgconf_license_ pkgconf_license_t;
 #define PKGCONF_FOREACH_LIST_ENTRY_REVERSE(tail, value) \
 	for ((value) = (tail); (value) != NULL; (value) = (value)->prev)
 
+#ifdef HAVE_STRDUPA
+#	define PKGCONF_LOCAL_COPY(s) strdupa(s)
+#elif defined(__INTEL_COMPILER) || defined(__GNUC__)
+#	define PKGCONF_LOCAL_COPY(s) __extension__({ char *_s = alloca(strlen(s) + 1); strcpy(_s, s); _s; })
+#else
+#	define PKGCONF_LOCAL_COPY(s) strcpy(alloca(strlen(s) + 1), s)
+#endif /* HAVE_STRDUPA */
+
 #define LIBPKGCONF_VERSION	20501
 #define LIBPKGCONF_VERSION_STR	"2.5.1"
 

--- a/libpkgconf/output.c
+++ b/libpkgconf/output.c
@@ -108,3 +108,44 @@ pkgconf_output_default(void)
 {
 	return &pkgconf_default_output;
 }
+
+/*
+ * !doc
+ *
+ * .. c:function:: bool pkgconf_output_file_vfmt(FILE *f, const char *fmt, va_list va)
+ *
+ *    Wrapper around :code:`vfprintf` that returns a boolean.
+ *
+ *    :param FILE *f: Pointer to an open `FILE` pointer.
+ *    :param: const char *fmt: Format string.
+ *    :param va_list va: Variable list.
+ *    :return: :code:`true` on success, :code:`false` on failure.
+ */
+bool
+pkgconf_output_file_vfmt(FILE *f, const char *fmt, va_list va)
+{
+	int ret = vfprintf(f, fmt, va);
+	return ret > 0;
+}
+
+/*
+ * !doc
+ *
+ * .. c:function:: bool pkgconf_output_file_fmt(FILE *f, const char *fmt, va_list va)
+ *
+ *    Wrapper around :code:`fprintf` that returns a boolean.
+ *
+ *    :param FILE *f: Pointer to an open `FILE` pointer.
+ *    :param: const char *fmt: Format string.
+ *    :return: :code:`true` on success, :code:`false` on failure.
+ */
+bool
+pkgconf_output_file_fmt(FILE *f, const char *fmt, ...)
+{
+	va_list va;
+	va_start(va, fmt);
+	bool ret = pkgconf_output_file_vfmt(f, fmt, va);
+	va_end(va);
+
+	return ret;
+}

--- a/libpkgconf/personality.c
+++ b/libpkgconf/personality.c
@@ -246,7 +246,7 @@ personality_warn_func(void *p, const char *fmt, ...)
 	(void) p;
 
 	va_start(va, fmt);
-	vfprintf(stderr, fmt, va);
+	pkgconf_output_file_vfmt(stderr, fmt, va);
 	va_end(va);
 }
 

--- a/meson.build
+++ b/meson.build
@@ -57,6 +57,7 @@ endif
 cdata = configuration_data()
 
 check_functions = [
+  ['strdupa', 'string.h'],
   ['strndup', 'string.h'],
   ['strdup', 'string.h'],
   ['strncasecmp', 'strings.h'],


### PR DESCRIPTION
This adds a new set of functions: `pkgconf_output_file_vfmt` and `pkgconf_output_file_fmt`, which act as simple wrappers around `fprintf` and convert the return type to `bool`.

This PR also converts most instances of `fprintf` and adds checking of the output of these functions, especially ones outputting to file descriptors besides `stderr`. If `stderr` fails, there is little we can do, so this is not generally checked. But it is useful to check other FDs, to display a diagnostic to the end user if a write fails (broken pipe, filesystem full, filesystem failure, etc.).

This is not perfect, and things are not always immediately aborted on I/O failure. This will require deeper API changes like in #492, but this is still an improvement.