### PR TITLE
autogen.sh: use /bin/echo for -n

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -59,7 +59,7 @@ run_or_die ()
    OPTIONS="$@"
    
    # print a message
-   echo -n "*info* running $COMMAND"
+   /bin/echo -n "*info* running $COMMAND"
    if test -n "$OPTIONS" ; then
       echo " ($OPTIONS)"
    else


### PR DESCRIPTION
On macOS, `echo` from `/bin/sh`'s shell builtin implementation does not support the `-n` flag. This uses `/bin/echo` instead when using `-n`.

Definitely not a big deal, feel free to reject if deemed too risky in terms of portability to rely on the presence of `/bin/echo` like this.