### PR TITLE
Add API test framework and buffer API tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -260,6 +260,8 @@ EXTRA_DIST =	pkg.m4 \
 		t/tuple/duplicate-upsert.test \
 		t/tuple/empty-tuple.test \
 		tests/test-path-utils.c \
+		tests/api/test-api.h \
+		tests/api/test-buffer.c \
 		tests/lib-relocatable/lib/pkgconfig/foo.pc \
 		tests/lib1/argv-parse-2.pc \
 		tests/lib1/billion-laughs.pc \
@@ -467,7 +469,7 @@ spdxtool_SOURCES  = \
 	cli/getopt_long.c
 spdxtool_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/cli -I$(top_srcdir)/cli/spdxtool
 
-noinst_PROGRAMS = test-runner test-path-utils
+noinst_PROGRAMS = test-runner test-path-utils test-api-buffer
 test_runner_LDADD = libpkgconf.la
 test_runner_SOURCES = \
 	cli/core.c \
@@ -479,6 +481,10 @@ test_path_utils_LDADD = libpkgconf.la
 test_path_utils_SOURCES = tests/test-path-utils.c
 test_path_utils_CPPFLAGS = -I$(top_srcdir)/libpkgconf
 
+test_api_buffer_LDADD = libpkgconf.la
+test_api_buffer_SOURCES = tests/api/test-buffer.c
+test_api_buffer_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/tests/api
+
 dist_doc_DATA = CONTRIBUTING.md DCO README.md AUTHORS
 
 m4datadir              = $(datadir)/aclocal
@@ -486,8 +492,9 @@ m4data_DATA            = pkg.m4
 
 CLEANFILES =	$(EXTRA_PROGRAMS)
 
-check: pkgconf test-runner test-path-utils
+check: pkgconf test-runner test-path-utils test-api-buffer
 	$(builddir)/test-path-utils$(EXEEXT)
+	$(builddir)/test-api-buffer$(EXEEXT)
 	$(builddir)/test-runner$(EXEEXT) --test-fixtures=$(top_srcdir)/tests --tool-dir="$(PWD)" $(top_srcdir)/t/basic
 	$(builddir)/test-runner$(EXEEXT) --test-fixtures=$(top_srcdir)/tests --tool-dir="$(PWD)" $(top_srcdir)/t/ordering
 	$(builddir)/test-runner$(EXEEXT) --test-fixtures=$(top_srcdir)/tests --tool-dir="$(PWD)" $(top_srcdir)/t/parser

--- a/libpkgconf/buffer.c
+++ b/libpkgconf/buffer.c
@@ -242,7 +242,11 @@ pkgconf_buffer_push_byte(pkgconf_buffer_t *buffer, char byte)
 bool
 pkgconf_buffer_trim_byte(pkgconf_buffer_t *buffer)
 {
-	size_t newsize = pkgconf_buffer_len(buffer) - 1;
+	size_t len = pkgconf_buffer_len(buffer);
+	if (len == 0)
+		return false;
+
+	size_t newsize = len - 1;
 	char *newbase = realloc(buffer->base, target_allocation_size(newsize));
 
 	if (newbase == NULL)

--- a/meson.build
+++ b/meson.build
@@ -224,6 +224,20 @@ test_path_utils_exe = executable('test-path-utils',
 
 test('path-utils', test_path_utils_exe)
 
+api_tests = [
+  'buffer',
+]
+
+foreach t : api_tests
+  exe = executable('test-api-' + t,
+    'tests/api/test-' + t + '.c',
+    link_with : libpkgconf,
+    c_args : build_static,
+    include_directories : [include_directories('.'), include_directories('tests/api')],
+    install : false)
+  test('api-' + t, exe)
+endforeach
+
 fixtures_dir = join_paths(meson.current_source_dir(), 'tests')
 tool_dir = meson.current_build_dir()
 

--- a/tests/api/test-api.h
+++ b/tests/api/test-api.h
@@ -18,10 +18,11 @@
 #ifndef TEST_API_H
 #define TEST_API_H
 
+#include <libpkgconf/stdinc.h>
+#include <libpkgconf/libpkgconf.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 
 #define TEST_FAIL_(fmt, ...)	\
 	do {	\

--- a/tests/api/test-api.h
+++ b/tests/api/test-api.h
@@ -1,0 +1,135 @@
+/*
+ * test-api.h
+ * test API macros and functions.
+ *
+ * SPDX-License-Identifier: pkgconf
+ *
+ * Copyright (c) 2026 pkgconf authors (see AUTHORS).
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * This software is provided 'as is' and without any warranty, express or
+ * implied.  In no event shall the authors be liable for any damages arising
+ * from the use of this software.
+ */
+
+#ifndef TEST_API_H
+#define TEST_API_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+#define TEST_FAIL_(fmt, ...)	\
+	do {	\
+		fprintf(stderr, "FAIL: %s:%d: " fmt "\n",	\
+			__FILE__, __LINE__, __VA_ARGS__);	\
+		exit(EXIT_FAILURE);	\
+	} while (0)
+
+#define TEST_ASSERT_TRUE(expr)	\
+	do {	\
+		if (!(expr))	\
+			TEST_FAIL_("TEST_ASSERT_TRUE(%s) was false", #expr);	\
+	} while (0)
+
+#define TEST_ASSERT_FALSE(expr)	\
+	do {	\
+		if ((expr))	\
+			TEST_FAIL_("TEST_ASSERT_FALSE(%s) was true", #expr);	\
+	} while (0)
+
+#define TEST_ASSERT_NULL(expr)	\
+	do {	\
+		const void *_v = (const void *)(expr);	\
+		if (_v != NULL)	\
+			TEST_FAIL_("TEST_ASSERT_NULL(%s) was %p", #expr, _v);	\
+	} while (0)
+
+#define TEST_ASSERT_NONNULL(expr)	\
+	do {	\
+		if ((expr) == NULL)	\
+			TEST_FAIL_("TEST_ASSERT_NONNULL(%s) was NULL", #expr);	\
+	} while (0)
+
+#define TEST_EQ(a, b)	\
+	do {	\
+		long long _a = (long long)(a);	\
+		long long _b = (long long)(b);	\
+		if (_a != _b)	\
+			TEST_FAIL_("TEST_EQ(%s, %s): %lld != %lld",	\
+				#a, #b, _a, _b);	\
+	} while (0)
+
+#define TEST_NE(a, b)	\
+	do {	\
+		long long _a = (long long)(a);	\
+		long long _b = (long long)(b);	\
+		if (_a == _b)	\
+			TEST_FAIL_("TEST_NE(%s, %s): both %lld",	\
+				#a, #b, _a);	\
+	} while (0)
+
+#define TEST_STRCMP(actual, expected)	\
+	do {	\
+		const char *_a = (actual);	\
+		const char *_e = (expected);	\
+		if (_a == NULL || _e == NULL || strcmp(_a, _e) != 0)	\
+			TEST_FAIL_("TEST_STRCMP(%s, %s): [%s] != [%s]",	\
+				#actual, #expected,	\
+				_a ? _a : "(null)", _e ? _e : "(null)");	\
+	} while (0)
+
+#define TEST_STRCASECMP(actual, expected)	\
+	do {	\
+		const char *_a = (actual);	\
+		const char *_e = (expected);	\
+		if (_a == NULL || _e == NULL || strcasecmp(_a, _e) != 0)	\
+			TEST_FAIL_("TEST_STRCASECMP(%s, %s): [%s] !~ [%s]",	\
+				#actual, #expected,	\
+				_a ? _a : "(null)", _e ? _e : "(null)");	\
+	} while (0)
+
+#define TEST_STRNCMP(actual, expected, n)	\
+	do {	\
+		const char *_a = (actual);	\
+		const char *_e = (expected);	\
+		size_t _n = (size_t)(n);	\
+		if (_a == NULL || _e == NULL || strncmp(_a, _e, _n) != 0)	\
+			TEST_FAIL_("TEST_STRNCMP(%s, %s, %zu): [%s] != [%s]",	\
+				#actual, #expected, _n,	\
+				_a ? _a : "(null)", _e ? _e : "(null)");	\
+	} while (0)
+
+#define TEST_RUN(name, fn)	\
+	do {	\
+		fprintf(stderr, "%s -> %s:", name, #fn);	\
+		fn();	\
+		fprintf(stderr, " PASS\n");	\
+	} while (0)
+
+static inline const char *
+test_progname(const char *argv0)
+{
+	const char *p;
+
+	if (argv0 == NULL || *argv0 == '\0')
+		return "test";
+
+	p = strrchr(argv0, '/');
+	if (p != NULL)
+		argv0 = p + 1;
+
+#ifdef _WIN32
+	p = strrchr(argv0, '\\');
+	if (p != NULL)
+		argv0 = p + 1;
+#endif
+
+	return argv0;
+}
+
+#endif // TEST_API_H

--- a/tests/api/test-buffer.c
+++ b/tests/api/test-buffer.c
@@ -1,0 +1,329 @@
+/*
+ * test-buffer.c
+ * Tests for libpkgconf buffer API.
+ *
+ * SPDX-License-Identifier: pkgconf
+ *
+ * Copyright (c) 2025 pkgconf authors (see AUTHORS).
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * This software is provided 'as is' and without any warranty, express or
+ * implied.  In no event shall the authors be liable for any damages arising
+ * from the use of this software.
+ */
+
+#include <libpkgconf/stdinc.h>
+#include <libpkgconf/libpkgconf.h>
+#include "test-api.h"
+
+static void
+test_buffer_empty(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+
+	TEST_EQ(pkgconf_buffer_len(&buf), 0);
+	TEST_ASSERT_NULL(pkgconf_buffer_str(&buf));
+	TEST_STRCMP(pkgconf_buffer_str_or_empty(&buf), "");
+	TEST_EQ(pkgconf_buffer_lastc(&buf), '\0');
+
+	pkgconf_buffer_finalize(&buf);
+}
+
+static void
+test_buffer_append(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+
+	TEST_ASSERT_TRUE(pkgconf_buffer_append(&buf, "hello"));
+	TEST_STRCMP(pkgconf_buffer_str(&buf), "hello");
+	TEST_EQ(pkgconf_buffer_len(&buf), 5);
+
+	TEST_ASSERT_TRUE(pkgconf_buffer_append(&buf, " world"));
+	TEST_STRCMP(pkgconf_buffer_str(&buf), "hello world");
+	TEST_EQ(pkgconf_buffer_len(&buf), 11);
+
+	TEST_EQ(pkgconf_buffer_lastc(&buf), 'd');
+
+	pkgconf_buffer_finalize(&buf);
+}
+
+static void
+test_buffer_append_slice(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+
+	TEST_ASSERT_TRUE(pkgconf_buffer_append_slice(&buf, "abcdefgh", 3));
+	TEST_STRCMP(pkgconf_buffer_str(&buf), "abc");
+
+	TEST_ASSERT_TRUE(pkgconf_buffer_append_slice(&buf, "xyz", 0));
+	TEST_STRCMP(pkgconf_buffer_str(&buf), "abc");
+
+	pkgconf_buffer_finalize(&buf);
+}
+
+static void
+test_buffer_append_fmt(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+
+	TEST_ASSERT_TRUE(pkgconf_buffer_append_fmt(&buf, "%s=%d", "x", 42));
+	TEST_STRCMP(pkgconf_buffer_str(&buf), "x=42");
+
+	TEST_ASSERT_TRUE(pkgconf_buffer_append_fmt(&buf, " %s", "ok"));
+	TEST_STRCMP(pkgconf_buffer_str(&buf), "x=42 ok");
+
+	pkgconf_buffer_finalize(&buf);
+}
+
+static void
+test_buffer_prepend(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+
+	pkgconf_buffer_append(&buf, "world");
+	TEST_ASSERT_TRUE(pkgconf_buffer_prepend(&buf, "hello "));
+	TEST_STRCMP(pkgconf_buffer_str(&buf), "hello world");
+
+	pkgconf_buffer_finalize(&buf);
+}
+
+static void
+test_buffer_push_byte(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+
+	TEST_ASSERT_TRUE(pkgconf_buffer_push_byte(&buf, 'a'));
+	TEST_ASSERT_TRUE(pkgconf_buffer_push_byte(&buf, 'b'));
+	TEST_ASSERT_TRUE(pkgconf_buffer_push_byte(&buf, 'c'));
+	TEST_STRCMP(pkgconf_buffer_str(&buf), "abc");
+	TEST_EQ(pkgconf_buffer_len(&buf), 3);
+
+	pkgconf_buffer_finalize(&buf);
+}
+
+static void
+test_buffer_trim_byte(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+
+	pkgconf_buffer_append(&buf, "hello\n");
+	TEST_ASSERT_TRUE(pkgconf_buffer_trim_byte(&buf));
+	TEST_STRCMP(pkgconf_buffer_str(&buf), "hello");
+
+	pkgconf_buffer_reset(&buf);
+	pkgconf_buffer_push_byte(&buf, 'x');
+	TEST_ASSERT_TRUE(pkgconf_buffer_trim_byte(&buf));
+	TEST_EQ(pkgconf_buffer_len(&buf), 0);
+	TEST_ASSERT_TRUE(pkgconf_buffer_trim_byte(&buf));
+
+	pkgconf_buffer_finalize(&buf);
+}
+
+static void
+test_buffer_reset(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+
+	pkgconf_buffer_append(&buf, "some content");
+	TEST_NE(pkgconf_buffer_len(&buf), 0);
+
+	pkgconf_buffer_reset(&buf);
+	TEST_EQ(pkgconf_buffer_len(&buf), 0);
+	TEST_ASSERT_NULL(pkgconf_buffer_str(&buf));
+
+	TEST_ASSERT_TRUE(pkgconf_buffer_append(&buf, "fresh"));
+	TEST_STRCMP(pkgconf_buffer_str(&buf), "fresh");
+
+	pkgconf_buffer_finalize(&buf);
+}
+
+static void
+test_buffer_freeze(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+
+	pkgconf_buffer_append(&buf, "frozen");
+	char *out = pkgconf_buffer_freeze(&buf);
+	TEST_ASSERT_NONNULL(out);
+	TEST_STRCMP(out, "frozen");
+	TEST_EQ(pkgconf_buffer_len(&buf), 0);
+
+	TEST_ASSERT_NULL(pkgconf_buffer_freeze(&buf));
+
+	free(out);
+	pkgconf_buffer_finalize(&buf);
+}
+
+static void
+test_buffer_copy(void)
+{
+	pkgconf_buffer_t src = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_buffer_t dst = PKGCONF_BUFFER_INITIALIZER;
+
+	pkgconf_buffer_append(&src, "original");
+	pkgconf_buffer_append(&dst, "to be replaced");
+	TEST_ASSERT_TRUE(pkgconf_buffer_copy(&src, &dst));
+	TEST_STRCMP(pkgconf_buffer_str(&dst), "original");
+	TEST_STRCMP(pkgconf_buffer_str(&src), "original"); // src is unchanged
+
+	pkgconf_buffer_finalize(&src);
+	pkgconf_buffer_finalize(&dst);
+}
+
+static void
+test_buffer_join(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+
+	TEST_ASSERT_TRUE(pkgconf_buffer_join(&buf, '/', "usr", "local", "lib", NULL));
+	TEST_STRCMP(pkgconf_buffer_str(&buf), "usr/local/lib");
+
+	pkgconf_buffer_finalize(&buf);
+}
+
+static void
+test_buffer_contains(void)
+{
+	pkgconf_buffer_t hay = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_buffer_t needle = PKGCONF_BUFFER_INITIALIZER;
+
+	pkgconf_buffer_append(&hay, "the quick brown fox");
+
+	pkgconf_buffer_append(&needle, "quick");
+	TEST_ASSERT_TRUE(pkgconf_buffer_contains(&hay, &needle));
+
+	pkgconf_buffer_reset(&needle);
+	pkgconf_buffer_append(&needle, "slow");
+	TEST_ASSERT_FALSE(pkgconf_buffer_contains(&hay, &needle));
+
+	TEST_ASSERT_TRUE(pkgconf_buffer_contains_byte(&hay, 'q'));
+	TEST_ASSERT_FALSE(pkgconf_buffer_contains_byte(&hay, 'z'));
+
+	pkgconf_buffer_finalize(&hay);
+	pkgconf_buffer_finalize(&needle);
+}
+
+static void
+test_buffer_match(void)
+{
+	pkgconf_buffer_t a = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_buffer_t b = PKGCONF_BUFFER_INITIALIZER;
+
+	pkgconf_buffer_append(&a, "identical");
+	pkgconf_buffer_append(&b, "identical");
+	TEST_ASSERT_TRUE(pkgconf_buffer_match(&a, &b));
+
+	pkgconf_buffer_reset(&b);
+	pkgconf_buffer_append(&b, "different");
+	TEST_ASSERT_FALSE(pkgconf_buffer_match(&a, &b));
+
+	pkgconf_buffer_finalize(&a);
+	pkgconf_buffer_finalize(&b);
+}
+
+static void
+test_buffer_has_prefix(void)
+{
+	pkgconf_buffer_t hay = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_buffer_t pre = PKGCONF_BUFFER_INITIALIZER;
+
+	pkgconf_buffer_append(&hay, "/usr/local/lib");
+
+	pkgconf_buffer_append(&pre, "/usr");
+	TEST_ASSERT_TRUE(pkgconf_buffer_has_prefix(&hay, &pre));
+
+	pkgconf_buffer_reset(&pre);
+	pkgconf_buffer_append(&pre, "/opt");
+	TEST_ASSERT_FALSE(pkgconf_buffer_has_prefix(&hay, &pre));
+
+	pkgconf_buffer_finalize(&hay);
+	pkgconf_buffer_finalize(&pre);
+}
+
+static void
+test_buffer_subst(void)
+{
+	pkgconf_buffer_t src = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_buffer_t dst = PKGCONF_BUFFER_INITIALIZER;
+
+	pkgconf_buffer_append(&src, "prefix=${PREFIX}/share");
+	TEST_ASSERT_TRUE(pkgconf_buffer_subst(&dst, &src, "${PREFIX}", "/opt/foo"));
+	TEST_STRCMP(pkgconf_buffer_str(&dst), "prefix=/opt/foo/share");
+
+	pkgconf_buffer_finalize(&src);
+	pkgconf_buffer_finalize(&dst);
+}
+
+static void
+test_buffer_escape(void)
+{
+	pkgconf_buffer_t src = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_buffer_t dst = PKGCONF_BUFFER_INITIALIZER;
+
+	pkgconf_span_t spans[] = {
+		{ ' ', ' ' },
+		{ '\t', '\t' },
+	};
+
+	pkgconf_buffer_append(&src, "a b\tc");
+	TEST_ASSERT_TRUE(pkgconf_buffer_escape(&dst, &src, spans, PKGCONF_ARRAY_SIZE(spans)));
+	TEST_STRCMP(pkgconf_buffer_str(&dst), "a\\ b\\\tc");
+
+	pkgconf_buffer_finalize(&src);
+	pkgconf_buffer_finalize(&dst);
+}
+
+static void
+test_str_eq_slice(void)
+{
+	TEST_ASSERT_TRUE(pkgconf_str_eq_slice("hello", "hello", 5));
+	TEST_ASSERT_FALSE(pkgconf_str_eq_slice("hello!", "hello", 5));
+	TEST_ASSERT_FALSE(pkgconf_str_eq_slice("hello", "world", 5));
+	TEST_ASSERT_FALSE(pkgconf_str_eq_slice(NULL, "hello", 5));
+}
+
+static void
+test_span_contains(void)
+{
+	pkgconf_span_t spans[] = {
+		{ '0', '9' },
+		{ 'a', 'z' },
+	};
+
+	TEST_ASSERT_TRUE(pkgconf_span_contains('5', spans, PKGCONF_ARRAY_SIZE(spans)));
+	TEST_ASSERT_TRUE(pkgconf_span_contains('m', spans, PKGCONF_ARRAY_SIZE(spans)));
+	TEST_ASSERT_FALSE(pkgconf_span_contains('A', spans, PKGCONF_ARRAY_SIZE(spans)));
+	TEST_ASSERT_FALSE(pkgconf_span_contains('!', spans, PKGCONF_ARRAY_SIZE(spans)));
+}
+
+int
+main(int argc, const char **argv)
+{
+	(void) argc;
+
+	const char *basename = test_progname(argv[0]);
+
+	TEST_RUN(basename, test_buffer_empty);
+	TEST_RUN(basename, test_buffer_append);
+	TEST_RUN(basename, test_buffer_append_slice);
+	TEST_RUN(basename, test_buffer_append_fmt);
+	TEST_RUN(basename, test_buffer_prepend);
+	TEST_RUN(basename, test_buffer_push_byte);
+	TEST_RUN(basename, test_buffer_trim_byte);
+	TEST_RUN(basename, test_buffer_reset);
+	TEST_RUN(basename, test_buffer_freeze);
+	TEST_RUN(basename, test_buffer_copy);
+	TEST_RUN(basename, test_buffer_join);
+	TEST_RUN(basename, test_buffer_contains);
+	TEST_RUN(basename, test_buffer_match);
+	TEST_RUN(basename, test_buffer_has_prefix);
+	TEST_RUN(basename, test_buffer_subst);
+	TEST_RUN(basename, test_buffer_escape);
+	TEST_RUN(basename, test_str_eq_slice);
+	TEST_RUN(basename, test_span_contains);
+
+	return 0;
+}

--- a/tests/api/test-buffer.c
+++ b/tests/api/test-buffer.c
@@ -117,7 +117,7 @@ test_buffer_trim_byte(void)
 	pkgconf_buffer_push_byte(&buf, 'x');
 	TEST_ASSERT_TRUE(pkgconf_buffer_trim_byte(&buf));
 	TEST_EQ(pkgconf_buffer_len(&buf), 0);
-	TEST_ASSERT_TRUE(pkgconf_buffer_trim_byte(&buf));
+	TEST_ASSERT_FALSE(pkgconf_buffer_trim_byte(&buf));
 
 	pkgconf_buffer_finalize(&buf);
 }


### PR DESCRIPTION
This adds a simple "framework" for tests (just some macros and a simple function) and some basic tests with the buffer API to demonstrate. More tests will come, this is just a demonstration.

This PR also fixes a bug where `pkgconf_buffer_trim_byte()` would underflow on an empty string.

Reference #488.