### PR TITLE
bomtool: Add command line parameter for defining variables

### DIFF
--- a/cli/bomtool/main.c
+++ b/cli/bomtool/main.c
@@ -23,6 +23,7 @@
 #define PKG_ABOUT			(((uint64_t) 1) << 2)
 #define PKG_HELP			(((uint64_t) 1) << 3)
 #define PKG_OUTPUT			(((uint64_t) 1) << 4)
+#define PKG_DEFINE_VARIABLE	(((uint64_t) 1) << 5)
 
 static const char *spdx_version = "SPDX-2.2";
 static const char *bom_license = "CC0-1.0";
@@ -290,6 +291,7 @@ usage(void)
 	printf("  --about                           print bomtool version and license to stdout\n");
 	printf("  --version                         print bomtool version to stdout\n");
 	printf("  --output FILE                     output SBOM text to FILE\n");
+	printf("  --define-variable=varname=value   define variable 'varname' as 'value'\n");
 
 	return EXIT_SUCCESS;
 }
@@ -314,7 +316,8 @@ main(int argc, char *argv[])
 		{ "version", no_argument, &want_flags, PKG_VERSION, },
 		{ "about", no_argument, &want_flags, PKG_ABOUT, },
 		{ "help", no_argument, &want_flags, PKG_HELP, },
-		{ "output", required_argument, NULL, PKG_OUTPUT, }, 
+		{ "output", required_argument, NULL, PKG_OUTPUT, },
+		{ "define-variable", required_argument, NULL, PKG_DEFINE_VARIABLE, },
 		{ NULL, 0, NULL, 0 }
 	};
 
@@ -330,6 +333,9 @@ main(int argc, char *argv[])
 				return EXIT_FAILURE;
 			}
 
+			break;
+		case PKG_DEFINE_VARIABLE:
+			pkgconf_tuple_define_global(&pkg_client, pkg_optarg);
 			break;
 		case '?':
 		case ':':

--- a/man/bomtool.1
+++ b/man/bomtool.1
@@ -38,6 +38,13 @@ Print the version number of the
 .Nm
 program to standard output and exit.
 Most other options and all command line arguments are ignored.
+.It Fl -define-variable Ns = Ns Ar varname Ns = Ns Ar value
+Define
+.Ar varname
+as
+.Ar value .
+Variables are used in query output, and some modules' results may change based
+on the presence of a variable definition.
 .El
 .Sh ENVIRONMENT
 .Bl -tag -width indent


### PR DESCRIPTION
Add similar command line parameter for `bomtool` for define variables than `pkgconf` has. Also update man page.