### PR TITLE
SPDX-License-Identifier: Add SPDX-License-Identifier information to files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,32 @@ contribution is conformant with the
 
    [dco]: DCO
 
+## License for new source file
+
+New source files should be licensed under pkgconf-license.
+Template for license header is:
+
+```
+/*
+ * [FILENAME].c
+ * Short one line description
+ *
+ * SPDX-License-Identifier: pkgconf
+ *
+ * Copyright (c) [YEAR] pkgconf authors (see AUTHORS).
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * This software is provided 'as is' and without any warranty, express or
+ * implied.  In no event shall the authors be liable for any damages arising
+ * from the use of this software.
+ */
+```
+
+Where `[FILENAME]` is source file's name like: `filename.c` and `[YEAR]` is current year
+
 ## Authorship, provenance and automated tooling
 
 Contributions to pkgconf must have clear and defensible provenance.

--- a/cli/bomtool/main.c
+++ b/cli/bomtool/main.c
@@ -2,6 +2,8 @@
  * bomtool/main.c
  * main() routine, printer functions
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
  *     pkgconf authors (see AUTHORS).
  *

--- a/cli/core.c
+++ b/cli/core.c
@@ -2,6 +2,8 @@
  * core.c
  * core, printer functions
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2011-2025 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/cli/core.h
+++ b/cli/core.h
@@ -2,6 +2,8 @@
  * core.h
  * core, printer functions
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2011-2025 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/cli/getopt_long.c
+++ b/cli/getopt_long.c
@@ -1,7 +1,8 @@
 /*	$OpenBSD: getopt_long.c,v 1.21 2006/09/22 17:22:05 millert Exp $	*/
 /*	$NetBSD: getopt_long.c,v 1.15 2002/01/31 22:43:40 tv Exp $	*/
 
-/*
+/* SPDX-License-Identifier: LicenseRef-scancode-sudo AND BSD-4-Clause
+ *
  * Copyright (c) 2002 Todd C. Miller <Todd.Miller@courtesan.com>
  *
  * Permission to use, copy, modify, and distribute this software for any

--- a/cli/getopt_long.h
+++ b/cli/getopt_long.h
@@ -2,6 +2,8 @@
 /*	$FreeBSD$ */
 
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2000 The NetBSD Foundation, Inc.
  * All rights reserved.
  *

--- a/cli/main.c
+++ b/cli/main.c
@@ -2,6 +2,8 @@
  * main.c
  * main() routine
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2011-2025 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/cli/renderer-msvc.c
+++ b/cli/renderer-msvc.c
@@ -2,6 +2,8 @@
  * renderer-msvc.c
  * MSVC library syntax renderer
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2017 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/cli/renderer-msvc.h
+++ b/cli/renderer-msvc.h
@@ -2,6 +2,8 @@
  * renderer-msvc.h
  * MSVC library syntax renderer header
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2017 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/fuzzer/parser-fuzzer.c
+++ b/fuzzer/parser-fuzzer.c
@@ -2,6 +2,8 @@
  * parser-fuzzer.c
  * parser fuzzing harness
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2026 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/argvsplit.c
+++ b/libpkgconf/argvsplit.c
@@ -2,6 +2,8 @@
  * argvsplit.c
  * argv_split() routine
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2012, 2017 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/audit.c
+++ b/libpkgconf/audit.c
@@ -2,6 +2,8 @@
  * audit.c
  * package audit log functions
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2016 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/bsdstubs.c
+++ b/libpkgconf/bsdstubs.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2012 Ariadne Conill <ariadne@dereferenced.org>
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/bsdstubs.h
+++ b/libpkgconf/bsdstubs.h
@@ -2,6 +2,8 @@
  * bsdstubs.h
  * Header for stub BSD function prototypes if unavailable on a specific platform.
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2012 William Pitcock <nenolod@dereferenced.org>.
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/buffer.c
+++ b/libpkgconf/buffer.c
@@ -2,6 +2,8 @@
  * buffer.c
  * dynamically-managed buffers
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2024 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/bufferset.c
+++ b/libpkgconf/bufferset.c
@@ -2,6 +2,8 @@
  * bufferset.c
  * dynamically-managed buffer sets
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2026 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/bytecode.c
+++ b/libpkgconf/bytecode.c
@@ -2,6 +2,8 @@
  * bytecode.c
  * variable expansion bytecode evaluator
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2026 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/cache.c
+++ b/libpkgconf/cache.c
@@ -2,6 +2,8 @@
  * cache.c
  * package object cache
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2013 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/client.c
+++ b/libpkgconf/client.c
@@ -2,6 +2,8 @@
  * client.c
  * libpkgconf consumer lifecycle management
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2016 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/dependency.c
+++ b/libpkgconf/dependency.c
@@ -2,6 +2,8 @@
  * dependency.c
  * dependency parsing and management
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2011, 2012, 2013 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/fileio.c
+++ b/libpkgconf/fileio.c
@@ -2,6 +2,8 @@
  * fileio.c
  * File reading utilities
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2012, 2025 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/fragment.c
+++ b/libpkgconf/fragment.c
@@ -2,6 +2,8 @@
  * fragment.c
  * Management of fragment lists.
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2012, 2013, 2014 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/iter.h
+++ b/libpkgconf/iter.h
@@ -2,6 +2,8 @@
  * iter.h
  * Linked lists and iterators.
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2013 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -2,6 +2,8 @@
  * libpkgconf.h
  * Global include file for everything in libpkgconf.
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2011, 2015 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/license.c
+++ b/libpkgconf/license.c
@@ -2,6 +2,8 @@
  * license.c
  * Evaluate SPDX license expressions
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2026 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/output.c
+++ b/libpkgconf/output.c
@@ -2,6 +2,8 @@
  * output.c
  * I/O abstraction layer
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2025 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/parser.c
+++ b/libpkgconf/parser.c
@@ -2,6 +2,8 @@
  * parser.c
  * rfc822 message parser
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2018, 2025 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/path.c
+++ b/libpkgconf/path.c
@@ -2,6 +2,8 @@
  * path.c
  * filesystem path management
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2016 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/personality.c
+++ b/libpkgconf/personality.c
@@ -2,6 +2,8 @@
  * personality.c
  * libpkgconf cross-compile personality database
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2018 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -2,6 +2,8 @@
  * pkg.c
  * higher-level dependency graph compilation, management and manipulation
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2011, 2012, 2013 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/queue.c
+++ b/libpkgconf/queue.c
@@ -2,6 +2,8 @@
  * queue.c
  * compilation of a list of packages into a world dependency set
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2012 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/stdinc.h
+++ b/libpkgconf/stdinc.h
@@ -2,6 +2,8 @@
  * stdinc.h
  * pull in standard headers (including portability hacks)
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2012 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/tuple.c
+++ b/libpkgconf/tuple.c
@@ -2,6 +2,8 @@
  * tuple.c
  * management of key->value tuples
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2011, 2012 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/variable.c
+++ b/libpkgconf/variable.c
@@ -2,6 +2,8 @@
  * variable.c
  * variable management
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2026 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/version.c
+++ b/libpkgconf/version.c
@@ -2,6 +2,8 @@
  * version.c
  * version comparison
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2011-2026 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/libpkgconf/win-dirent.h
+++ b/libpkgconf/win-dirent.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: MIT
+ *
  * Dirent interface for Microsoft Visual Studio
  *
  * Copyright (C) 1998-2019 Toni Ronkko

--- a/tests/test-runner.c
+++ b/tests/test-runner.c
@@ -2,6 +2,8 @@
  * test-runner.c
  * test harness
  *
+ * SPDX-License-Identifier: pkgconf
+ *
  * Copyright (c) 2025 pkgconf authors (see AUTHORS).
  *
  * Permission to use, copy, modify, and/or distribute this software for any


### PR DESCRIPTION
Add missing SPDX-License-Identifier information to files which makes easier to determine license. Also update CONTRIBUTING.md to contain license information and template for source files header.