### PR TITLE
spdxtool: Add command line paramter for variable defination

### DIFF
--- a/cli/spdxtool/main.c
+++ b/cli/spdxtool/main.c
@@ -247,6 +247,7 @@ usage(void)
 	printf("  --output FILE                     output SBOM data to file\n");
 	printf("  --spdx-base-id URL                Uset string as base of SPDX ids [default: %s]\n", xsd_any_uri_default_base);
 	printf("  --use-uri                         Use URIs not URLs as SPDX id");
+	printf("  --define-variable=varname=value   define variable global 'varname' as 'value'\n");
 
 	return EXIT_SUCCESS;
 }
@@ -286,6 +287,7 @@ main(int argc, char *argv[])
 		{ "output", required_argument, NULL, 103, },
 		{ "spdx-base-id", required_argument, NULL, 104, },
 		{ "use-uri", no_argument, NULL, 105, },
+		{ "define-variable", required_argument, NULL, 106, },
 		{ NULL, 0, NULL, 0 }
 	};
 
@@ -318,6 +320,9 @@ main(int argc, char *argv[])
 			if (!strcmp(spdx_id_base, xsd_any_url_default_base))
 				spdx_id_base = xsd_any_uri_default_base;
 			colon_sep = true;
+			break;
+		case 106:
+			pkgconf_tuple_define_global(&pkg_client, pkg_optarg);
 			break;
 		case '?':
 		case ':':

--- a/man/spdxtool.1
+++ b/man/spdxtool.1
@@ -52,6 +52,13 @@ Default is document creation time.
 Set creation ID in /Core/CreationInfoc-class.
 As ID in creation info mainly have special format and it's
 default is '_:creationinfo_1'.
+.It Fl -define-variable Ns = Ns Ar varname Ns = Ns Ar value
+Define
+.Ar varname
+as
+.Ar value .
+Variables are used in query output, and some modules' results may change based
+on the presence of a variable definition.
 .El
 .Sh ENVIRONMENT
 .Bl -tag -width indent

--- a/t/spdxtool/define-variable-with-depencency.test
+++ b/t/spdxtool/define-variable-with-depencency.test
@@ -1,0 +1,5 @@
+Tool: spdxtool
+ToolArgs: --creation-time=test --define-variable=VERSION_VARIABLE_TEST=1.0-123 --define-variable=license_variable_test=MIT variable-test2
+Environment: PKG_CONFIG_PATH=%TEST_FIXTURES_DIR%/lib-sbom
+ExpectedStdoutFile: ../../tests/lib-sbom-files/define_variable_with_dependency.json
+ExpectedExitCode: 0

--- a/t/spdxtool/define-variable.test
+++ b/t/spdxtool/define-variable.test
@@ -1,0 +1,5 @@
+Tool: spdxtool
+ToolArgs: --creation-time=test --define-variable=VERSION_VARIABLE_TEST=1.0-123 variable-test1
+Environment: PKG_CONFIG_PATH=%TEST_FIXTURES_DIR%/lib-sbom
+ExpectedStdoutFile: ../../tests/lib-sbom-files/define_variable.json
+ExpectedExitCode: 0

--- a/tests/lib-sbom-files/define_variable.json
+++ b/tests/lib-sbom-files/define_variable.json
@@ -1,0 +1,90 @@
+{
+    "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+    "@graph": [
+        {
+            "type": "Agent",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/Agent/default",
+            "name": "Default"
+        },
+        {
+            "type": "CreationInfo",
+            "@id": "_:creationinfo_1",
+            "created": "test",
+            "createdBy": [
+                "https://github.com/pkgconf/pkgconf/Agent/default"
+            ],
+            "specVersion": "3.0.1"
+        },
+        {
+            "type": "simplelicensing_LicenseExpression",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/simplelicensing_LicenseExpression/BSD-2-Clause",
+            "simplelicensing_licenseExpression": "BSD-2-Clause"
+        },
+        {
+            "type": "software_Sbom",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/software_Sbom/variable-test1",
+            "software_sbomType": [
+                "build"
+            ],
+            "rootElement": [
+                "https://github.com/pkgconf/pkgconf/Package/variable-test1"
+            ],
+            "element": [
+                "https://github.com/pkgconf/pkgconf/Relationship/variable-test1/hasDeclaredLicense",
+                "https://github.com/pkgconf/pkgconf/Relationship/variable-test1/hasConcludedLicense"
+            ]
+        },
+        {
+            "type": "software_Package",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/Package/variable-test1",
+            "name": "variable-test1",
+            "originatedBy": [
+                "https://github.com/pkgconf/pkgconf/Agent/default"
+            ],
+            "software_copyrightText": "NOASSERTION",
+            "software_homePage": "https://github.com/pkgconf/pkgconf/releases/",
+            "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",
+            "software_packageVersion": "1.0-123"
+        },
+        {
+            "type": "Relationship",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/Relationship/variable-test1/hasDeclaredLicense",
+            "from": "https://github.com/pkgconf/pkgconf/Package/variable-test1",
+            "to": [
+                "https://github.com/pkgconf/pkgconf/simplelicensing_LicenseExpression/BSD-2-Clause"
+            ],
+            "relationshipType": "hasDeclaredLicense"
+        },
+        {
+            "type": "Relationship",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/Relationship/variable-test1/hasConcludedLicense",
+            "from": "https://github.com/pkgconf/pkgconf/Package/variable-test1",
+            "to": [
+                "https://github.com/pkgconf/pkgconf/simplelicensing_LicenseExpression/BSD-2-Clause"
+            ],
+            "relationshipType": "hasConcludedLicense"
+        },
+        {
+            "type": "SpdxDocument",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/spdxDocument/1",
+            "rootElement": [
+                "https://github.com/pkgconf/pkgconf/software_Sbom/variable-test1"
+            ],
+            "element": [
+                "https://github.com/pkgconf/pkgconf/Agent/default",
+                "https://github.com/pkgconf/pkgconf/simplelicensing_LicenseExpression/BSD-2-Clause",
+                "https://github.com/pkgconf/pkgconf/Relationship/variable-test1/hasDeclaredLicense",
+                "https://github.com/pkgconf/pkgconf/Relationship/variable-test1/hasConcludedLicense",
+                "https://github.com/pkgconf/pkgconf/software_Sbom/variable-test1",
+                "https://github.com/pkgconf/pkgconf/Package/variable-test1"
+            ]
+        }
+    ]
+}

--- a/tests/lib-sbom-files/define_variable_with_dependency.json
+++ b/tests/lib-sbom-files/define_variable_with_dependency.json
@@ -1,0 +1,162 @@
+{
+    "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+    "@graph": [
+        {
+            "type": "Agent",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/Agent/default",
+            "name": "Default"
+        },
+        {
+            "type": "CreationInfo",
+            "@id": "_:creationinfo_1",
+            "created": "test",
+            "createdBy": [
+                "https://github.com/pkgconf/pkgconf/Agent/default"
+            ],
+            "specVersion": "3.0.1"
+        },
+        {
+            "type": "simplelicensing_LicenseExpression",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/simplelicensing_LicenseExpression/MIT",
+            "simplelicensing_licenseExpression": "MIT"
+        },
+        {
+            "type": "simplelicensing_LicenseExpression",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/simplelicensing_LicenseExpression/BSD-2-Clause",
+            "simplelicensing_licenseExpression": "BSD-2-Clause"
+        },
+        {
+            "type": "software_Sbom",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/software_Sbom/variable-test2",
+            "software_sbomType": [
+                "build"
+            ],
+            "rootElement": [
+                "https://github.com/pkgconf/pkgconf/Package/variable-test2"
+            ],
+            "element": [
+                "https://github.com/pkgconf/pkgconf/Relationship/variable-test2/dependsOn/variable-test1",
+                "https://github.com/pkgconf/pkgconf/Relationship/variable-test2/hasDeclaredLicense",
+                "https://github.com/pkgconf/pkgconf/Relationship/variable-test2/hasConcludedLicense"
+            ]
+        },
+        {
+            "type": "software_Sbom",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/software_Sbom/variable-test1",
+            "software_sbomType": [
+                "build"
+            ],
+            "rootElement": [
+                "https://github.com/pkgconf/pkgconf/Package/variable-test1"
+            ],
+            "element": [
+                "https://github.com/pkgconf/pkgconf/Relationship/variable-test1/hasDeclaredLicense",
+                "https://github.com/pkgconf/pkgconf/Relationship/variable-test1/hasConcludedLicense"
+            ]
+        },
+        {
+            "type": "software_Package",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/Package/variable-test2",
+            "name": "variable-test2",
+            "originatedBy": [
+                "https://github.com/pkgconf/pkgconf/Agent/default"
+            ],
+            "software_copyrightText": "NOASSERTION",
+            "software_homePage": "https://github.com/pkgconf/pkgconf/releases/",
+            "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",
+            "software_packageVersion": "2.0"
+        },
+        {
+            "type": "software_Package",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/Package/variable-test1",
+            "name": "variable-test1",
+            "originatedBy": [
+                "https://github.com/pkgconf/pkgconf/Agent/default"
+            ],
+            "software_copyrightText": "NOASSERTION",
+            "software_homePage": "https://github.com/pkgconf/pkgconf/releases/",
+            "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",
+            "software_packageVersion": "1.0-123"
+        },
+        {
+            "type": "Relationship",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/Relationship/variable-test2/hasDeclaredLicense",
+            "from": "https://github.com/pkgconf/pkgconf/Package/variable-test2",
+            "to": [
+                "https://github.com/pkgconf/pkgconf/simplelicensing_LicenseExpression/MIT"
+            ],
+            "relationshipType": "hasDeclaredLicense"
+        },
+        {
+            "type": "Relationship",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/Relationship/variable-test2/hasConcludedLicense",
+            "from": "https://github.com/pkgconf/pkgconf/Package/variable-test2",
+            "to": [
+                "https://github.com/pkgconf/pkgconf/simplelicensing_LicenseExpression/MIT"
+            ],
+            "relationshipType": "hasConcludedLicense"
+        },
+        {
+            "type": "Relationship",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/Relationship/variable-test2/dependsOn/variable-test1",
+            "from": "https://github.com/pkgconf/pkgconf/Package/variable-test2",
+            "to": [
+                "https://github.com/pkgconf/pkgconf/Package/variable-test1"
+            ],
+            "relationshipType": "dependsOn"
+        },
+        {
+            "type": "Relationship",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/Relationship/variable-test1/hasDeclaredLicense",
+            "from": "https://github.com/pkgconf/pkgconf/Package/variable-test1",
+            "to": [
+                "https://github.com/pkgconf/pkgconf/simplelicensing_LicenseExpression/BSD-2-Clause"
+            ],
+            "relationshipType": "hasDeclaredLicense"
+        },
+        {
+            "type": "Relationship",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/Relationship/variable-test1/hasConcludedLicense",
+            "from": "https://github.com/pkgconf/pkgconf/Package/variable-test1",
+            "to": [
+                "https://github.com/pkgconf/pkgconf/simplelicensing_LicenseExpression/BSD-2-Clause"
+            ],
+            "relationshipType": "hasConcludedLicense"
+        },
+        {
+            "type": "SpdxDocument",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/spdxDocument/1",
+            "rootElement": [
+                "https://github.com/pkgconf/pkgconf/software_Sbom/variable-test2",
+                "https://github.com/pkgconf/pkgconf/software_Sbom/variable-test1"
+            ],
+            "element": [
+                "https://github.com/pkgconf/pkgconf/Agent/default",
+                "https://github.com/pkgconf/pkgconf/simplelicensing_LicenseExpression/MIT",
+                "https://github.com/pkgconf/pkgconf/simplelicensing_LicenseExpression/BSD-2-Clause",
+                "https://github.com/pkgconf/pkgconf/Relationship/variable-test2/dependsOn/variable-test1",
+                "https://github.com/pkgconf/pkgconf/Relationship/variable-test2/hasDeclaredLicense",
+                "https://github.com/pkgconf/pkgconf/Relationship/variable-test2/hasConcludedLicense",
+                "https://github.com/pkgconf/pkgconf/Relationship/variable-test1/hasDeclaredLicense",
+                "https://github.com/pkgconf/pkgconf/Relationship/variable-test1/hasConcludedLicense",
+                "https://github.com/pkgconf/pkgconf/software_Sbom/variable-test2",
+                "https://github.com/pkgconf/pkgconf/Package/variable-test2",
+                "https://github.com/pkgconf/pkgconf/software_Sbom/variable-test1",
+                "https://github.com/pkgconf/pkgconf/Package/variable-test1"
+            ]
+        }
+    ]
+}

--- a/tests/lib-sbom/variable-test1.pc
+++ b/tests/lib-sbom/variable-test1.pc
@@ -1,0 +1,7 @@
+Name: variable-test1
+Description: Variable test 1
+URL: https://github.com/pkgconf/pkgconf/releases/
+Version: ${VERSION_VARIABLE_TEST}
+License: BSD-2-Clause
+Source: https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz
+

--- a/tests/lib-sbom/variable-test2.pc
+++ b/tests/lib-sbom/variable-test2.pc
@@ -1,0 +1,7 @@
+Name: variable-test2
+Description: Variable test 2
+URL: https://github.com/pkgconf/pkgconf/releases/
+Version: 2.0
+License: ${license_variable_test}
+Source: https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz
+Requires: variable-test1


### PR DESCRIPTION
Add similar command line parameter for `spdxtool` for define variables than `pkgconf` has. Add test for new functionality and also update man page.