### PR TITLE
Fix personality boolean comparison

### DIFF
--- a/libpkgconf/personality.c
+++ b/libpkgconf/personality.c
@@ -177,7 +177,7 @@ personality_bool_func(pkgconf_cross_personality_t *p, const char *keyword, const
 	(void) warnprefix;
 
 	bool *dest = (bool *)((char *) p + offset);
-	*dest = strcasecmp(value, "true") == 0 || strcasecmp(value, "yes") == 0 || *value == '1';
+	*dest = strcasecmp(value, "true") == 0 || strcasecmp(value, "yes") == 0 || strcasecmp(value, "1") == 0;
 }
 
 static void


### PR DESCRIPTION
A simple naïve comparison of the first character for "1" can result in values like "1false" being accepted as true in boolean personality checks. This PR makes it so the value "1" must be present unconditionally.