### PR TITLE
libpkgconf: various bugfixes

### DIFF
--- a/libpkgconf/buffer.c
+++ b/libpkgconf/buffer.c
@@ -472,6 +472,13 @@ bool
 pkgconf_buffer_subst(pkgconf_buffer_t *dest, const pkgconf_buffer_t *src, const char *pattern, const char *value)
 {
 	const char *iter = src->base;
+
+	if (pattern == NULL)
+		pattern = "";
+
+	if (value == NULL)
+		value = "";
+
 	size_t pattern_len = strlen(pattern);
 
 	if (!pkgconf_buffer_len(src))

--- a/libpkgconf/bytecode.c
+++ b/libpkgconf/bytecode.c
@@ -468,7 +468,7 @@ pkgconf_bytecode_references_var(const pkgconf_buffer_t *buf, const char *key)
 
 		if (op->tag == PKGCONF_BYTECODE_OP_VAR)
 		{
-			if (op->size == (uint32_t) klen && pkgconf_str_eq_slice(op->data, key, klen))
+			if (op->size == (uint32_t) klen && memcmp(op->data, key, klen) == 0)
 				return true;
 		}
 
@@ -489,7 +489,7 @@ pkgconf_bytecode_op_is_selfref(const pkgconf_bytecode_op_t *op, const char *key)
 	if (op->size != (uint32_t) klen)
 		return false;
 
-	return pkgconf_str_eq_slice(op->data, key, klen);
+	return memcmp(op->data, key, klen) == 0;
 }
 
 static bool

--- a/libpkgconf/dependency.c
+++ b/libpkgconf/dependency.c
@@ -176,6 +176,8 @@ pkgconf_dependency_add(pkgconf_client_t *client, pkgconf_list_t *list, const cha
 	pkgconf_dependency_t *dep;
 	dep = pkgconf_dependency_addraw(client, list, package, strlen(package), version,
 					version != NULL ? strlen(version) : 0, compare, flags);
+	if (dep == NULL)
+		return NULL;
 	return pkgconf_dependency_ref(dep->owner, dep);
 }
 


### PR DESCRIPTION
In the process of writing more tests to improve coverage, I found several bugs in libpkgconf:

* `pkgconf_dependency_add`: does not check if `pkgconf_dependency_addraw` returns `NULL`
* `pkgconf_buffer_subst`: does not check for `NULL` pointers
* `pkgconf_bytecode_references_var` and `pkgconf_bytecode_op_is_selfref`: using string comparison functions on non-`NULL` terminated bytecode bytestrings

This PR fixes them.