### PR TITLE
Introduce bytecode + variable + tuple libpkgconf API tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -263,6 +263,7 @@ EXTRA_DIST =	pkg.m4 \
 		tests/api/test-api.h \
 		tests/api/test-buffer.c \
 		tests/api/test-bytecode.c \
+		tests/api/test-tuple.c \
 		tests/api/test-variable.c \
 		tests/lib-relocatable/lib/pkgconfig/foo.pc \
 		tests/lib1/argv-parse-2.pc \
@@ -471,7 +472,13 @@ spdxtool_SOURCES  = \
 	cli/getopt_long.c
 spdxtool_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/cli -I$(top_srcdir)/cli/spdxtool
 
-noinst_PROGRAMS = test-runner test-path-utils test-api-buffer test-api-bytecode test-api-variable
+noinst_PROGRAMS =		\
+	test-runner		\
+	test-path-utils		\
+	test-api-buffer		\
+	test-api-bytecode	\
+	test-api-tuple		\
+	test-api-variable
 test_runner_LDADD = libpkgconf.la
 test_runner_SOURCES = \
 	cli/core.c \
@@ -488,11 +495,15 @@ test_api_buffer_SOURCES = tests/api/test-buffer.c
 test_api_buffer_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/tests/api
 
 test_api_bytecode_LDADD = libpkgconf.la
-test_api_bytecode_SOURCES = tests/api/test-buffer.c
+test_api_bytecode_SOURCES = tests/api/test-bytecode.c
 test_api_bytecode_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/tests/api
 
+test_api_tuple_LDADD = libpkgconf.la
+test_api_tuple_SOURCES = tests/api/test-tuple.c
+test_api_tuple_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/tests/api
+
 test_api_variable_LDADD = libpkgconf.la
-test_api_variable_SOURCES = tests/api/test-buffer.c
+test_api_variable_SOURCES = tests/api/test-variable.c
 test_api_variable_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/tests/api
 
 dist_doc_DATA = CONTRIBUTING.md DCO README.md AUTHORS
@@ -502,10 +513,11 @@ m4data_DATA            = pkg.m4
 
 CLEANFILES =	$(EXTRA_PROGRAMS)
 
-check: pkgconf test-runner test-path-utils test-api-buffer test-api-bytecode test-api-variable
+check: pkgconf test-runner test-path-utils test-api-buffer test-api-bytecode test-api-tuple test-api-variable
 	$(builddir)/test-path-utils$(EXEEXT)
 	$(builddir)/test-api-buffer$(EXEEXT)
 	$(builddir)/test-api-bytecode$(EXEEXT)
+	$(builddir)/test-api-tuple$(EXEEXT)
 	$(builddir)/test-runner$(EXEEXT) --test-fixtures=$(top_srcdir)/tests --tool-dir="$(PWD)" $(top_srcdir)/t/basic
 	$(builddir)/test-runner$(EXEEXT) --test-fixtures=$(top_srcdir)/tests --tool-dir="$(PWD)" $(top_srcdir)/t/ordering
 	$(builddir)/test-runner$(EXEEXT) --test-fixtures=$(top_srcdir)/tests --tool-dir="$(PWD)" $(top_srcdir)/t/parser

--- a/Makefile.am
+++ b/Makefile.am
@@ -262,6 +262,7 @@ EXTRA_DIST =	pkg.m4 \
 		tests/test-path-utils.c \
 		tests/api/test-api.h \
 		tests/api/test-buffer.c \
+		tests/api/test-bytecode.c \
 		tests/lib-relocatable/lib/pkgconfig/foo.pc \
 		tests/lib1/argv-parse-2.pc \
 		tests/lib1/billion-laughs.pc \
@@ -469,7 +470,7 @@ spdxtool_SOURCES  = \
 	cli/getopt_long.c
 spdxtool_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/cli -I$(top_srcdir)/cli/spdxtool
 
-noinst_PROGRAMS = test-runner test-path-utils test-api-buffer
+noinst_PROGRAMS = test-runner test-path-utils test-api-buffer test-api-bytecode
 test_runner_LDADD = libpkgconf.la
 test_runner_SOURCES = \
 	cli/core.c \
@@ -485,6 +486,10 @@ test_api_buffer_LDADD = libpkgconf.la
 test_api_buffer_SOURCES = tests/api/test-buffer.c
 test_api_buffer_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/tests/api
 
+test_api_bytecode_LDADD = libpkgconf.la
+test_api_bytecode_SOURCES = tests/api/test-buffer.c
+test_api_bytecode_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/tests/api
+
 dist_doc_DATA = CONTRIBUTING.md DCO README.md AUTHORS
 
 m4datadir              = $(datadir)/aclocal
@@ -492,9 +497,10 @@ m4data_DATA            = pkg.m4
 
 CLEANFILES =	$(EXTRA_PROGRAMS)
 
-check: pkgconf test-runner test-path-utils test-api-buffer
+check: pkgconf test-runner test-path-utils test-api-buffer test-api-bytecode
 	$(builddir)/test-path-utils$(EXEEXT)
 	$(builddir)/test-api-buffer$(EXEEXT)
+	$(builddir)/test-api-bytecode$(EXEEXT)
 	$(builddir)/test-runner$(EXEEXT) --test-fixtures=$(top_srcdir)/tests --tool-dir="$(PWD)" $(top_srcdir)/t/basic
 	$(builddir)/test-runner$(EXEEXT) --test-fixtures=$(top_srcdir)/tests --tool-dir="$(PWD)" $(top_srcdir)/t/ordering
 	$(builddir)/test-runner$(EXEEXT) --test-fixtures=$(top_srcdir)/tests --tool-dir="$(PWD)" $(top_srcdir)/t/parser

--- a/Makefile.am
+++ b/Makefile.am
@@ -263,6 +263,7 @@ EXTRA_DIST =	pkg.m4 \
 		tests/api/test-api.h \
 		tests/api/test-buffer.c \
 		tests/api/test-bytecode.c \
+		tests/api/test-variable.c \
 		tests/lib-relocatable/lib/pkgconfig/foo.pc \
 		tests/lib1/argv-parse-2.pc \
 		tests/lib1/billion-laughs.pc \
@@ -470,7 +471,7 @@ spdxtool_SOURCES  = \
 	cli/getopt_long.c
 spdxtool_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/cli -I$(top_srcdir)/cli/spdxtool
 
-noinst_PROGRAMS = test-runner test-path-utils test-api-buffer test-api-bytecode
+noinst_PROGRAMS = test-runner test-path-utils test-api-buffer test-api-bytecode test-api-variable
 test_runner_LDADD = libpkgconf.la
 test_runner_SOURCES = \
 	cli/core.c \
@@ -490,6 +491,10 @@ test_api_bytecode_LDADD = libpkgconf.la
 test_api_bytecode_SOURCES = tests/api/test-buffer.c
 test_api_bytecode_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/tests/api
 
+test_api_variable_LDADD = libpkgconf.la
+test_api_variable_SOURCES = tests/api/test-buffer.c
+test_api_variable_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/tests/api
+
 dist_doc_DATA = CONTRIBUTING.md DCO README.md AUTHORS
 
 m4datadir              = $(datadir)/aclocal
@@ -497,7 +502,7 @@ m4data_DATA            = pkg.m4
 
 CLEANFILES =	$(EXTRA_PROGRAMS)
 
-check: pkgconf test-runner test-path-utils test-api-buffer test-api-bytecode
+check: pkgconf test-runner test-path-utils test-api-buffer test-api-bytecode test-api-variable
 	$(builddir)/test-path-utils$(EXEEXT)
 	$(builddir)/test-api-buffer$(EXEEXT)
 	$(builddir)/test-api-bytecode$(EXEEXT)

--- a/Makefile.am
+++ b/Makefile.am
@@ -518,6 +518,7 @@ check: pkgconf test-runner test-path-utils test-api-buffer test-api-bytecode tes
 	$(builddir)/test-api-buffer$(EXEEXT)
 	$(builddir)/test-api-bytecode$(EXEEXT)
 	$(builddir)/test-api-tuple$(EXEEXT)
+	$(builddir)/test-api-variable$(EXEEXT)
 	$(builddir)/test-runner$(EXEEXT) --test-fixtures=$(top_srcdir)/tests --tool-dir="$(PWD)" $(top_srcdir)/t/basic
 	$(builddir)/test-runner$(EXEEXT) --test-fixtures=$(top_srcdir)/tests --tool-dir="$(PWD)" $(top_srcdir)/t/ordering
 	$(builddir)/test-runner$(EXEEXT) --test-fixtures=$(top_srcdir)/tests --tool-dir="$(PWD)" $(top_srcdir)/t/parser

--- a/meson.build
+++ b/meson.build
@@ -226,6 +226,7 @@ test('path-utils', test_path_utils_exe)
 
 api_tests = [
   'buffer',
+  'bytecode',
 ]
 
 foreach t : api_tests

--- a/meson.build
+++ b/meson.build
@@ -227,6 +227,7 @@ test('path-utils', test_path_utils_exe)
 api_tests = [
   'buffer',
   'bytecode',
+  'variable',
 ]
 
 foreach t : api_tests

--- a/meson.build
+++ b/meson.build
@@ -227,6 +227,7 @@ test('path-utils', test_path_utils_exe)
 api_tests = [
   'buffer',
   'bytecode',
+  'tuple',
   'variable',
 ]
 

--- a/tests/api/test-api.h
+++ b/tests/api/test-api.h
@@ -56,53 +56,62 @@
 			TEST_FAIL_("TEST_ASSERT_NONNULL(%s) was NULL", #expr);	\
 	} while (0)
 
-#define TEST_EQ(a, b)	\
+#define TEST_ASSERT_EQ(a, b)	\
 	do {	\
 		long long _a = (long long)(a);	\
 		long long _b = (long long)(b);	\
 		if (_a != _b)	\
-			TEST_FAIL_("TEST_EQ(%s, %s): %lld != %lld",	\
+			TEST_FAIL_("TEST_ASSERT_EQ(%s, %s): %lld != %lld",	\
 				#a, #b, _a, _b);	\
 	} while (0)
 
-#define TEST_NE(a, b)	\
+#define TEST_ASSERT_NE(a, b)	\
 	do {	\
 		long long _a = (long long)(a);	\
 		long long _b = (long long)(b);	\
 		if (_a == _b)	\
-			TEST_FAIL_("TEST_NE(%s, %s): both %lld",	\
+			TEST_FAIL_("TEST_ASSERT_NE(%s, %s): both %lld",	\
 				#a, #b, _a);	\
 	} while (0)
 
-#define TEST_STRCMP(actual, expected)	\
+#define TEST_ASSERT_STRCMP_EQ(actual, expected)	\
 	do {	\
 		const char *_a = (actual);	\
 		const char *_e = (expected);	\
 		if (_a == NULL || _e == NULL || strcmp(_a, _e) != 0)	\
-			TEST_FAIL_("TEST_STRCMP(%s, %s): [%s] != [%s]",	\
+			TEST_FAIL_("TEST_ASSERT_STRCMP_EQ(%s, %s): [%s] != [%s]",	\
 				#actual, #expected,	\
 				_a ? _a : "(null)", _e ? _e : "(null)");	\
 	} while (0)
 
-#define TEST_STRCASECMP(actual, expected)	\
+#define TEST_ASSERT_STRCASECMP_EQ(actual, expected)	\
 	do {	\
 		const char *_a = (actual);	\
 		const char *_e = (expected);	\
 		if (_a == NULL || _e == NULL || strcasecmp(_a, _e) != 0)	\
-			TEST_FAIL_("TEST_STRCASECMP(%s, %s): [%s] !~ [%s]",	\
+			TEST_FAIL_("TEST_ASSERT_STRCASECMP_EQ(%s, %s): [%s] !~ [%s]",	\
 				#actual, #expected,	\
 				_a ? _a : "(null)", _e ? _e : "(null)");	\
 	} while (0)
 
-#define TEST_STRNCMP(actual, expected, n)	\
+#define TEST_ASSERT_STRNCMP_EQ(actual, expected, n)	\
 	do {	\
 		const char *_a = (actual);	\
 		const char *_e = (expected);	\
 		size_t _n = (size_t)(n);	\
 		if (_a == NULL || _e == NULL || strncmp(_a, _e, _n) != 0)	\
-			TEST_FAIL_("TEST_STRNCMP(%s, %s, %zu): [%s] != [%s]",	\
+			TEST_FAIL_("TEST_ASSERT_STRNCMP_EQ(%s, %s, %zu): [%s] != [%s]",	\
 				#actual, #expected, _n,	\
 				_a ? _a : "(null)", _e ? _e : "(null)");	\
+	} while (0)
+
+#define TEST_ASSERT_EMPTY_STRING(expr)	\
+	do {	\
+		const char *_s = (expr);	\
+		if (_s == NULL)	\
+			TEST_FAIL_("TEST_ASSERT_EMPTY_STRING(%s) was NULL", #expr);	\
+		if (_s[0] != '\0')	\
+			TEST_FAIL_("TEST_ASSERT_EMPTY_STRING(%s) was [%s]", #expr, _s);	\
 	} while (0)
 
 #define TEST_RUN(name, fn)	\

--- a/tests/api/test-api.h
+++ b/tests/api/test-api.h
@@ -133,4 +133,11 @@ test_progname(const char *argv0)
 	return argv0;
 }
 
+static inline pkgconf_client_t *
+test_client_new(void)
+{
+	pkgconf_cross_personality_t *pers = pkgconf_cross_personality_default();
+	return pkgconf_client_new(NULL, NULL, pers, NULL, NULL);
+}
+
 #endif // TEST_API_H

--- a/tests/api/test-buffer.c
+++ b/tests/api/test-buffer.c
@@ -325,5 +325,5 @@ main(int argc, const char **argv)
 	TEST_RUN(basename, test_str_eq_slice);
 	TEST_RUN(basename, test_span_contains);
 
-	return 0;
+	return EXIT_SUCCESS;
 }

--- a/tests/api/test-buffer.c
+++ b/tests/api/test-buffer.c
@@ -24,10 +24,10 @@ test_buffer_empty(void)
 {
 	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
 
-	TEST_EQ(pkgconf_buffer_len(&buf), 0);
+	TEST_ASSERT_EQ(pkgconf_buffer_len(&buf), 0);
 	TEST_ASSERT_NULL(pkgconf_buffer_str(&buf));
-	TEST_STRCMP(pkgconf_buffer_str_or_empty(&buf), "");
-	TEST_EQ(pkgconf_buffer_lastc(&buf), '\0');
+	TEST_ASSERT_EMPTY_STRING(pkgconf_buffer_str_or_empty(&buf));
+	TEST_ASSERT_EQ(pkgconf_buffer_lastc(&buf), '\0');
 
 	pkgconf_buffer_finalize(&buf);
 }
@@ -38,14 +38,14 @@ test_buffer_append(void)
 	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
 
 	TEST_ASSERT_TRUE(pkgconf_buffer_append(&buf, "hello"));
-	TEST_STRCMP(pkgconf_buffer_str(&buf), "hello");
-	TEST_EQ(pkgconf_buffer_len(&buf), 5);
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "hello");
+	TEST_ASSERT_EQ(pkgconf_buffer_len(&buf), 5);
 
 	TEST_ASSERT_TRUE(pkgconf_buffer_append(&buf, " world"));
-	TEST_STRCMP(pkgconf_buffer_str(&buf), "hello world");
-	TEST_EQ(pkgconf_buffer_len(&buf), 11);
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "hello world");
+	TEST_ASSERT_EQ(pkgconf_buffer_len(&buf), 11);
 
-	TEST_EQ(pkgconf_buffer_lastc(&buf), 'd');
+	TEST_ASSERT_EQ(pkgconf_buffer_lastc(&buf), 'd');
 
 	pkgconf_buffer_finalize(&buf);
 }
@@ -56,10 +56,10 @@ test_buffer_append_slice(void)
 	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
 
 	TEST_ASSERT_TRUE(pkgconf_buffer_append_slice(&buf, "abcdefgh", 3));
-	TEST_STRCMP(pkgconf_buffer_str(&buf), "abc");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "abc");
 
 	TEST_ASSERT_TRUE(pkgconf_buffer_append_slice(&buf, "xyz", 0));
-	TEST_STRCMP(pkgconf_buffer_str(&buf), "abc");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "abc");
 
 	pkgconf_buffer_finalize(&buf);
 }
@@ -70,10 +70,10 @@ test_buffer_append_fmt(void)
 	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
 
 	TEST_ASSERT_TRUE(pkgconf_buffer_append_fmt(&buf, "%s=%d", "x", 42));
-	TEST_STRCMP(pkgconf_buffer_str(&buf), "x=42");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "x=42");
 
 	TEST_ASSERT_TRUE(pkgconf_buffer_append_fmt(&buf, " %s", "ok"));
-	TEST_STRCMP(pkgconf_buffer_str(&buf), "x=42 ok");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "x=42 ok");
 
 	pkgconf_buffer_finalize(&buf);
 }
@@ -85,7 +85,7 @@ test_buffer_prepend(void)
 
 	pkgconf_buffer_append(&buf, "world");
 	TEST_ASSERT_TRUE(pkgconf_buffer_prepend(&buf, "hello "));
-	TEST_STRCMP(pkgconf_buffer_str(&buf), "hello world");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "hello world");
 
 	pkgconf_buffer_finalize(&buf);
 }
@@ -98,8 +98,8 @@ test_buffer_push_byte(void)
 	TEST_ASSERT_TRUE(pkgconf_buffer_push_byte(&buf, 'a'));
 	TEST_ASSERT_TRUE(pkgconf_buffer_push_byte(&buf, 'b'));
 	TEST_ASSERT_TRUE(pkgconf_buffer_push_byte(&buf, 'c'));
-	TEST_STRCMP(pkgconf_buffer_str(&buf), "abc");
-	TEST_EQ(pkgconf_buffer_len(&buf), 3);
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "abc");
+	TEST_ASSERT_EQ(pkgconf_buffer_len(&buf), 3);
 
 	pkgconf_buffer_finalize(&buf);
 }
@@ -111,12 +111,12 @@ test_buffer_trim_byte(void)
 
 	pkgconf_buffer_append(&buf, "hello\n");
 	TEST_ASSERT_TRUE(pkgconf_buffer_trim_byte(&buf));
-	TEST_STRCMP(pkgconf_buffer_str(&buf), "hello");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "hello");
 
 	pkgconf_buffer_reset(&buf);
 	pkgconf_buffer_push_byte(&buf, 'x');
 	TEST_ASSERT_TRUE(pkgconf_buffer_trim_byte(&buf));
-	TEST_EQ(pkgconf_buffer_len(&buf), 0);
+	TEST_ASSERT_EQ(pkgconf_buffer_len(&buf), 0);
 	TEST_ASSERT_FALSE(pkgconf_buffer_trim_byte(&buf));
 
 	pkgconf_buffer_finalize(&buf);
@@ -128,14 +128,14 @@ test_buffer_reset(void)
 	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
 
 	pkgconf_buffer_append(&buf, "some content");
-	TEST_NE(pkgconf_buffer_len(&buf), 0);
+	TEST_ASSERT_NE(pkgconf_buffer_len(&buf), 0);
 
 	pkgconf_buffer_reset(&buf);
-	TEST_EQ(pkgconf_buffer_len(&buf), 0);
+	TEST_ASSERT_EQ(pkgconf_buffer_len(&buf), 0);
 	TEST_ASSERT_NULL(pkgconf_buffer_str(&buf));
 
 	TEST_ASSERT_TRUE(pkgconf_buffer_append(&buf, "fresh"));
-	TEST_STRCMP(pkgconf_buffer_str(&buf), "fresh");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "fresh");
 
 	pkgconf_buffer_finalize(&buf);
 }
@@ -148,8 +148,8 @@ test_buffer_freeze(void)
 	pkgconf_buffer_append(&buf, "frozen");
 	char *out = pkgconf_buffer_freeze(&buf);
 	TEST_ASSERT_NONNULL(out);
-	TEST_STRCMP(out, "frozen");
-	TEST_EQ(pkgconf_buffer_len(&buf), 0);
+	TEST_ASSERT_STRCMP_EQ(out, "frozen");
+	TEST_ASSERT_EQ(pkgconf_buffer_len(&buf), 0);
 
 	TEST_ASSERT_NULL(pkgconf_buffer_freeze(&buf));
 
@@ -166,8 +166,8 @@ test_buffer_copy(void)
 	pkgconf_buffer_append(&src, "original");
 	pkgconf_buffer_append(&dst, "to be replaced");
 	TEST_ASSERT_TRUE(pkgconf_buffer_copy(&src, &dst));
-	TEST_STRCMP(pkgconf_buffer_str(&dst), "original");
-	TEST_STRCMP(pkgconf_buffer_str(&src), "original"); // src is unchanged
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&dst), "original");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&src), "original"); // src is unchanged
 
 	pkgconf_buffer_finalize(&src);
 	pkgconf_buffer_finalize(&dst);
@@ -179,7 +179,7 @@ test_buffer_join(void)
 	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
 
 	TEST_ASSERT_TRUE(pkgconf_buffer_join(&buf, '/', "usr", "local", "lib", NULL));
-	TEST_STRCMP(pkgconf_buffer_str(&buf), "usr/local/lib");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "usr/local/lib");
 
 	pkgconf_buffer_finalize(&buf);
 }
@@ -251,7 +251,7 @@ test_buffer_subst(void)
 
 	pkgconf_buffer_append(&src, "prefix=${PREFIX}/share");
 	TEST_ASSERT_TRUE(pkgconf_buffer_subst(&dst, &src, "${PREFIX}", "/opt/foo"));
-	TEST_STRCMP(pkgconf_buffer_str(&dst), "prefix=/opt/foo/share");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&dst), "prefix=/opt/foo/share");
 
 	pkgconf_buffer_finalize(&src);
 	pkgconf_buffer_finalize(&dst);
@@ -270,7 +270,7 @@ test_buffer_escape(void)
 
 	pkgconf_buffer_append(&src, "a b\tc");
 	TEST_ASSERT_TRUE(pkgconf_buffer_escape(&dst, &src, spans, PKGCONF_ARRAY_SIZE(spans)));
-	TEST_STRCMP(pkgconf_buffer_str(&dst), "a\\ b\\\tc");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&dst), "a\\ b\\\tc");
 
 	pkgconf_buffer_finalize(&src);
 	pkgconf_buffer_finalize(&dst);

--- a/tests/api/test-bytecode.c
+++ b/tests/api/test-bytecode.c
@@ -224,7 +224,6 @@ int
 main(int argc, char *argv[])
 {
 	(void) argc;
-
 	const char *name = test_progname(argv[0]);
 
 	TEST_RUN(name, test_compile_produces_nonempty_buffer);
@@ -237,5 +236,5 @@ main(int argc, char *argv[])
 	TEST_RUN(name, test_eval_sysroot_detection);
 	TEST_RUN(name, test_compile_eval_roundtrip);
 
-	return 0;
+	return EXIT_SUCCESS;
 }

--- a/tests/api/test-bytecode.c
+++ b/tests/api/test-bytecode.c
@@ -1,0 +1,241 @@
+/*
+ * test-bytecode.c
+ * Tests for the public libpkgconf bytecode API:
+ * pkgconf_bytecode_compile and pkgconf_bytecode_eval_str.
+ *
+ * SPDX-License-Identifier: pkgconf
+ *
+ * Copyright (c) 2025 pkgconf authors (see AUTHORS).
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * This software is provided 'as is' and without any warranty, express or
+ * implied.  In no event shall the authors be liable for any damages arising
+ * from the use of this software.
+ */
+
+#include <libpkgconf/stdinc.h>
+#include <libpkgconf/libpkgconf.h>
+#include "test-api.h"
+
+/*
+ * Build a variable list with the given key/value pairs. Caller frees
+ * with pkgconf_variable_list_free().
+ *
+ * The key/value pairs are stored by compiling `value` as bytecode and
+ * stashing the result on a pkgconf_variable_t inside the list, which
+ * is how the parser builds variable scopes for real .pc files.
+ */
+static void
+seed_variable(pkgconf_list_t *vars, const char *key, const char *value)
+{
+	pkgconf_variable_t *v = pkgconf_variable_get_or_create(vars, key);
+	TEST_ASSERT_NONNULL(v);
+
+	pkgconf_buffer_reset(&v->bcbuf);
+	pkgconf_bytecode_compile(&v->bcbuf, value);
+	pkgconf_bytecode_from_buffer(&v->bc, &v->bcbuf);
+}
+
+static void
+test_eval_plain_text(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	// A string with no variable references should round-trip unchanged.
+	char *out = pkgconf_bytecode_eval_str(client, &vars, "plain text value", &saw_sysroot);
+
+	TEST_ASSERT_NONNULL(out);
+	TEST_STRCMP(out, "plain text value");
+	TEST_ASSERT_FALSE(saw_sysroot);
+
+	free(out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_eval_variable_substitution(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	seed_variable(&vars, "prefix", "/opt/foo");
+
+	char *out = pkgconf_bytecode_eval_str(client, &vars, "${prefix}/lib", &saw_sysroot);
+
+	TEST_ASSERT_NONNULL(out);
+	TEST_STRCMP(out, "/opt/foo/lib");
+	TEST_ASSERT_FALSE(saw_sysroot);
+
+	free(out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_eval_nested_variables(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	// Recursive expansion: libdir references prefix.
+	seed_variable(&vars, "prefix", "/usr/local");
+	seed_variable(&vars, "libdir", "${prefix}/lib");
+
+	char *out = pkgconf_bytecode_eval_str(client, &vars,
+		"-L${libdir}", &saw_sysroot);
+
+	TEST_ASSERT_NONNULL(out);
+	TEST_STRCMP(out, "-L/usr/local/lib");
+
+	free(out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_eval_undefined_variable(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	// Referencing an undefined variable should produce empty substitution, not failure
+	char *out = pkgconf_bytecode_eval_str(client, &vars, "prefix=${nonexistent}/end", &saw_sysroot);
+
+	TEST_ASSERT_NONNULL(out);
+	TEST_STRCMP(out, "prefix=/end");
+
+	free(out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_eval_multiple_variables(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	seed_variable(&vars, "prefix", "/usr");
+	seed_variable(&vars, "exec_prefix", "/usr/local");
+
+	char *out = pkgconf_bytecode_eval_str(client, &vars, "-I${prefix}/include -L${exec_prefix}/lib", &saw_sysroot);
+
+	TEST_ASSERT_NONNULL(out);
+	TEST_STRCMP(out, "-I/usr/include -L/usr/local/lib");
+
+	free(out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_eval_empty_input(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	char *out = pkgconf_bytecode_eval_str(client, &vars,
+		"", &saw_sysroot);
+
+	// An empty input may evaluate to either NULL or an empty string
+	if (out != NULL)
+	{
+		TEST_STRCMP(out, "");
+		free(out);
+	}
+
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_eval_sysroot_detection(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	pkgconf_client_set_sysroot_dir(client, "/sysroot");
+
+	seed_variable(&vars, "pc_sysrootdir", "/sysroot");
+	seed_variable(&vars, "includedir", "${pc_sysrootdir}/usr/include");
+
+	char *out = pkgconf_bytecode_eval_str(client, &vars, "${includedir}", &saw_sysroot);
+
+	TEST_ASSERT_NONNULL(out);
+	TEST_ASSERT_TRUE(saw_sysroot);
+
+	free(out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_compile_produces_nonempty_buffer(void)
+{
+	pkgconf_buffer_t bc = PKGCONF_BUFFER_INITIALIZER;
+
+	pkgconf_bytecode_compile(&bc, "hello ${world}");
+
+	// The compiled bytecode buffer should be non-empty
+	TEST_NE(pkgconf_buffer_len(&bc), 0);
+
+	pkgconf_buffer_finalize(&bc);
+}
+
+static void
+test_compile_eval_roundtrip(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	/* Compile directly, then evaluate via the bc field on a variable.
+	 * This is what the parser does internally for every .pc field. */
+	seed_variable(&vars, "name", "world");
+
+	pkgconf_variable_t *v = pkgconf_variable_get_or_create(&vars, "greeting");
+	TEST_ASSERT_NONNULL(v);
+	pkgconf_buffer_reset(&v->bcbuf);
+	pkgconf_bytecode_compile(&v->bcbuf, "hello ${name}");
+	pkgconf_bytecode_from_buffer(&v->bc, &v->bcbuf);
+
+	char *out = pkgconf_variable_eval_str(client, &vars, v, &saw_sysroot);
+	TEST_ASSERT_NONNULL(out);
+	TEST_STRCMP(out, "hello world");
+
+	free(out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+int
+main(int argc, char *argv[])
+{
+	(void) argc;
+
+	const char *name = test_progname(argv[0]);
+
+	TEST_RUN(name, test_compile_produces_nonempty_buffer);
+	TEST_RUN(name, test_eval_plain_text);
+	TEST_RUN(name, test_eval_empty_input);
+	TEST_RUN(name, test_eval_variable_substitution);
+	TEST_RUN(name, test_eval_nested_variables);
+	TEST_RUN(name, test_eval_multiple_variables);
+	TEST_RUN(name, test_eval_undefined_variable);
+	TEST_RUN(name, test_eval_sysroot_detection);
+	TEST_RUN(name, test_compile_eval_roundtrip);
+
+	return 0;
+}

--- a/tests/api/test-bytecode.c
+++ b/tests/api/test-bytecode.c
@@ -50,7 +50,7 @@ test_eval_plain_text(void)
 	char *out = pkgconf_bytecode_eval_str(client, &vars, "plain text value", &saw_sysroot);
 
 	TEST_ASSERT_NONNULL(out);
-	TEST_STRCMP(out, "plain text value");
+	TEST_ASSERT_STRCMP_EQ(out, "plain text value");
 	TEST_ASSERT_FALSE(saw_sysroot);
 
 	free(out);
@@ -70,7 +70,7 @@ test_eval_variable_substitution(void)
 	char *out = pkgconf_bytecode_eval_str(client, &vars, "${prefix}/lib", &saw_sysroot);
 
 	TEST_ASSERT_NONNULL(out);
-	TEST_STRCMP(out, "/opt/foo/lib");
+	TEST_ASSERT_STRCMP_EQ(out, "/opt/foo/lib");
 	TEST_ASSERT_FALSE(saw_sysroot);
 
 	free(out);
@@ -93,7 +93,7 @@ test_eval_nested_variables(void)
 		"-L${libdir}", &saw_sysroot);
 
 	TEST_ASSERT_NONNULL(out);
-	TEST_STRCMP(out, "-L/usr/local/lib");
+	TEST_ASSERT_STRCMP_EQ(out, "-L/usr/local/lib");
 
 	free(out);
 	pkgconf_variable_list_free(&vars);
@@ -111,7 +111,7 @@ test_eval_undefined_variable(void)
 	char *out = pkgconf_bytecode_eval_str(client, &vars, "prefix=${nonexistent}/end", &saw_sysroot);
 
 	TEST_ASSERT_NONNULL(out);
-	TEST_STRCMP(out, "prefix=/end");
+	TEST_ASSERT_STRCMP_EQ(out, "prefix=/end");
 
 	free(out);
 	pkgconf_variable_list_free(&vars);
@@ -131,7 +131,7 @@ test_eval_multiple_variables(void)
 	char *out = pkgconf_bytecode_eval_str(client, &vars, "-I${prefix}/include -L${exec_prefix}/lib", &saw_sysroot);
 
 	TEST_ASSERT_NONNULL(out);
-	TEST_STRCMP(out, "-I/usr/include -L/usr/local/lib");
+	TEST_ASSERT_STRCMP_EQ(out, "-I/usr/include -L/usr/local/lib");
 
 	free(out);
 	pkgconf_variable_list_free(&vars);
@@ -151,7 +151,7 @@ test_eval_empty_input(void)
 	// An empty input may evaluate to either NULL or an empty string
 	if (out != NULL)
 	{
-		TEST_STRCMP(out, "");
+		TEST_ASSERT_STRCMP_EQ(out, "");
 		free(out);
 	}
 
@@ -189,7 +189,7 @@ test_compile_produces_nonempty_buffer(void)
 	pkgconf_bytecode_compile(&bc, "hello ${world}");
 
 	// The compiled bytecode buffer should be non-empty
-	TEST_NE(pkgconf_buffer_len(&bc), 0);
+	TEST_ASSERT_NE(pkgconf_buffer_len(&bc), 0);
 
 	pkgconf_buffer_finalize(&bc);
 }
@@ -213,7 +213,7 @@ test_compile_eval_roundtrip(void)
 
 	char *out = pkgconf_variable_eval_str(client, &vars, v, &saw_sysroot);
 	TEST_ASSERT_NONNULL(out);
-	TEST_STRCMP(out, "hello world");
+	TEST_ASSERT_STRCMP_EQ(out, "hello world");
 
 	free(out);
 	pkgconf_variable_list_free(&vars);

--- a/tests/api/test-bytecode.c
+++ b/tests/api/test-bytecode.c
@@ -89,8 +89,7 @@ test_eval_nested_variables(void)
 	seed_variable(&vars, "prefix", "/usr/local");
 	seed_variable(&vars, "libdir", "${prefix}/lib");
 
-	char *out = pkgconf_bytecode_eval_str(client, &vars,
-		"-L${libdir}", &saw_sysroot);
+	char *out = pkgconf_bytecode_eval_str(client, &vars, "-L${libdir}", &saw_sysroot);
 
 	TEST_ASSERT_NONNULL(out);
 	TEST_ASSERT_STRCMP_EQ(out, "-L/usr/local/lib");
@@ -145,8 +144,7 @@ test_eval_empty_input(void)
 	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
 	bool saw_sysroot = false;
 
-	char *out = pkgconf_bytecode_eval_str(client, &vars,
-		"", &saw_sysroot);
+	char *out = pkgconf_bytecode_eval_str(client, &vars, "", &saw_sysroot);
 
 	// An empty input may evaluate to either NULL or an empty string
 	if (out != NULL)

--- a/tests/api/test-tuple.c
+++ b/tests/api/test-tuple.c
@@ -32,7 +32,7 @@ test_tuple_add_and_find(void)
 
 	const char *found = pkgconf_tuple_find(client, &tuples, "prefix");
 	TEST_ASSERT_NONNULL(found);
-	TEST_STRCMP(found, "/opt/foo");
+	TEST_ASSERT_STRCMP_EQ(found, "/opt/foo");
 
 	pkgconf_tuple_free(&tuples);
 	pkgconf_client_free(client);
@@ -45,7 +45,7 @@ test_tuple_find_absent(void)
 	pkgconf_list_t tuples = PKGCONF_LIST_INITIALIZER;
 
 	const char *found = pkgconf_tuple_find(client, &tuples, "nonexistent");
-	TEST_STRCMP(found, "");
+	TEST_ASSERT_EMPTY_STRING(found);
 
 	pkgconf_tuple_free(&tuples);
 	pkgconf_client_free(client);
@@ -61,10 +61,10 @@ test_tuple_add_multiple(void)
 	pkgconf_tuple_add(client, &tuples, "exec_prefix", "/usr/local", false, 0);
 	pkgconf_tuple_add(client, &tuples, "libdir", "/usr/lib", false, 0);
 
-	TEST_STRCMP(pkgconf_tuple_find(client, &tuples, "prefix"), "/usr");
-	TEST_STRCMP(pkgconf_tuple_find(client, &tuples, "exec_prefix"), "/usr/local");
-	TEST_STRCMP(pkgconf_tuple_find(client, &tuples, "libdir"), "/usr/lib");
-	TEST_STRCMP(pkgconf_tuple_find(client, &tuples, "datadir"), "");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_tuple_find(client, &tuples, "prefix"), "/usr");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_tuple_find(client, &tuples, "exec_prefix"), "/usr/local");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_tuple_find(client, &tuples, "libdir"), "/usr/lib");
+	TEST_ASSERT_EMPTY_STRING(pkgconf_tuple_find(client, &tuples, "datadir"));
 
 	pkgconf_tuple_free(&tuples);
 	pkgconf_client_free(client);
@@ -79,7 +79,7 @@ test_tuple_global_add_and_find(void)
 
 	const char *found = pkgconf_tuple_find_global(client, "PKG_TEST_KEY");
 	TEST_ASSERT_NONNULL(found);
-	TEST_STRCMP(found, "test_value");
+	TEST_ASSERT_STRCMP_EQ(found, "test_value");
 
 	pkgconf_tuple_free_global(client);
 	pkgconf_client_free(client);
@@ -91,7 +91,7 @@ test_tuple_global_find_absent(void)
 	pkgconf_client_t *client = test_client_new();
 
 	const char *found = pkgconf_tuple_find_global(client, "DOES_NOT_EXIST");
-	TEST_STRCMP(found, "");
+	TEST_ASSERT_EMPTY_STRING(found);
 
 	pkgconf_client_free(client);
 }
@@ -107,7 +107,7 @@ test_tuple_define_global_kv_form(void)
 
 	const char *found = pkgconf_tuple_find_global(client, "myvar");
 	TEST_ASSERT_NONNULL(found);
-	TEST_STRCMP(found, "myvalue");
+	TEST_ASSERT_STRCMP_EQ(found, "myvalue");
 
 	pkgconf_tuple_free_global(client);
 	pkgconf_client_free(client);
@@ -123,7 +123,7 @@ test_tuple_define_global_with_equals_in_value(void)
 
 	const char *found = pkgconf_tuple_find_global(client, "CFLAGS");
 	TEST_ASSERT_NONNULL(found);
-	TEST_STRCMP(found, "-DFOO=bar");
+	TEST_ASSERT_STRCMP_EQ(found, "-DFOO=bar");
 
 	pkgconf_tuple_free_global(client);
 	pkgconf_client_free(client);
@@ -138,9 +138,9 @@ test_tuple_global_multiple(void)
 	pkgconf_tuple_define_global(client, "b=2");
 	pkgconf_tuple_define_global(client, "c=3");
 
-	TEST_STRCMP(pkgconf_tuple_find_global(client, "a"), "1");
-	TEST_STRCMP(pkgconf_tuple_find_global(client, "b"), "2");
-	TEST_STRCMP(pkgconf_tuple_find_global(client, "c"), "3");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_tuple_find_global(client, "a"), "1");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_tuple_find_global(client, "b"), "2");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_tuple_find_global(client, "c"), "3");
 
 	pkgconf_tuple_free_global(client);
 	pkgconf_client_free(client);
@@ -155,7 +155,7 @@ test_tuple_global_free_resets(void)
 	TEST_ASSERT_NONNULL(pkgconf_tuple_find_global(client, "temp"));
 
 	pkgconf_tuple_free_global(client);
-	TEST_STRCMP(pkgconf_tuple_find_global(client, "temp"), "");
+	TEST_ASSERT_EMPTY_STRING(pkgconf_tuple_find_global(client, "temp"));
 
 	pkgconf_client_free(client);
 }
@@ -181,7 +181,7 @@ test_tuple_define_variable_end_to_end(void)
 	char *out = pkgconf_bytecode_eval_str(client, &vars, "-I${myprefix}/include", &saw_sysroot);
  
 	TEST_ASSERT_NONNULL(out);
-	TEST_STRCMP(out, "-I/opt/custom/include");
+	TEST_ASSERT_STRCMP_EQ(out, "-I/opt/custom/include");
  
 	free(out);
 	pkgconf_variable_list_free(&vars);
@@ -208,7 +208,7 @@ test_tuple_define_variable_overrides_local(void)
 	char *out = pkgconf_bytecode_eval_str(client, &vars, "${prefix}/lib", &saw_sysroot);
  
 	TEST_ASSERT_NONNULL(out);
-	TEST_STRCMP(out, "/custom/lib");
+	TEST_ASSERT_STRCMP_EQ(out, "/custom/lib");
  
 	free(out);
 	pkgconf_variable_list_free(&vars);

--- a/tests/api/test-tuple.c
+++ b/tests/api/test-tuple.c
@@ -1,0 +1,239 @@
+/*
+ * test-tuple.c
+ * Tests for the public libpkgconf tuple API.
+ *
+ * SPDX-License-Identifier: pkgconf
+ *
+ * Copyright (c) 2025 pkgconf authors (see AUTHORS).
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * This software is provided 'as is' and without any warranty, express or
+ * implied.  In no event shall the authors be liable for any damages arising
+ * from the use of this software.
+ */
+
+#include <libpkgconf/stdinc.h>
+#include <libpkgconf/libpkgconf.h>
+#include "test-api.h"
+
+static void
+test_tuple_add_and_find(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t tuples = PKGCONF_LIST_INITIALIZER;
+
+	/* parse=false means store the value verbatim, no bytecode compile.
+	 * That's the right mode for storing already-evaluated values. */
+	pkgconf_tuple_t *t = pkgconf_tuple_add(client, &tuples, "prefix", "/opt/foo", false, 0);
+	TEST_ASSERT_NONNULL(t);
+
+	const char *found = pkgconf_tuple_find(client, &tuples, "prefix");
+	TEST_ASSERT_NONNULL(found);
+	TEST_STRCMP(found, "/opt/foo");
+
+	pkgconf_tuple_free(&tuples);
+	pkgconf_client_free(client);
+}
+
+static void
+test_tuple_find_absent(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t tuples = PKGCONF_LIST_INITIALIZER;
+
+	const char *found = pkgconf_tuple_find(client, &tuples, "nonexistent");
+	TEST_STRCMP(found, "");
+
+	pkgconf_tuple_free(&tuples);
+	pkgconf_client_free(client);
+}
+
+static void
+test_tuple_add_multiple(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t tuples = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_tuple_add(client, &tuples, "prefix", "/usr", false, 0);
+	pkgconf_tuple_add(client, &tuples, "exec_prefix", "/usr/local", false, 0);
+	pkgconf_tuple_add(client, &tuples, "libdir", "/usr/lib", false, 0);
+
+	TEST_STRCMP(pkgconf_tuple_find(client, &tuples, "prefix"), "/usr");
+	TEST_STRCMP(pkgconf_tuple_find(client, &tuples, "exec_prefix"), "/usr/local");
+	TEST_STRCMP(pkgconf_tuple_find(client, &tuples, "libdir"), "/usr/lib");
+	TEST_STRCMP(pkgconf_tuple_find(client, &tuples, "datadir"), "");
+
+	pkgconf_tuple_free(&tuples);
+	pkgconf_client_free(client);
+}
+
+static void
+test_tuple_global_add_and_find(void)
+{
+	pkgconf_client_t *client = test_client_new();
+
+	pkgconf_tuple_add_global(client, "PKG_TEST_KEY", "test_value");
+
+	const char *found = pkgconf_tuple_find_global(client, "PKG_TEST_KEY");
+	TEST_ASSERT_NONNULL(found);
+	TEST_STRCMP(found, "test_value");
+
+	pkgconf_tuple_free_global(client);
+	pkgconf_client_free(client);
+}
+
+static void
+test_tuple_global_find_absent(void)
+{
+	pkgconf_client_t *client = test_client_new();
+
+	const char *found = pkgconf_tuple_find_global(client, "DOES_NOT_EXIST");
+	TEST_STRCMP(found, "");
+
+	pkgconf_client_free(client);
+}
+
+static void
+test_tuple_define_global_kv_form(void)
+{
+	pkgconf_client_t *client = test_client_new();
+
+	/* This is the exact path --define-variable=KEY=VALUE takes
+	 * pkgconf_tuple_define_global parses the "key=value" form and inserts it as a global tuple. */
+	pkgconf_tuple_define_global(client, "myvar=myvalue");
+
+	const char *found = pkgconf_tuple_find_global(client, "myvar");
+	TEST_ASSERT_NONNULL(found);
+	TEST_STRCMP(found, "myvalue");
+
+	pkgconf_tuple_free_global(client);
+	pkgconf_client_free(client);
+}
+
+static void
+test_tuple_define_global_with_equals_in_value(void)
+{
+	pkgconf_client_t *client = test_client_new();
+
+	// Only the first '=' should split key from value; subsequent '=' characters belong to the value.
+	pkgconf_tuple_define_global(client, "CFLAGS=-DFOO=bar");
+
+	const char *found = pkgconf_tuple_find_global(client, "CFLAGS");
+	TEST_ASSERT_NONNULL(found);
+	TEST_STRCMP(found, "-DFOO=bar");
+
+	pkgconf_tuple_free_global(client);
+	pkgconf_client_free(client);
+}
+
+static void
+test_tuple_global_multiple(void)
+{
+	pkgconf_client_t *client = test_client_new();
+
+	pkgconf_tuple_define_global(client, "a=1");
+	pkgconf_tuple_define_global(client, "b=2");
+	pkgconf_tuple_define_global(client, "c=3");
+
+	TEST_STRCMP(pkgconf_tuple_find_global(client, "a"), "1");
+	TEST_STRCMP(pkgconf_tuple_find_global(client, "b"), "2");
+	TEST_STRCMP(pkgconf_tuple_find_global(client, "c"), "3");
+
+	pkgconf_tuple_free_global(client);
+	pkgconf_client_free(client);
+}
+
+static void
+test_tuple_global_free_resets(void)
+{
+	pkgconf_client_t *client = test_client_new();
+
+	pkgconf_tuple_define_global(client, "temp=value");
+	TEST_ASSERT_NONNULL(pkgconf_tuple_find_global(client, "temp"));
+
+	pkgconf_tuple_free_global(client);
+	TEST_STRCMP(pkgconf_tuple_find_global(client, "temp"), "");
+
+	pkgconf_client_free(client);
+}
+
+static void
+test_tuple_free_empty(void)
+{
+	pkgconf_list_t tuples = PKGCONF_LIST_INITIALIZER;
+
+	// Freeing an empty list should be a no-op. Mostly an ASan/leak check smoke test.
+	pkgconf_tuple_free(&tuples);
+}
+
+static void
+test_tuple_define_variable_end_to_end(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+ 
+	pkgconf_tuple_define_global(client, "myprefix=/opt/custom");
+ 
+	char *out = pkgconf_bytecode_eval_str(client, &vars, "-I${myprefix}/include", &saw_sysroot);
+ 
+	TEST_ASSERT_NONNULL(out);
+	TEST_STRCMP(out, "-I/opt/custom/include");
+ 
+	free(out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_tuple_free_global(client);
+	pkgconf_client_free(client);
+}
+ 
+static void
+test_tuple_define_variable_overrides_local(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+ 
+	pkgconf_variable_t *v = pkgconf_variable_get_or_create(&vars, "prefix");
+	TEST_ASSERT_NONNULL(v);
+	pkgconf_buffer_reset(&v->bcbuf);
+	pkgconf_bytecode_compile(&v->bcbuf, "/usr");
+	pkgconf_bytecode_from_buffer(&v->bc, &v->bcbuf);
+ 
+	// Simulate user passing --define-variable=prefix=/custom.
+	pkgconf_tuple_define_global(client, "prefix=/custom");
+ 
+	char *out = pkgconf_bytecode_eval_str(client, &vars, "${prefix}/lib", &saw_sysroot);
+ 
+	TEST_ASSERT_NONNULL(out);
+	TEST_STRCMP(out, "/custom/lib");
+ 
+	free(out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_tuple_free_global(client);
+	pkgconf_client_free(client);
+}
+
+int
+main(int argc, char *argv[])
+{
+	(void) argc;
+	const char *basename = test_progname(argv[0]);
+
+	TEST_RUN(basename, test_tuple_add_and_find);
+	TEST_RUN(basename, test_tuple_find_absent);
+	TEST_RUN(basename, test_tuple_add_multiple);
+	TEST_RUN(basename, test_tuple_free_empty);
+	TEST_RUN(basename, test_tuple_global_add_and_find);
+	TEST_RUN(basename, test_tuple_global_find_absent);
+	TEST_RUN(basename, test_tuple_define_global_kv_form);
+	TEST_RUN(basename, test_tuple_define_global_with_equals_in_value);
+	TEST_RUN(basename, test_tuple_global_multiple);
+	TEST_RUN(basename, test_tuple_global_free_resets);
+	TEST_RUN(basename, test_tuple_define_variable_end_to_end);
+	TEST_RUN(basename, test_tuple_define_variable_overrides_local);
+
+	return EXIT_SUCCESS;
+}

--- a/tests/api/test-variable.c
+++ b/tests/api/test-variable.c
@@ -40,7 +40,7 @@ test_variable_new_and_free(void)
 	pkgconf_variable_t *v = pkgconf_variable_new("prefix");
 
 	TEST_ASSERT_NONNULL(v);
-	TEST_STRCMP(v->key, "prefix");
+	TEST_ASSERT_STRCMP_EQ(v->key, "prefix");
 
 	pkgconf_variable_free(v);
 }
@@ -52,7 +52,7 @@ test_variable_get_or_create_creates(void)
 
 	pkgconf_variable_t *v = pkgconf_variable_get_or_create(&vars, "prefix");
 	TEST_ASSERT_NONNULL(v);
-	TEST_STRCMP(v->key, "prefix");
+	TEST_ASSERT_STRCMP_EQ(v->key, "prefix");
 
 	pkgconf_variable_list_free(&vars);
 }
@@ -68,7 +68,7 @@ test_variable_get_or_create_returns_existing(void)
 	// A second call with the same key should return the same object, not create a duplicate.
 	pkgconf_variable_t *second = pkgconf_variable_get_or_create(&vars, "libdir");
 	TEST_ASSERT_NONNULL(second);
-	TEST_EQ(first, second);
+	TEST_ASSERT_EQ(first, second);
 
 	pkgconf_variable_list_free(&vars);
 }
@@ -83,7 +83,7 @@ test_variable_find_present(void)
 
 	pkgconf_variable_t *found = pkgconf_variable_find(&vars, "prefix");
 	TEST_ASSERT_NONNULL(found);
-	TEST_EQ(created, found);
+	TEST_ASSERT_EQ(created, found);
 
 	pkgconf_variable_list_free(&vars);
 }
@@ -147,7 +147,7 @@ test_variable_eval_str_plain(void)
 
 	char *out = pkgconf_variable_eval_str(client, &vars, v, &saw_sysroot);
 	TEST_ASSERT_NONNULL(out);
-	TEST_STRCMP(out, "1.2.3");
+	TEST_ASSERT_STRCMP_EQ(out, "1.2.3");
 
 	free(out);
 	pkgconf_variable_list_free(&vars);
@@ -170,7 +170,7 @@ test_variable_eval_str_with_reference(void)
 
 	char *out = pkgconf_variable_eval_str(client, &vars, libdir, &saw_sysroot);
 	TEST_ASSERT_NONNULL(out);
-	TEST_STRCMP(out, "/opt/foo/lib");
+	TEST_ASSERT_STRCMP_EQ(out, "/opt/foo/lib");
 
 	free(out);
 	pkgconf_variable_list_free(&vars);
@@ -193,7 +193,7 @@ test_variable_eval_str_chained(void)
 
 	char *out = pkgconf_variable_eval_str(client, &vars, includedir, &saw_sysroot);
 	TEST_ASSERT_NONNULL(out);
-	TEST_STRCMP(out, "/usr/local/include");
+	TEST_ASSERT_STRCMP_EQ(out, "/usr/local/include");
 
 	free(out);
 	pkgconf_variable_list_free(&vars);

--- a/tests/api/test-variable.c
+++ b/tests/api/test-variable.c
@@ -205,7 +205,7 @@ test_variable_list_free_handles_empty(void)
 {
 	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
 
-	/* Freeing an empty list should be a no-op and not crash. */
+	// Freeing an empty list should be a no-op and not crash. Mostly an ASan/leak smoke test.
 	pkgconf_variable_list_free(&vars);
 }
 

--- a/tests/api/test-variable.c
+++ b/tests/api/test-variable.c
@@ -1,0 +1,247 @@
+/*
+ * test-variable.c
+ * Tests for the public libpkgconf variable API.
+ *
+ * SPDX-License-Identifier: pkgconf
+ *
+ * Copyright (c) 2025 pkgconf authors (see AUTHORS).
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * This software is provided 'as is' and without any warranty, express or
+ * implied.  In no event shall the authors be liable for any damages arising
+ * from the use of this software.
+ */
+
+#include <libpkgconf/stdinc.h>
+#include <libpkgconf/libpkgconf.h>
+#include "test-api.h"
+
+/*
+ * Install a value on a variable by compiling it as bytecode.
+ * Mirrors what the parser does when it reads a .pc field.
+ */
+static void
+seed_variable(pkgconf_list_t *vars, const char *key, const char *value)
+{
+	pkgconf_variable_t *v = pkgconf_variable_get_or_create(vars, key);
+	TEST_ASSERT_NONNULL(v);
+
+	pkgconf_buffer_reset(&v->bcbuf);
+	pkgconf_bytecode_compile(&v->bcbuf, value);
+	pkgconf_bytecode_from_buffer(&v->bc, &v->bcbuf);
+}
+
+static void
+test_variable_new_and_free(void)
+{
+	pkgconf_variable_t *v = pkgconf_variable_new("prefix");
+
+	TEST_ASSERT_NONNULL(v);
+	TEST_STRCMP(v->key, "prefix");
+
+	pkgconf_variable_free(v);
+}
+
+static void
+test_variable_get_or_create_creates(void)
+{
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_variable_t *v = pkgconf_variable_get_or_create(&vars, "prefix");
+	TEST_ASSERT_NONNULL(v);
+	TEST_STRCMP(v->key, "prefix");
+
+	pkgconf_variable_list_free(&vars);
+}
+
+static void
+test_variable_get_or_create_returns_existing(void)
+{
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_variable_t *first = pkgconf_variable_get_or_create(&vars, "libdir");
+	TEST_ASSERT_NONNULL(first);
+
+	// A second call with the same key should return the same object, not create a duplicate.
+	pkgconf_variable_t *second = pkgconf_variable_get_or_create(&vars, "libdir");
+	TEST_ASSERT_NONNULL(second);
+	TEST_EQ(first, second);
+
+	pkgconf_variable_list_free(&vars);
+}
+
+static void
+test_variable_find_present(void)
+{
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_variable_t *created = pkgconf_variable_get_or_create(&vars, "prefix");
+	TEST_ASSERT_NONNULL(created);
+
+	pkgconf_variable_t *found = pkgconf_variable_find(&vars, "prefix");
+	TEST_ASSERT_NONNULL(found);
+	TEST_EQ(created, found);
+
+	pkgconf_variable_list_free(&vars);
+}
+
+static void
+test_variable_find_absent(void)
+{
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_variable_t *found = pkgconf_variable_find(&vars, "nonexistent");
+	TEST_ASSERT_NULL(found);
+
+	pkgconf_variable_list_free(&vars);
+}
+
+static void
+test_variable_find_among_many(void)
+{
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_variable_get_or_create(&vars, "prefix");
+	pkgconf_variable_get_or_create(&vars, "exec_prefix");
+	pkgconf_variable_get_or_create(&vars, "libdir");
+	pkgconf_variable_get_or_create(&vars, "includedir");
+
+	TEST_ASSERT_NONNULL(pkgconf_variable_find(&vars, "prefix"));
+	TEST_ASSERT_NONNULL(pkgconf_variable_find(&vars, "exec_prefix"));
+	TEST_ASSERT_NONNULL(pkgconf_variable_find(&vars, "libdir"));
+	TEST_ASSERT_NONNULL(pkgconf_variable_find(&vars, "includedir"));
+	TEST_ASSERT_NULL(pkgconf_variable_find(&vars, "notpresent"));
+
+	pkgconf_variable_list_free(&vars);
+}
+
+static void
+test_variable_delete(void)
+{
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_variable_t *v = pkgconf_variable_get_or_create(&vars, "prefix");
+	TEST_ASSERT_NONNULL(v);
+	TEST_ASSERT_NONNULL(pkgconf_variable_find(&vars, "prefix"));
+
+	pkgconf_variable_delete(&vars, v);
+	TEST_ASSERT_NULL(pkgconf_variable_find(&vars, "prefix"));
+
+	pkgconf_variable_list_free(&vars);
+}
+
+static void
+test_variable_eval_str_plain(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	seed_variable(&vars, "version", "1.2.3");
+
+	pkgconf_variable_t *v = pkgconf_variable_find(&vars, "version");
+	TEST_ASSERT_NONNULL(v);
+
+	char *out = pkgconf_variable_eval_str(client, &vars, v, &saw_sysroot);
+	TEST_ASSERT_NONNULL(out);
+	TEST_STRCMP(out, "1.2.3");
+
+	free(out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_variable_eval_str_with_reference(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	// Standard pkg-config layout: libdir is derived from prefix.
+	seed_variable(&vars, "prefix", "/opt/foo");
+	seed_variable(&vars, "libdir", "${prefix}/lib");
+
+	pkgconf_variable_t *libdir = pkgconf_variable_find(&vars, "libdir");
+	TEST_ASSERT_NONNULL(libdir);
+
+	char *out = pkgconf_variable_eval_str(client, &vars, libdir, &saw_sysroot);
+	TEST_ASSERT_NONNULL(out);
+	TEST_STRCMP(out, "/opt/foo/lib");
+
+	free(out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_variable_eval_str_chained(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	seed_variable(&vars, "prefix", "/usr/local");
+	seed_variable(&vars, "exec_prefix", "${prefix}");
+	seed_variable(&vars, "includedir", "${exec_prefix}/include");
+
+	pkgconf_variable_t *includedir = pkgconf_variable_find(&vars, "includedir");
+	TEST_ASSERT_NONNULL(includedir);
+
+	char *out = pkgconf_variable_eval_str(client, &vars, includedir, &saw_sysroot);
+	TEST_ASSERT_NONNULL(out);
+	TEST_STRCMP(out, "/usr/local/include");
+
+	free(out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_variable_list_free_handles_empty(void)
+{
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+
+	/* Freeing an empty list should be a no-op and not crash. */
+	pkgconf_variable_list_free(&vars);
+}
+
+static void
+test_variable_list_free_handles_many(void)
+{
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+
+	/* Add a mix of bare and value-carrying variables, then free the whole list at once.
+	 * Mostly an ASan/leak smoke test. */
+	pkgconf_variable_get_or_create(&vars, "a");
+	seed_variable(&vars, "b", "/path/b");
+	pkgconf_variable_get_or_create(&vars, "c");
+	seed_variable(&vars, "d", "${b}/sub");
+
+	pkgconf_variable_list_free(&vars);
+}
+
+int
+main(int argc, char *argv[])
+{
+	(void) argc;
+	const char *basename = test_progname(argv[0]);
+
+	TEST_RUN(basename, test_variable_new_and_free);
+	TEST_RUN(basename, test_variable_get_or_create_creates);
+	TEST_RUN(basename, test_variable_get_or_create_returns_existing);
+	TEST_RUN(basename, test_variable_find_present);
+	TEST_RUN(basename, test_variable_find_absent);
+	TEST_RUN(basename, test_variable_find_among_many);
+	TEST_RUN(basename, test_variable_delete);
+	TEST_RUN(basename, test_variable_eval_str_plain);
+	TEST_RUN(basename, test_variable_eval_str_with_reference);
+	TEST_RUN(basename, test_variable_eval_str_chained);
+	TEST_RUN(basename, test_variable_list_free_handles_empty);
+	TEST_RUN(basename, test_variable_list_free_handles_many);
+
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This adds tests for the bytecode, variable, and tuple APIs in libpkgconf.

This also introduces some renaming of the existing test macros to be self-consistent and the introduction of `TEST_ASSERT_EMPTY_STRING(expr)` for asserting if a string is empty. Useful for `pkgconf_tuple_find()` etc. (since those return the empty string on a nonexistent value).

References #488 