### PR TITLE
Add fragment and dependency API tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -265,6 +265,7 @@ EXTRA_DIST =	pkg.m4 \
 		tests/api/test-api.h \
 		tests/api/test-buffer.c \
 		tests/api/test-bytecode.c \
+		tests/api/test-dependency.c \
 		tests/api/test-fragment.c \
 		tests/api/test-tuple.c \
 		tests/api/test-variable.c \
@@ -476,14 +477,16 @@ spdxtool_SOURCES  = \
 	cli/getopt_long.c
 spdxtool_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/cli -I$(top_srcdir)/cli/spdxtool
 
-noinst_PROGRAMS =		\
-	test-runner		\
-	test-path-utils		\
+API_TEST_PROGS =		\
 	test-api-buffer		\
 	test-api-bytecode	\
+	test-api-dependency	\
 	test-api-fragment	\
 	test-api-tuple		\
 	test-api-variable
+
+noinst_PROGRAMS = test-runner test-path-utils $(API_TEST_PROGS)
+
 test_runner_LDADD = libpkgconf.la
 test_runner_SOURCES = \
 	cli/core.c \
@@ -495,25 +498,32 @@ test_path_utils_LDADD = libpkgconf.la
 test_path_utils_SOURCES = tests/test-path-utils.c
 test_path_utils_CPPFLAGS = -I$(top_srcdir)/libpkgconf
 
-test_api_buffer_LDADD = libpkgconf.la
+api_test_ldadd = libpkgconf.la
+api_test_cppflags = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/tests/api
+
+test_api_buffer_LDADD = $(api_test_ldadd)
 test_api_buffer_SOURCES = tests/api/test-buffer.c
-test_api_buffer_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/tests/api
+test_api_buffer_CPPFLAGS = $(api_test_cppflags)
 
-test_api_bytecode_LDADD = libpkgconf.la
+test_api_bytecode_LDADD = $(api_test_ldadd)
 test_api_bytecode_SOURCES = tests/api/test-bytecode.c
-test_api_bytecode_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/tests/api
+test_api_bytecode_CPPFLAGS = $(api_test_cppflags)
 
-test_api_fragment_LDADD = libpkgconf.la
+test_api_dependency_LDADD = $(api_test_ldadd)
+test_api_dependency_SOURCES = tests/api/test-dependency.c
+test_api_dependency_CPPFLAGS = $(api_test_cppflags)
+
+test_api_fragment_LDADD = $(api_test_ldadd)
 test_api_fragment_SOURCES = tests/api/test-fragment.c
-test_api_fragment_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/tests/api
+test_api_fragment_CPPFLAGS = $(api_test_cppflags)
 
-test_api_tuple_LDADD = libpkgconf.la
+test_api_tuple_LDADD = $(api_test_ldadd)
 test_api_tuple_SOURCES = tests/api/test-tuple.c
-test_api_tuple_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/tests/api
+test_api_tuple_CPPFLAGS = $(api_test_cppflags)
 
-test_api_variable_LDADD = libpkgconf.la
+test_api_variable_LDADD = $(api_test_ldadd)
 test_api_variable_SOURCES = tests/api/test-variable.c
-test_api_variable_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/tests/api
+test_api_variable_CPPFLAGS = $(api_test_cppflags)
 
 dist_doc_DATA = CONTRIBUTING.md DCO README.md AUTHORS
 
@@ -522,10 +532,11 @@ m4data_DATA            = pkg.m4
 
 CLEANFILES =	$(EXTRA_PROGRAMS)
 
-check: pkgconf test-runner test-path-utils test-api-buffer test-api-bytecode test-api-fragment test-api-tuple test-api-variable
+check: pkgconf test-runner test-path-utils $(API_TEST_PROGS)
 	$(builddir)/test-path-utils$(EXEEXT)
 	$(builddir)/test-api-buffer$(EXEEXT)
 	$(builddir)/test-api-bytecode$(EXEEXT)
+	$(builddir)/test-api-dependency$(EXEEXT)
 	$(builddir)/test-api-fragment$(EXEEXT)
 	$(builddir)/test-api-tuple$(EXEEXT)
 	$(builddir)/test-api-variable$(EXEEXT)

--- a/Makefile.am
+++ b/Makefile.am
@@ -265,6 +265,7 @@ EXTRA_DIST =	pkg.m4 \
 		tests/api/test-api.h \
 		tests/api/test-buffer.c \
 		tests/api/test-bytecode.c \
+		tests/api/test-fragment.c \
 		tests/api/test-tuple.c \
 		tests/api/test-variable.c \
 		tests/lib-relocatable/lib/pkgconfig/foo.pc \
@@ -480,6 +481,7 @@ noinst_PROGRAMS =		\
 	test-path-utils		\
 	test-api-buffer		\
 	test-api-bytecode	\
+	test-api-fragment	\
 	test-api-tuple		\
 	test-api-variable
 test_runner_LDADD = libpkgconf.la
@@ -501,6 +503,10 @@ test_api_bytecode_LDADD = libpkgconf.la
 test_api_bytecode_SOURCES = tests/api/test-bytecode.c
 test_api_bytecode_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/tests/api
 
+test_api_fragment_LDADD = libpkgconf.la
+test_api_fragment_SOURCES = tests/api/test-fragment.c
+test_api_fragment_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/tests/api
+
 test_api_tuple_LDADD = libpkgconf.la
 test_api_tuple_SOURCES = tests/api/test-tuple.c
 test_api_tuple_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/tests/api
@@ -516,10 +522,11 @@ m4data_DATA            = pkg.m4
 
 CLEANFILES =	$(EXTRA_PROGRAMS)
 
-check: pkgconf test-runner test-path-utils test-api-buffer test-api-bytecode test-api-tuple test-api-variable
+check: pkgconf test-runner test-path-utils test-api-buffer test-api-bytecode test-api-fragment test-api-tuple test-api-variable
 	$(builddir)/test-path-utils$(EXEEXT)
 	$(builddir)/test-api-buffer$(EXEEXT)
 	$(builddir)/test-api-bytecode$(EXEEXT)
+	$(builddir)/test-api-fragment$(EXEEXT)
 	$(builddir)/test-api-tuple$(EXEEXT)
 	$(builddir)/test-api-variable$(EXEEXT)
 	$(builddir)/test-runner$(EXEEXT) --test-fixtures=$(top_srcdir)/tests --tool-dir="$(PWD)" $(top_srcdir)/t/basic

--- a/meson.build
+++ b/meson.build
@@ -227,6 +227,7 @@ test('path-utils', test_path_utils_exe)
 api_tests = [
   'buffer',
   'bytecode',
+  'fragment',
   'tuple',
   'variable',
 ]

--- a/meson.build
+++ b/meson.build
@@ -227,6 +227,7 @@ test('path-utils', test_path_utils_exe)
 api_tests = [
   'buffer',
   'bytecode',
+  'dependency',
   'fragment',
   'tuple',
   'variable',

--- a/tests/api/test-api.h
+++ b/tests/api/test-api.h
@@ -65,6 +65,42 @@
 				#a, #b, _a, _b);	\
 	} while (0)
 
+#define TEST_ASSERT_LT(a, b)	\
+	do {	\
+		long long _a = (long long)(a);	\
+		long long _b = (long long)(b);	\
+		if (_a >= _b)	\
+			TEST_FAIL_("TEST_ASSERT_LT(%s, %s): %lld >= %lld",	\
+				#a, #b, _a, _b);	\
+	} while (0)
+
+#define TEST_ASSERT_LE(a, b)	\
+	do {	\
+		long long _a = (long long)(a);	\
+		long long _b = (long long)(b);	\
+		if (_a > _b)	\
+			TEST_FAIL_("TEST_ASSERT_LE(%s, %s): %lld > %lld",	\
+				#a, #b, _a, _b);	\
+	} while (0)
+
+#define TEST_ASSERT_GT(a, b)	\
+	do {	\
+		long long _a = (long long)(a);	\
+		long long _b = (long long)(b);	\
+		if (_a <= _b)	\
+			TEST_FAIL_("TEST_ASSERT_GT(%s, %s): %lld <= %lld",	\
+				#a, #b, _a, _b);	\
+	} while (0)
+
+#define TEST_ASSERT_GE(a, b)	\
+	do {	\
+		long long _a = (long long)(a);	\
+		long long _b = (long long)(b);	\
+		if (_a < _b)	\
+			TEST_FAIL_("TEST_ASSERT_GE(%s, %s): %lld < %lld",	\
+				#a, #b, _a, _b);	\
+	} while (0)
+
 #define TEST_ASSERT_NE(a, b)	\
 	do {	\
 		long long _a = (long long)(a);	\

--- a/tests/api/test-dependency.c
+++ b/tests/api/test-dependency.c
@@ -170,6 +170,9 @@ test_parse_str_multiple_comma_separated(void)
 	const pkgconf_dependency_t *d0 = dependency_at(&deps, 0);
 	const pkgconf_dependency_t *d1 = dependency_at(&deps, 1);
 	const pkgconf_dependency_t *d2 = dependency_at(&deps, 2);
+	TEST_ASSERT_NONNULL(d0);
+	TEST_ASSERT_NONNULL(d1);
+	TEST_ASSERT_NONNULL(d2);
 	TEST_ASSERT_STRCMP_EQ(d0->package, "foo");
 	TEST_ASSERT_STRCMP_EQ(d1->package, "bar");
 	TEST_ASSERT_STRCMP_EQ(d2->package, "baz");
@@ -191,6 +194,10 @@ test_parse_str_mixed_versioned_and_bare(void)
 	const pkgconf_dependency_t *d0 = dependency_at(&deps, 0);
 	const pkgconf_dependency_t *d1 = dependency_at(&deps, 1);
 	const pkgconf_dependency_t *d2 = dependency_at(&deps, 2);
+	
+	TEST_ASSERT_NONNULL(d0);
+	TEST_ASSERT_NONNULL(d1);
+	TEST_ASSERT_NONNULL(d2);
 
 	TEST_ASSERT_STRCMP_EQ(d0->package, "foo");
 	TEST_ASSERT_EQ(d0->compare, PKGCONF_CMP_GREATER_THAN_EQUAL);
@@ -236,6 +243,13 @@ test_parse_str_all_comparators(void)
 	const pkgconf_dependency_t *d3 = dependency_at(&deps, 3);
 	const pkgconf_dependency_t *d4 = dependency_at(&deps, 4);
 	const pkgconf_dependency_t *d5 = dependency_at(&deps, 5);
+	
+	TEST_ASSERT_NONNULL(d0);
+	TEST_ASSERT_NONNULL(d1);
+	TEST_ASSERT_NONNULL(d2);
+	TEST_ASSERT_NONNULL(d3);
+	TEST_ASSERT_NONNULL(d4);
+	TEST_ASSERT_NONNULL(d5);
 
 	TEST_ASSERT_EQ(d0->compare, PKGCONF_CMP_EQUAL);
 	TEST_ASSERT_EQ(d1->compare, PKGCONF_CMP_NOT_EQUAL);
@@ -292,6 +306,10 @@ test_dependency_add_multiple(void)
 	pkgconf_dependency_t *d0 = pkgconf_dependency_add(client, &deps, "foo", NULL, PKGCONF_CMP_ANY, 0);
 	pkgconf_dependency_t *d1 = pkgconf_dependency_add(client, &deps, "bar", "2.0", PKGCONF_CMP_EQUAL, 0);
 	pkgconf_dependency_t *d2 = pkgconf_dependency_add(client, &deps, "baz", "3.0", PKGCONF_CMP_LESS_THAN, 0);
+	
+	TEST_ASSERT_NONNULL(d0);
+	TEST_ASSERT_NONNULL(d1);
+	TEST_ASSERT_NONNULL(d2);
 
 	TEST_ASSERT_EQ(dependency_count(&deps), 3);
 

--- a/tests/api/test-dependency.c
+++ b/tests/api/test-dependency.c
@@ -1,0 +1,431 @@
+/*
+ * test-dependency.c
+ * Tests for the public libpkgconf dependency API.
+ *
+ * SPDX-License-Identifier: pkgconf
+ *
+ * Copyright (c) 2026 pkgconf authors (see AUTHORS).
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * This software is provided 'as is' and without any warranty, express or
+ * implied.  In no event shall the authors be liable for any damages arising
+ * from the use of this software.
+ */
+
+#include "test-api.h"
+
+static size_t
+dependency_count(const pkgconf_list_t *list)
+{
+	size_t n = 0;
+	const pkgconf_node_t *iter;
+
+	PKGCONF_FOREACH_LIST_ENTRY(list->head, iter)
+	{
+		n++;
+	}
+
+	return n;
+}
+
+static const pkgconf_dependency_t *
+dependency_at(const pkgconf_list_t *list, size_t index)
+{
+	const pkgconf_node_t *iter;
+	size_t i = 0;
+
+	PKGCONF_FOREACH_LIST_ENTRY(list->head, iter)
+	{
+		if (i++ == index)
+			return iter->data;
+	}
+
+	return NULL;
+}
+
+static void
+test_comparator_lookup_known(void)
+{
+	TEST_ASSERT_EQ(pkgconf_pkg_comparator_lookup_by_name("="), PKGCONF_CMP_EQUAL);
+	TEST_ASSERT_EQ(pkgconf_pkg_comparator_lookup_by_name("!="), PKGCONF_CMP_NOT_EQUAL);
+	TEST_ASSERT_EQ(pkgconf_pkg_comparator_lookup_by_name("<"), PKGCONF_CMP_LESS_THAN);
+	TEST_ASSERT_EQ(pkgconf_pkg_comparator_lookup_by_name("<="), PKGCONF_CMP_LESS_THAN_EQUAL);
+	TEST_ASSERT_EQ(pkgconf_pkg_comparator_lookup_by_name(">"), PKGCONF_CMP_GREATER_THAN);
+	TEST_ASSERT_EQ(pkgconf_pkg_comparator_lookup_by_name(">="), PKGCONF_CMP_GREATER_THAN_EQUAL);
+}
+
+static void
+test_comparator_lookup_unknown(void)
+{
+	TEST_ASSERT_EQ(pkgconf_pkg_comparator_lookup_by_name("~~"), PKGCONF_CMP_ANY);
+	TEST_ASSERT_EQ(pkgconf_pkg_comparator_lookup_by_name(""), PKGCONF_CMP_ANY);
+}
+
+static void
+test_comparator_roundtrip(void)
+{
+	pkgconf_pkg_comparator_t values[] =
+	{
+		PKGCONF_CMP_NOT_EQUAL,
+		PKGCONF_CMP_ANY,
+		PKGCONF_CMP_LESS_THAN,
+		PKGCONF_CMP_LESS_THAN_EQUAL,
+		PKGCONF_CMP_EQUAL,
+		PKGCONF_CMP_GREATER_THAN,
+		PKGCONF_CMP_GREATER_THAN_EQUAL,
+	};
+
+	for (size_t i = 0; i < PKGCONF_ARRAY_SIZE(values); i++)
+	{
+		pkgconf_dependency_t dep = { 0 };
+		dep.compare = values[i];
+
+		const char *str = pkgconf_pkg_get_comparator(&dep);
+		TEST_ASSERT_NONNULL(str);
+
+		// ANY's value does not round-trip so do not check
+		if (values[i] == PKGCONF_CMP_ANY)
+			continue;
+
+		pkgconf_pkg_comparator_t back = pkgconf_pkg_comparator_lookup_by_name(str);
+		TEST_ASSERT_EQ(back, values[i]);
+	}
+}
+
+static void
+test_parse_str_single(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t deps = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_dependency_parse_str(client, &deps, "foo", 0);
+
+	TEST_ASSERT_EQ(dependency_count(&deps), 1);
+	const pkgconf_dependency_t *d = dependency_at(&deps, 0);
+	TEST_ASSERT_NONNULL(d);
+	TEST_ASSERT_STRCMP_EQ(d->package, "foo");
+	TEST_ASSERT_EQ(d->compare, PKGCONF_CMP_ANY);
+	TEST_ASSERT_NULL(d->version);
+
+	pkgconf_dependency_free(&deps);
+	pkgconf_client_free(client);
+}
+
+static void
+test_parse_str_versioned(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t deps = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_dependency_parse_str(client, &deps, "foo >= 1.2.3", 0);
+
+	TEST_ASSERT_EQ(dependency_count(&deps), 1);
+	const pkgconf_dependency_t *d = dependency_at(&deps, 0);
+	TEST_ASSERT_NONNULL(d);
+	TEST_ASSERT_STRCMP_EQ(d->package, "foo");
+	TEST_ASSERT_EQ(d->compare, PKGCONF_CMP_GREATER_THAN_EQUAL);
+	TEST_ASSERT_STRCMP_EQ(d->version, "1.2.3");
+
+	pkgconf_dependency_free(&deps);
+	pkgconf_client_free(client);
+}
+
+static void
+test_parse_str_multiple_space_separated(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t deps = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_dependency_parse_str(client, &deps, "foo bar baz", 0);
+
+	TEST_ASSERT_EQ(dependency_count(&deps), 3);
+
+	const pkgconf_dependency_t *d0 = dependency_at(&deps, 0);
+	const pkgconf_dependency_t *d1 = dependency_at(&deps, 1);
+	const pkgconf_dependency_t *d2 = dependency_at(&deps, 2);
+	TEST_ASSERT_NONNULL(d0);
+	TEST_ASSERT_NONNULL(d1);
+	TEST_ASSERT_NONNULL(d2);
+	TEST_ASSERT_STRCMP_EQ(d0->package, "foo");
+	TEST_ASSERT_STRCMP_EQ(d1->package, "bar");
+	TEST_ASSERT_STRCMP_EQ(d2->package, "baz");
+
+	pkgconf_dependency_free(&deps);
+	pkgconf_client_free(client);
+}
+
+static void
+test_parse_str_multiple_comma_separated(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t deps = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_dependency_parse_str(client, &deps, "foo, bar, baz", 0);
+
+	TEST_ASSERT_EQ(dependency_count(&deps), 3);
+
+	const pkgconf_dependency_t *d0 = dependency_at(&deps, 0);
+	const pkgconf_dependency_t *d1 = dependency_at(&deps, 1);
+	const pkgconf_dependency_t *d2 = dependency_at(&deps, 2);
+	TEST_ASSERT_STRCMP_EQ(d0->package, "foo");
+	TEST_ASSERT_STRCMP_EQ(d1->package, "bar");
+	TEST_ASSERT_STRCMP_EQ(d2->package, "baz");
+
+	pkgconf_dependency_free(&deps);
+	pkgconf_client_free(client);
+}
+
+static void
+test_parse_str_mixed_versioned_and_bare(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t deps = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_dependency_parse_str(client, &deps, "foo >= 1.0, bar, baz < 2.0", 0);
+
+	TEST_ASSERT_EQ(dependency_count(&deps), 3);
+
+	const pkgconf_dependency_t *d0 = dependency_at(&deps, 0);
+	const pkgconf_dependency_t *d1 = dependency_at(&deps, 1);
+	const pkgconf_dependency_t *d2 = dependency_at(&deps, 2);
+
+	TEST_ASSERT_STRCMP_EQ(d0->package, "foo");
+	TEST_ASSERT_EQ(d0->compare, PKGCONF_CMP_GREATER_THAN_EQUAL);
+	TEST_ASSERT_STRCMP_EQ(d0->version, "1.0");
+
+	TEST_ASSERT_STRCMP_EQ(d1->package, "bar");
+	TEST_ASSERT_EQ(d1->compare, PKGCONF_CMP_ANY);
+
+	TEST_ASSERT_STRCMP_EQ(d2->package, "baz");
+	TEST_ASSERT_EQ(d2->compare, PKGCONF_CMP_LESS_THAN);
+	TEST_ASSERT_STRCMP_EQ(d2->version, "2.0");
+
+	pkgconf_dependency_free(&deps);
+	pkgconf_client_free(client);
+}
+
+static void
+test_parse_str_empty(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t deps = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_dependency_parse_str(client, &deps, "", 0);
+	TEST_ASSERT_EQ(dependency_count(&deps), 0);
+
+	pkgconf_dependency_free(&deps);
+	pkgconf_client_free(client);
+}
+
+static void
+test_parse_str_all_comparators(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t deps = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_dependency_parse_str(client, &deps, "a = 1, b != 2, c < 3, d <= 4, e > 5, f >= 6", 0);
+
+	TEST_ASSERT_EQ(dependency_count(&deps), 6);
+
+	const pkgconf_dependency_t *d0 = dependency_at(&deps, 0);
+	const pkgconf_dependency_t *d1 = dependency_at(&deps, 1);
+	const pkgconf_dependency_t *d2 = dependency_at(&deps, 2);
+	const pkgconf_dependency_t *d3 = dependency_at(&deps, 3);
+	const pkgconf_dependency_t *d4 = dependency_at(&deps, 4);
+	const pkgconf_dependency_t *d5 = dependency_at(&deps, 5);
+
+	TEST_ASSERT_EQ(d0->compare, PKGCONF_CMP_EQUAL);
+	TEST_ASSERT_EQ(d1->compare, PKGCONF_CMP_NOT_EQUAL);
+	TEST_ASSERT_EQ(d2->compare, PKGCONF_CMP_LESS_THAN);
+	TEST_ASSERT_EQ(d3->compare, PKGCONF_CMP_LESS_THAN_EQUAL);
+	TEST_ASSERT_EQ(d4->compare, PKGCONF_CMP_GREATER_THAN);
+	TEST_ASSERT_EQ(d5->compare, PKGCONF_CMP_GREATER_THAN_EQUAL);
+
+	pkgconf_dependency_free(&deps);
+	pkgconf_client_free(client);
+}
+
+static void
+test_dependency_add(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t deps = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_dependency_t *d = pkgconf_dependency_add(client, &deps, "foo", "1.0", PKGCONF_CMP_GREATER_THAN_EQUAL, 0);
+	TEST_ASSERT_NONNULL(d);
+	TEST_ASSERT_STRCMP_EQ(d->package, "foo");
+	TEST_ASSERT_STRCMP_EQ(d->version, "1.0");
+	TEST_ASSERT_EQ(d->compare, PKGCONF_CMP_GREATER_THAN_EQUAL);
+
+	TEST_ASSERT_EQ(dependency_count(&deps), 1);
+
+	pkgconf_dependency_free(&deps);
+	pkgconf_client_free(client);
+}
+
+static void
+test_dependency_add_no_version(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t deps = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_dependency_t *d = pkgconf_dependency_add(client, &deps, "foo", NULL, PKGCONF_CMP_ANY, 0);
+	TEST_ASSERT_NONNULL(d);
+	TEST_ASSERT_STRCMP_EQ(d->package, "foo");
+	TEST_ASSERT_EQ(d->compare, PKGCONF_CMP_ANY);
+
+	pkgconf_dependency_free(&deps);
+	pkgconf_client_free(client);
+}
+
+static void
+test_dependency_add_multiple(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t deps = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_dependency_add(client, &deps, "foo", NULL, PKGCONF_CMP_ANY, 0);
+	pkgconf_dependency_add(client, &deps, "bar", "2.0", PKGCONF_CMP_EQUAL, 0);
+	pkgconf_dependency_add(client, &deps, "baz", "3.0", PKGCONF_CMP_LESS_THAN, 0);
+
+	TEST_ASSERT_EQ(dependency_count(&deps), 3);
+
+	pkgconf_dependency_free(&deps);
+	pkgconf_client_free(client);
+}
+
+static void
+test_version_equal(void)
+{
+	TEST_ASSERT_EQ(pkgconf_compare_version("1.0", "1.0"), 0);
+	TEST_ASSERT_EQ(pkgconf_compare_version("1.2.3", "1.2.3"), 0);
+	TEST_ASSERT_EQ(pkgconf_compare_version("", ""), 0);
+}
+
+static void
+test_version_simple_numeric(void)
+{
+	TEST_ASSERT_LT(pkgconf_compare_version("1.0", "1.1"), 0);
+	TEST_ASSERT_GT(pkgconf_compare_version("1.1", "1.0"), 0);
+
+	TEST_ASSERT_LT(pkgconf_compare_version("1.0", "2.0"), 0);
+	TEST_ASSERT_GT(pkgconf_compare_version("2.0", "1.0"), 0);
+
+	TEST_ASSERT_LT(pkgconf_compare_version("1.2.3", "1.2.4"), 0);
+	TEST_ASSERT_LT(pkgconf_compare_version("1.2.3", "1.3.0"), 0);
+	TEST_ASSERT_LT(pkgconf_compare_version("1.2.3", "2.0.0"), 0);
+}
+
+static void
+test_version_numeric_segments_not_lexical(void)
+{
+	TEST_ASSERT_GT(pkgconf_compare_version("1.10", "1.9"), 0);
+	TEST_ASSERT_GT(pkgconf_compare_version("1.100", "1.99"), 0);
+}
+
+static void
+test_version_different_lengths(void)
+{
+	TEST_ASSERT_LT(pkgconf_compare_version("1.0", "1.0.1"), 0);
+	TEST_ASSERT_GT(pkgconf_compare_version("1.0.1", "1.0"), 0);
+}
+
+static void
+test_version_alpha_suffix(void)
+{
+	TEST_ASSERT_GT(pkgconf_compare_version("1.0a", "1.0"), 0);
+	TEST_ASSERT_GT(pkgconf_compare_version("1.0alpha", "1.0"), 0);
+	TEST_ASSERT_GT(pkgconf_compare_version("1.0rc1", "1.0"), 0);
+
+	TEST_ASSERT_LT(pkgconf_compare_version("1.0alpha", "1.0beta"), 0);
+	TEST_ASSERT_LT(pkgconf_compare_version("1.0beta", "1.0rc"), 0);
+}
+
+static void
+test_version_tilde_prerelease(void)
+{
+	TEST_ASSERT_LT(pkgconf_compare_version("1.0~rc1", "1.0"), 0);
+	TEST_ASSERT_LT(pkgconf_compare_version("1.0~alpha", "1.0"), 0);
+	TEST_ASSERT_LT(pkgconf_compare_version("1.0~beta", "1.0~rc"), 0);
+
+	TEST_ASSERT_LT(pkgconf_compare_version("1.0~rc1", "1.0rc1"), 0);
+}
+
+static void
+test_version_numeric_beats_alpha(void)
+{
+	TEST_ASSERT_GT(pkgconf_compare_version("1.0.1", "1.0a"), 0);
+	TEST_ASSERT_LT(pkgconf_compare_version("1.0a", "1.0.1"), 0);
+}
+
+static void
+test_version_alpha_ordering(void)
+{
+	TEST_ASSERT_LT(pkgconf_compare_version("1.0a", "1.0b"), 0);
+	TEST_ASSERT_GT(pkgconf_compare_version("1.0b", "1.0a"), 0);
+}
+
+static void
+test_version_dotted_vs_hyphenated(void)
+{
+	TEST_ASSERT_EQ(pkgconf_compare_version("1.0-1", "1.0.1"), 0);
+}
+
+static void
+test_version_leading_zeros(void)
+{
+	TEST_ASSERT_EQ(pkgconf_compare_version("1.01", "1.1"), 0);
+	TEST_ASSERT_EQ(pkgconf_compare_version("01.0", "1.0"), 0);
+}
+
+static void
+test_version_trailing_zero_segments(void)
+{
+	/* Pkgconf does NOT treat "1.0" and "1.0.0" as equivalent. 
+	 * Even a zero trailing numeric segment is additional content that makes the version greater.
+	 */
+	TEST_ASSERT_LT(pkgconf_compare_version("1.0", "1.0.0"), 0);
+	TEST_ASSERT_GT(pkgconf_compare_version("1.0.0", "1.0"), 0);
+	TEST_ASSERT_LT(pkgconf_compare_version("1", "1.0"), 0);
+	TEST_ASSERT_LT(pkgconf_compare_version("1", "1.0.0.0"), 0);
+}
+
+int
+main(int argc, char *argv[])
+{
+	(void) argc;
+	const char *basename = test_progname(argv[0]);
+
+	TEST_RUN(basename, test_comparator_lookup_known);
+	TEST_RUN(basename, test_comparator_lookup_unknown);
+	TEST_RUN(basename, test_comparator_roundtrip);
+
+	TEST_RUN(basename, test_parse_str_empty);
+	TEST_RUN(basename, test_parse_str_single);
+	TEST_RUN(basename, test_parse_str_versioned);
+	TEST_RUN(basename, test_parse_str_multiple_space_separated);
+	TEST_RUN(basename, test_parse_str_multiple_comma_separated);
+	TEST_RUN(basename, test_parse_str_mixed_versioned_and_bare);
+	TEST_RUN(basename, test_parse_str_all_comparators);
+
+	TEST_RUN(basename, test_dependency_add);
+	TEST_RUN(basename, test_dependency_add_no_version);
+	TEST_RUN(basename, test_dependency_add_multiple);
+
+	TEST_RUN(basename, test_version_equal);
+	TEST_RUN(basename, test_version_simple_numeric);
+	TEST_RUN(basename, test_version_numeric_segments_not_lexical);
+	TEST_RUN(basename, test_version_different_lengths);
+	TEST_RUN(basename, test_version_alpha_suffix);
+	TEST_RUN(basename, test_version_tilde_prerelease);
+	TEST_RUN(basename, test_version_numeric_beats_alpha);
+	TEST_RUN(basename, test_version_alpha_ordering);
+	TEST_RUN(basename, test_version_dotted_vs_hyphenated);
+	TEST_RUN(basename, test_version_leading_zeros);
+	TEST_RUN(basename, test_version_trailing_zero_segments);
+
+	return EXIT_SUCCESS;
+}

--- a/tests/api/test-dependency.c
+++ b/tests/api/test-dependency.c
@@ -262,6 +262,7 @@ test_dependency_add(void)
 
 	TEST_ASSERT_EQ(dependency_count(&deps), 1);
 
+	pkgconf_dependency_unref(client, d);
 	pkgconf_dependency_free(&deps);
 	pkgconf_client_free(client);
 }
@@ -277,6 +278,7 @@ test_dependency_add_no_version(void)
 	TEST_ASSERT_STRCMP_EQ(d->package, "foo");
 	TEST_ASSERT_EQ(d->compare, PKGCONF_CMP_ANY);
 
+	pkgconf_dependency_unref(client, d);
 	pkgconf_dependency_free(&deps);
 	pkgconf_client_free(client);
 }
@@ -287,12 +289,15 @@ test_dependency_add_multiple(void)
 	pkgconf_client_t *client = test_client_new();
 	pkgconf_list_t deps = PKGCONF_LIST_INITIALIZER;
 
-	pkgconf_dependency_add(client, &deps, "foo", NULL, PKGCONF_CMP_ANY, 0);
-	pkgconf_dependency_add(client, &deps, "bar", "2.0", PKGCONF_CMP_EQUAL, 0);
-	pkgconf_dependency_add(client, &deps, "baz", "3.0", PKGCONF_CMP_LESS_THAN, 0);
+	pkgconf_dependency_t *d0 = pkgconf_dependency_add(client, &deps, "foo", NULL, PKGCONF_CMP_ANY, 0);
+	pkgconf_dependency_t *d1 = pkgconf_dependency_add(client, &deps, "bar", "2.0", PKGCONF_CMP_EQUAL, 0);
+	pkgconf_dependency_t *d2 = pkgconf_dependency_add(client, &deps, "baz", "3.0", PKGCONF_CMP_LESS_THAN, 0);
 
 	TEST_ASSERT_EQ(dependency_count(&deps), 3);
 
+	pkgconf_dependency_unref(client, d0);
+	pkgconf_dependency_unref(client, d1);
+	pkgconf_dependency_unref(client, d2);
 	pkgconf_dependency_free(&deps);
 	pkgconf_client_free(client);
 }

--- a/tests/api/test-fragment.c
+++ b/tests/api/test-fragment.c
@@ -1,0 +1,376 @@
+/*
+ * test-fragment.c
+ * Tests for the public libpkgconf fragment API.
+ *
+ * SPDX-License-Identifier: pkgconf
+ *
+ * Copyright (c) 2026 pkgconf authors (see AUTHORS).
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * This software is provided 'as is' and without any warranty, express or
+ * implied.  In no event shall the authors be liable for any damages arising
+ * from the use of this software.
+ */
+
+#include "test-api.h"
+
+static size_t
+fragment_count(const pkgconf_list_t *list)
+{
+	size_t n = 0;
+	const pkgconf_node_t *iter;
+
+	PKGCONF_FOREACH_LIST_ENTRY(list->head, iter)
+	{
+		n++;
+	}
+
+	return n;
+}
+
+static const pkgconf_fragment_t *
+fragment_at(const pkgconf_list_t *list, size_t index)
+{
+	const pkgconf_node_t *iter;
+	size_t i = 0;
+
+	PKGCONF_FOREACH_LIST_ENTRY(list->head, iter)
+	{
+		if (i++ == index)
+			return iter->data;
+	}
+
+	return NULL;
+}
+
+/*
+ * Render a fragment list to a newly-allocated C string for assertions.
+ * Caller frees.
+ */
+static char *
+render_to_string(const pkgconf_list_t *list)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_fragment_render_buf(list, &buf, false, NULL, ' ');
+
+	if (pkgconf_buffer_str(&buf) == NULL)
+		return strdup("");
+
+	char *out = strdup(pkgconf_buffer_str(&buf));
+	pkgconf_buffer_finalize(&buf);
+	return out;
+}
+
+static void
+test_fragment_parse_cflags(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t frags = PKGCONF_LIST_INITIALIZER;
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+
+	TEST_ASSERT_TRUE(pkgconf_fragment_parse(client, &frags, &vars, "-I/usr/include -DFOO=1", 0));
+	TEST_ASSERT_EQ(fragment_count(&frags), 2);
+
+	const pkgconf_fragment_t *first = fragment_at(&frags, 0);
+	TEST_ASSERT_NONNULL(first);
+	TEST_ASSERT_EQ(first->type, 'I');
+	TEST_ASSERT_STRCMP_EQ(first->data, "/usr/include");
+
+	pkgconf_fragment_free(&frags);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_fragment_parse_libs(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t frags = PKGCONF_LIST_INITIALIZER;
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+
+	TEST_ASSERT_TRUE(pkgconf_fragment_parse(client, &frags, &vars, "-L/usr/lib -lfoo -lbar", 0));
+	TEST_ASSERT_EQ(fragment_count(&frags), 3);
+
+	const pkgconf_fragment_t *f0 = fragment_at(&frags, 0);
+	const pkgconf_fragment_t *f1 = fragment_at(&frags, 1);
+	const pkgconf_fragment_t *f2 = fragment_at(&frags, 2);
+
+	TEST_ASSERT_NONNULL(f0);
+	TEST_ASSERT_NONNULL(f1);
+	TEST_ASSERT_NONNULL(f2);
+
+	TEST_ASSERT_EQ(f0->type, 'L');
+	TEST_ASSERT_STRCMP_EQ(f0->data, "/usr/lib");
+	TEST_ASSERT_EQ(f1->type, 'l');
+	TEST_ASSERT_STRCMP_EQ(f1->data, "foo");
+	TEST_ASSERT_EQ(f2->type, 'l');
+	TEST_ASSERT_STRCMP_EQ(f2->data, "bar");
+
+	pkgconf_fragment_free(&frags);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_fragment_parse_empty(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t frags = PKGCONF_LIST_INITIALIZER;
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+
+	TEST_ASSERT_TRUE(pkgconf_fragment_parse(client, &frags, &vars, "", 0));
+	TEST_ASSERT_EQ(fragment_count(&frags), 0);
+
+	pkgconf_fragment_free(&frags);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_fragment_add_single(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t frags = PKGCONF_LIST_INITIALIZER;
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_fragment_add(client, &frags, &vars, "-I/opt/include", 0);
+
+	TEST_ASSERT_EQ(fragment_count(&frags), 1);
+
+	const pkgconf_fragment_t *f = fragment_at(&frags, 0);
+	TEST_ASSERT_NONNULL(f);
+	TEST_ASSERT_EQ(f->type, 'I');
+	TEST_ASSERT_STRCMP_EQ(f->data, "/opt/include");
+
+	pkgconf_fragment_free(&frags);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_fragment_render_cflags(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t frags = PKGCONF_LIST_INITIALIZER;
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_fragment_parse(client, &frags, &vars, "-I/usr/include -I/opt/include", 0);
+
+	char *rendered = render_to_string(&frags);
+	TEST_ASSERT_NONNULL(rendered);
+	TEST_ASSERT_STRCMP_EQ(rendered, "-I/usr/include -I/opt/include");
+
+	free(rendered);
+	pkgconf_fragment_free(&frags);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_fragment_render_libs(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t frags = PKGCONF_LIST_INITIALIZER;
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_fragment_parse(client, &frags, &vars, "-L/usr/lib -lfoo", 0);
+
+	char *rendered = render_to_string(&frags);
+	TEST_ASSERT_NONNULL(rendered);
+	TEST_ASSERT_STRCMP_EQ(rendered, "-L/usr/lib -lfoo");
+
+	free(rendered);
+	pkgconf_fragment_free(&frags);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_fragment_render_empty(void)
+{
+	pkgconf_list_t frags = PKGCONF_LIST_INITIALIZER;
+
+	char *rendered = render_to_string(&frags);
+	TEST_ASSERT_NONNULL(rendered);
+	TEST_ASSERT_EMPTY_STRING(rendered);
+
+	free(rendered);
+}
+
+// Filter predicate: keep only -I (include) fragments.
+static bool
+filter_only_includes(const pkgconf_client_t *client, const pkgconf_fragment_t *frag, void *data)
+{
+	(void) client;
+	(void) data;
+	return frag->type == 'I';
+}
+
+// Filter predicate: keep only -l (library name) fragments.
+static bool
+filter_only_libnames(const pkgconf_client_t *client, const pkgconf_fragment_t *frag, void *data)
+{
+	(void) client;
+	(void) data;
+	return frag->type == 'l';
+}
+
+// Filter predicate: keep nothing.
+static bool
+filter_nothing(const pkgconf_client_t *client, const pkgconf_fragment_t *frag, void *data)
+{
+	(void) client;
+	(void) frag;
+	(void) data;
+	return false;
+}
+
+static void
+test_fragment_filter_only_includes(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t src = PKGCONF_LIST_INITIALIZER;
+	pkgconf_list_t dst = PKGCONF_LIST_INITIALIZER;
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_fragment_parse(client, &src, &vars, "-I/usr/include -L/usr/lib -lfoo -I/opt/include", 0);
+
+	pkgconf_fragment_filter(client, &dst, &src, filter_only_includes, NULL);
+	TEST_ASSERT_EQ(fragment_count(&dst), 2);
+
+	const pkgconf_fragment_t *f0 = fragment_at(&dst, 0);
+	const pkgconf_fragment_t *f1 = fragment_at(&dst, 1);
+	TEST_ASSERT_NONNULL(f0);
+	TEST_ASSERT_NONNULL(f1);
+	TEST_ASSERT_EQ(f0->type, 'I');
+	TEST_ASSERT_STRCMP_EQ(f0->data, "/usr/include");
+	TEST_ASSERT_EQ(f1->type, 'I');
+	TEST_ASSERT_STRCMP_EQ(f1->data, "/opt/include");
+
+	pkgconf_fragment_free(&dst);
+	pkgconf_fragment_free(&src);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_fragment_filter_only_libnames(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t src = PKGCONF_LIST_INITIALIZER;
+	pkgconf_list_t dst = PKGCONF_LIST_INITIALIZER;
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_fragment_parse(client, &src, &vars, "-L/usr/lib -lfoo -lbar -I/usr/include", 0);
+
+	pkgconf_fragment_filter(client, &dst, &src, filter_only_libnames, NULL);
+
+	TEST_ASSERT_EQ(fragment_count(&dst), 2);
+
+	const pkgconf_fragment_t *f0 = fragment_at(&dst, 0);
+	const pkgconf_fragment_t *f1 = fragment_at(&dst, 1);
+	TEST_ASSERT_NONNULL(f0);
+	TEST_ASSERT_NONNULL(f1);
+	TEST_ASSERT_EQ(f0->type, 'l');
+	TEST_ASSERT_STRCMP_EQ(f0->data, "foo");
+	TEST_ASSERT_EQ(f1->type, 'l');
+	TEST_ASSERT_STRCMP_EQ(f1->data, "bar");
+
+	pkgconf_fragment_free(&dst);
+	pkgconf_fragment_free(&src);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_fragment_filter_keeps_nothing(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t src = PKGCONF_LIST_INITIALIZER;
+	pkgconf_list_t dst = PKGCONF_LIST_INITIALIZER;
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_fragment_parse(client, &src, &vars, "-I/usr/include -lfoo", 0);
+
+	pkgconf_fragment_filter(client, &dst, &src, filter_nothing, NULL);
+
+	TEST_ASSERT_EQ(fragment_count(&dst), 0);
+
+	pkgconf_fragment_free(&dst);
+	pkgconf_fragment_free(&src);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_fragment_has_system_dir_matches(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t frags = PKGCONF_LIST_INITIALIZER;
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_path_add("/usr/include", &client->filter_includedirs, false);
+
+	pkgconf_fragment_parse(client, &frags, &vars, "-I/usr/include -I/opt/include", 0);
+
+	const pkgconf_fragment_t *system = fragment_at(&frags, 0);
+	const pkgconf_fragment_t *other = fragment_at(&frags, 1);
+	TEST_ASSERT_NONNULL(system);
+	TEST_ASSERT_NONNULL(other);
+
+	TEST_ASSERT_TRUE(pkgconf_fragment_has_system_dir(client, system));
+	TEST_ASSERT_FALSE(pkgconf_fragment_has_system_dir(client, other));
+
+	pkgconf_fragment_free(&frags);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_fragment_has_system_dir_libs(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t frags = PKGCONF_LIST_INITIALIZER;
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_path_add("/usr/lib", &client->filter_libdirs, false);
+
+	pkgconf_fragment_parse(client, &frags, &vars, "-L/usr/lib -L/opt/lib", 0);
+
+	const pkgconf_fragment_t *system = fragment_at(&frags, 0);
+	const pkgconf_fragment_t *other = fragment_at(&frags, 1);
+	TEST_ASSERT_NONNULL(system);
+	TEST_ASSERT_NONNULL(other);
+
+	TEST_ASSERT_TRUE(pkgconf_fragment_has_system_dir(client, system));
+	TEST_ASSERT_FALSE(pkgconf_fragment_has_system_dir(client, other));
+
+	pkgconf_fragment_free(&frags);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+int
+main(int argc, char *argv[])
+{
+	(void) argc;
+	const char *basename = test_progname(argv[0]);
+
+	TEST_RUN(basename, test_fragment_parse_empty);
+	TEST_RUN(basename, test_fragment_parse_cflags);
+	TEST_RUN(basename, test_fragment_parse_libs);
+	TEST_RUN(basename, test_fragment_add_single);
+	TEST_RUN(basename, test_fragment_render_empty);
+	TEST_RUN(basename, test_fragment_render_cflags);
+	TEST_RUN(basename, test_fragment_render_libs);
+	TEST_RUN(basename, test_fragment_filter_only_includes);
+	TEST_RUN(basename, test_fragment_filter_only_libnames);
+	TEST_RUN(basename, test_fragment_filter_keeps_nothing);
+	TEST_RUN(basename, test_fragment_has_system_dir_matches);
+	TEST_RUN(basename, test_fragment_has_system_dir_libs);
+
+	return EXIT_SUCCESS; 
+}


### PR DESCRIPTION
This PR adds API tests for the fragment and dependency APIs. The API test macros are augmented with additional comparator macros to facilitate the dependency API checks.

References #488.