### PR TITLE
Add additional test coverage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -267,6 +267,7 @@ EXTRA_DIST =	pkg.m4 \
 		tests/api/test-client.c \
 		tests/api/test-dependency.c \
 		tests/api/test-fragment.c \
+		tests/api/test-license.c \
 		tests/api/test-path-utils.c \
 		tests/api/test-tuple.c \
 		tests/api/test-variable.c \
@@ -484,6 +485,7 @@ API_TEST_PROGS =		\
 	test-api-client		\
 	test-api-dependency	\
 	test-api-fragment	\
+	test-api-license	\
 	test-api-path-utils	\
 	test-api-tuple		\
 	test-api-variable
@@ -520,6 +522,10 @@ test_api_fragment_LDADD = $(api_test_ldadd)
 test_api_fragment_SOURCES = tests/api/test-fragment.c
 test_api_fragment_CPPFLAGS = $(api_test_cppflags)
 
+test_api_license_LDADD = $(api_test_ldadd)
+test_api_license_SOURCES = tests/api/test-license.c
+test_api_license_CPPFLAGS = $(api_test_cppflags)
+
 test_api_path_utils_LDADD = $(api_test_ldadd)
 test_api_path_utils_SOURCES = tests/api/test-path-utils.c
 test_api_path_utils_CPPFLAGS = $(api_test_cppflags)
@@ -545,6 +551,7 @@ check: pkgconf test-runner $(API_TEST_PROGS)
 	$(builddir)/test-api-client$(EXEEXT)
 	$(builddir)/test-api-dependency$(EXEEXT)
 	$(builddir)/test-api-fragment$(EXEEXT)
+	$(builddir)/test-api-license$(EXEEXT)
 	$(builddir)/test-api-path-utils$(EXEEXT)
 	$(builddir)/test-api-tuple$(EXEEXT)
 	$(builddir)/test-api-variable$(EXEEXT)

--- a/Makefile.am
+++ b/Makefile.am
@@ -262,6 +262,7 @@ EXTRA_DIST =	pkg.m4 \
 		t/tuple/duplicate-upsert.test \
 		t/tuple/empty-tuple.test \
 		tests/api/test-api.h \
+		tests/api/test-audit.c \
 		tests/api/test-buffer.c \
 		tests/api/test-bytecode.c \
 		tests/api/test-client.c \
@@ -480,6 +481,7 @@ spdxtool_SOURCES  = \
 spdxtool_CPPFLAGS = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/cli -I$(top_srcdir)/cli/spdxtool
 
 API_TEST_PROGS =		\
+	test-api-audit		\
 	test-api-buffer		\
 	test-api-bytecode	\
 	test-api-client		\
@@ -501,6 +503,10 @@ test_runner_SOURCES = \
 
 api_test_ldadd = libpkgconf.la
 api_test_cppflags = -I$(top_srcdir)/libpkgconf -I$(top_srcdir)/tests/api
+
+test_api_audit_LDADD = $(api_test_ldadd)
+test_api_audit_SOURCES = tests/api/test-audit.c
+test_api_audit_CPPFLAGS = $(api_test_cppflags)
 
 test_api_buffer_LDADD = $(api_test_ldadd)
 test_api_buffer_SOURCES = tests/api/test-buffer.c
@@ -546,6 +552,7 @@ m4data_DATA            = pkg.m4
 CLEANFILES =	$(EXTRA_PROGRAMS)
 
 check: pkgconf test-runner $(API_TEST_PROGS)
+	$(builddir)/test-api-audit$(EXEEXT)
 	$(builddir)/test-api-buffer$(EXEEXT)
 	$(builddir)/test-api-bytecode$(EXEEXT)
 	$(builddir)/test-api-client$(EXEEXT)

--- a/meson.build
+++ b/meson.build
@@ -220,6 +220,7 @@ api_tests = [
   'client',
   'dependency',
   'fragment',
+  'license',
   'path-utils',
   'tuple',
   'variable',

--- a/meson.build
+++ b/meson.build
@@ -215,6 +215,7 @@ test_runner_exe = executable('test-runner',
   install : false)
 
 api_tests = [
+  'audit',
   'buffer',
   'bytecode',
   'client',

--- a/tests/api/test-audit.c
+++ b/tests/api/test-audit.c
@@ -1,0 +1,171 @@
+/*
+ * test-audit.c
+ * Tests for the public libpkgconf audit API.
+ *
+ * SPDX-License-Identifier: pkgconf
+ *
+ * Copyright (c) 2026 pkgconf authors (see AUTHORS).
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * This software is provided 'as is' and without any warranty, express or
+ * implied.  In no event shall the authors be liable for any damages arising
+ * from the use of this software.
+ */
+
+#include "test-api.h"
+
+/*
+ * Read the entire contents of f (from the start) into buf.
+ * buf must be large enough; we keep test inputs small.
+ */
+static void
+slurp(FILE *f, char *buf, size_t bufsz)
+{
+	rewind(f);
+	size_t n = fread(buf, 1, bufsz - 1, f);
+	buf[n] = '\0';
+}
+
+static void
+test_audit_log_no_logfile_is_noop(void)
+{
+	pkgconf_client_t *client = test_client_new();
+
+	// With no audit log set, logging must be a silent no-op and must not crash.
+	pkgconf_audit_log(client, "should go nowhere\n");
+
+	pkgconf_client_free(client);
+}
+
+static void
+test_audit_set_log_and_write(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	FILE *logf = tmpfile();
+	TEST_ASSERT_NONNULL(logf);
+
+	pkgconf_audit_set_log(client, logf);
+	pkgconf_audit_log(client, "hello %s\n", "world");
+
+	char buf[256];
+	slurp(logf, buf, sizeof(buf));
+	TEST_ASSERT_STRCMP_EQ(buf, "hello world\n");
+
+	fclose(logf);
+	pkgconf_client_free(client);
+}
+
+static void
+test_audit_log_multiple_writes(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	FILE *logf = tmpfile();
+	TEST_ASSERT_NONNULL(logf);
+
+	pkgconf_audit_set_log(client, logf);
+	pkgconf_audit_log(client, "first\n");
+	pkgconf_audit_log(client, "second %d\n", 2);
+
+	char buf[256];
+	slurp(logf, buf, sizeof(buf));
+	TEST_ASSERT_STRCMP_EQ(buf, "first\nsecond 2\n");
+
+	fclose(logf);
+	pkgconf_client_free(client);
+}
+
+static void
+test_audit_log_dependency_versionless(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	FILE *logf = tmpfile();
+	TEST_ASSERT_NONNULL(logf);
+
+	pkgconf_audit_set_log(client, logf);
+
+	// A minimal package: only the fields the logger reads
+	pkgconf_pkg_t pkg = { 0 };
+	pkg.id = (char *) "foo";
+	pkg.version = (char *) "1.2.3";
+
+	/* A dependency with PKGCONF_CMP_ANY and no version: the logger
+	 * should emit only "id [version]", skipping the comparator */
+	pkgconf_dependency_t dep = { 0 };
+	dep.compare = PKGCONF_CMP_ANY;
+	dep.version = NULL;
+
+	pkgconf_audit_log_dependency(client, &pkg, &dep);
+
+	char buf[256];
+	slurp(logf, buf, sizeof(buf));
+	TEST_ASSERT_STRCMP_EQ(buf, "foo [1.2.3]\n");
+
+	fclose(logf);
+	pkgconf_client_free(client);
+}
+
+static void
+test_audit_log_dependency_versioned(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	FILE *logf = tmpfile();
+	TEST_ASSERT_NONNULL(logf);
+
+	pkgconf_audit_set_log(client, logf);
+
+	pkgconf_pkg_t pkg = { 0 };
+	pkg.id = (char *) "bar";
+	pkg.version = (char *) "2.0";
+
+	/* version set AND compare != ANY: the logger emits the
+	 * comparator and required version between id and [version] */
+	pkgconf_dependency_t dep = { 0 };
+	dep.compare = PKGCONF_CMP_GREATER_THAN_EQUAL;
+	dep.version = (char *) "1.5";
+
+	pkgconf_audit_log_dependency(client, &pkg, &dep);
+
+	char buf[256];
+	slurp(logf, buf, sizeof(buf));
+	TEST_ASSERT_STRCMP_EQ(buf, "bar >= 1.5 [2.0]\n");
+
+	fclose(logf);
+	pkgconf_client_free(client);
+}
+
+static void
+test_audit_log_dependency_no_logfile_is_noop(void)
+{
+	pkgconf_client_t *client = test_client_new();
+
+	pkgconf_pkg_t pkg = { 0 };
+	pkg.id = (char *) "foo";
+	pkg.version = (char *) "1.0";
+
+	pkgconf_dependency_t dep = { 0 };
+	dep.compare = PKGCONF_CMP_ANY;
+
+	// No log set: must be a silent no-op
+	pkgconf_audit_log_dependency(client, &pkg, &dep);
+
+	pkgconf_client_free(client);
+}
+
+int
+main(int argc, char *argv[])
+{
+	(void) argc;
+	const char *basename = test_progname(argv[0]);
+
+	TEST_RUN(basename, test_audit_log_no_logfile_is_noop);
+	TEST_RUN(basename, test_audit_set_log_and_write);
+	TEST_RUN(basename, test_audit_log_multiple_writes);
+	TEST_RUN(basename, test_audit_log_dependency_versionless);
+	TEST_RUN(basename, test_audit_log_dependency_versioned);
+	TEST_RUN(basename, test_audit_log_dependency_no_logfile_is_noop);
+
+	return EXIT_SUCCESS;
+}

--- a/tests/api/test-buffer.c
+++ b/tests/api/test-buffer.c
@@ -216,8 +216,14 @@ test_buffer_match(void)
 	pkgconf_buffer_append(&b, "identical");
 	TEST_ASSERT_TRUE(pkgconf_buffer_match(&a, &b));
 
+	// Identical length, but different contents
 	pkgconf_buffer_reset(&b);
 	pkgconf_buffer_append(&b, "different");
+	TEST_ASSERT_FALSE(pkgconf_buffer_match(&a, &b));
+
+	// Different length and contents
+	pkgconf_buffer_reset(&b);
+	pkgconf_buffer_append(&b, "different!");
 	TEST_ASSERT_FALSE(pkgconf_buffer_match(&a, &b));
 
 	pkgconf_buffer_finalize(&a);
@@ -255,6 +261,42 @@ test_buffer_subst(void)
 
 	pkgconf_buffer_finalize(&src);
 	pkgconf_buffer_finalize(&dst);
+}
+
+static void
+test_buffer_subst_empty_pattern(void)
+{
+	pkgconf_buffer_t src = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_buffer_t dst0 = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_buffer_t dst1 = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_buffer_t dst2 = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_buffer_t dst3 = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_buffer_t dst4 = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_buffer_t dst5 = PKGCONF_BUFFER_INITIALIZER;
+
+	pkgconf_buffer_append(&src, "prefix=${PREFIX}/share");
+
+	TEST_ASSERT_TRUE(pkgconf_buffer_subst(&dst0, &src, "", "foo"));
+	TEST_ASSERT_TRUE(pkgconf_buffer_subst(&dst1, &src, "", ""));
+	TEST_ASSERT_TRUE(pkgconf_buffer_subst(&dst2, &src, "", NULL));
+	TEST_ASSERT_TRUE(pkgconf_buffer_subst(&dst3, &src, NULL, "foo"));
+	TEST_ASSERT_TRUE(pkgconf_buffer_subst(&dst4, &src, NULL, ""));
+	TEST_ASSERT_TRUE(pkgconf_buffer_subst(&dst5, &src, NULL, NULL));
+
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&dst0), "prefix=${PREFIX}/share");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&dst1), "prefix=${PREFIX}/share");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&dst2), "prefix=${PREFIX}/share");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&dst3), "prefix=${PREFIX}/share");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&dst4), "prefix=${PREFIX}/share");
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&dst5), "prefix=${PREFIX}/share");
+
+	pkgconf_buffer_finalize(&src);
+	pkgconf_buffer_finalize(&dst0);
+	pkgconf_buffer_finalize(&dst1);
+	pkgconf_buffer_finalize(&dst2);
+	pkgconf_buffer_finalize(&dst3);
+	pkgconf_buffer_finalize(&dst4);
+	pkgconf_buffer_finalize(&dst5);
 }
 
 static void
@@ -299,6 +341,49 @@ test_span_contains(void)
 	TEST_ASSERT_FALSE(pkgconf_span_contains('!', spans, PKGCONF_ARRAY_SIZE(spans)));
 }
 
+static void
+test_buffer_fputs_nonempty(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+	FILE *f = tmpfile();
+	TEST_ASSERT_NONNULL(f);
+
+	pkgconf_buffer_append(&buf, "hello world");
+	TEST_ASSERT_TRUE(pkgconf_buffer_fputs(&buf, f));
+
+	char out[64];
+	rewind(f);
+	size_t n = fread(out, 1, sizeof(out) - 1, f);
+	out[n] = '\0';
+
+	// Buffer contents followed by a newline.
+	TEST_ASSERT_STRCMP_EQ(out, "hello world\n");
+
+	fclose(f);
+	pkgconf_buffer_finalize(&buf);
+}
+
+static void
+test_buffer_fputs_empty(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+	FILE *f = tmpfile();
+	TEST_ASSERT_NONNULL(f);
+
+	// An empty buffer writes only a newline.
+	TEST_ASSERT_TRUE(pkgconf_buffer_fputs(&buf, f));
+
+	char out[64];
+	rewind(f);
+	size_t n = fread(out, 1, sizeof(out) - 1, f);
+	out[n] = '\0';
+
+	TEST_ASSERT_STRCMP_EQ(out, "\n");
+
+	fclose(f);
+	pkgconf_buffer_finalize(&buf);
+}
+
 int
 main(int argc, const char **argv)
 {
@@ -321,9 +406,12 @@ main(int argc, const char **argv)
 	TEST_RUN(basename, test_buffer_match);
 	TEST_RUN(basename, test_buffer_has_prefix);
 	TEST_RUN(basename, test_buffer_subst);
+	TEST_RUN(basename, test_buffer_subst_empty_pattern);
 	TEST_RUN(basename, test_buffer_escape);
 	TEST_RUN(basename, test_str_eq_slice);
 	TEST_RUN(basename, test_span_contains);
+	TEST_RUN(basename, test_buffer_fputs_nonempty);
+	TEST_RUN(basename, test_buffer_fputs_empty);
 
 	return EXIT_SUCCESS;
 }

--- a/tests/api/test-bytecode.c
+++ b/tests/api/test-bytecode.c
@@ -40,6 +40,387 @@ seed_variable(pkgconf_list_t *vars, const char *key, const char *value)
 }
 
 static void
+test_emit_text_and_eval(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	pkgconf_buffer_t bcbuf = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_bytecode_t bc;
+	bool saw_sysroot = false;
+
+	TEST_ASSERT_TRUE(pkgconf_bytecode_emit_text(&bcbuf, "plain", 5));
+	pkgconf_bytecode_from_buffer(&bc, &bcbuf);
+
+	pkgconf_buffer_t out = PKGCONF_BUFFER_INITIALIZER;
+	TEST_ASSERT_TRUE(pkgconf_bytecode_eval(client, &vars, &bc, &out, &saw_sysroot));
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str_or_empty(&out), "plain");
+
+	pkgconf_buffer_finalize(&out);
+	pkgconf_buffer_finalize(&bcbuf);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_emit_guards(void)
+{
+	pkgconf_buffer_t bcbuf = PKGCONF_BUFFER_INITIALIZER;
+
+	TEST_ASSERT_TRUE(pkgconf_bytecode_emit_text(&bcbuf, NULL, 5));
+	TEST_ASSERT_TRUE(pkgconf_bytecode_emit_text(&bcbuf, "x", 0));
+	TEST_ASSERT_TRUE(pkgconf_bytecode_emit_var(&bcbuf, NULL, 3));
+	TEST_ASSERT_TRUE(pkgconf_bytecode_emit_var(&bcbuf, "x", 0));
+
+	TEST_ASSERT_EQ(pkgconf_buffer_len(&bcbuf), 0);
+
+	pkgconf_buffer_finalize(&bcbuf);
+}
+
+static void
+test_emit_var_and_eval(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	pkgconf_buffer_t bcbuf = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_bytecode_t bc;
+	bool saw_sysroot = false;
+
+	seed_variable(&vars, "name", "world");
+
+	TEST_ASSERT_TRUE(pkgconf_bytecode_emit_text(&bcbuf, "hello ", 6));
+	TEST_ASSERT_TRUE(pkgconf_bytecode_emit_var(&bcbuf, "name", 4));
+	pkgconf_bytecode_from_buffer(&bc, &bcbuf);
+
+	pkgconf_buffer_t out = PKGCONF_BUFFER_INITIALIZER;
+	TEST_ASSERT_TRUE(pkgconf_bytecode_eval(client, &vars, &bc, &out, &saw_sysroot));
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str_or_empty(&out), "hello world");
+
+	pkgconf_buffer_finalize(&out);
+	pkgconf_buffer_finalize(&bcbuf);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_emit_sysroot_and_eval(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	pkgconf_buffer_t bcbuf = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_bytecode_t bc;
+	bool saw_sysroot = false;
+
+	pkgconf_client_set_sysroot_dir(client, "/sysroot");
+
+	TEST_ASSERT_TRUE(pkgconf_bytecode_emit_sysroot(&bcbuf));
+	TEST_ASSERT_TRUE(pkgconf_bytecode_emit_text(&bcbuf, "/usr/include", 12));
+	pkgconf_bytecode_from_buffer(&bc, &bcbuf);
+
+	pkgconf_buffer_t out = PKGCONF_BUFFER_INITIALIZER;
+	TEST_ASSERT_TRUE(pkgconf_bytecode_eval(client, &vars, &bc, &out, &saw_sysroot));
+	TEST_ASSERT_TRUE(saw_sysroot);
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str_or_empty(&out), "/sysroot/usr/include");
+
+	pkgconf_buffer_finalize(&out);
+	pkgconf_buffer_finalize(&bcbuf);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_eval_null_args(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	pkgconf_buffer_t out = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_bytecode_t bc = { NULL, 0 };
+
+	// NULL client, bc, or out all return false.
+	TEST_ASSERT_FALSE(pkgconf_bytecode_eval(NULL, &vars, &bc, &out, NULL));
+	TEST_ASSERT_FALSE(pkgconf_bytecode_eval(client, &vars, NULL, &out, NULL));
+	TEST_ASSERT_FALSE(pkgconf_bytecode_eval(client, &vars, &bc, NULL, NULL));
+
+	pkgconf_buffer_finalize(&out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_compile_null_args(void)
+{
+	pkgconf_buffer_t out = PKGCONF_BUFFER_INITIALIZER;
+
+	TEST_ASSERT_FALSE(pkgconf_bytecode_compile(NULL, "x"));
+	TEST_ASSERT_FALSE(pkgconf_bytecode_compile(&out, NULL));
+
+	pkgconf_buffer_finalize(&out);
+}
+
+static void
+test_dollar_escape(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	// $$ collapses to a literal $; the following text is NOT treated as a variable reference
+	char *out = pkgconf_bytecode_eval_str(client, &vars, "price: $$5 and $${notavar}", &saw_sysroot);
+	TEST_ASSERT_NONNULL(out);
+	TEST_ASSERT_STRCMP_EQ(out, "price: $5 and ${notavar}");
+
+	free(out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_malformed_unclosed(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	// A ${ with no closing } is emitted as literal text
+	char *out = pkgconf_bytecode_eval_str(client, &vars, "broken ${unclosed", &saw_sysroot);
+	TEST_ASSERT_NONNULL(out);
+	TEST_ASSERT_STRCMP_EQ(out, "broken ${unclosed");
+
+	free(out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_empty_braces(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	// ${} has a zero-length name; it's emitted as literal text rather than treated as a variable
+	char *out = pkgconf_bytecode_eval_str(client, &vars, "empty ${} here", &saw_sysroot);
+	TEST_ASSERT_NONNULL(out);
+	TEST_ASSERT_STRCMP_EQ(out, "empty ${} here");
+
+	free(out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_compile_time_sysroot(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	pkgconf_client_set_sysroot_dir(client, "/sysroot");
+
+	// ${pc_sysrootdir} is special-cased at compile time into an OP_SYSROOT op rather than a variable lookup
+	char *out = pkgconf_bytecode_eval_str(client, &vars, "${pc_sysrootdir}/usr/lib", &saw_sysroot);
+	TEST_ASSERT_NONNULL(out);
+	TEST_ASSERT_TRUE(saw_sysroot);
+	TEST_ASSERT_STRCMP_EQ(out, "/sysroot/usr/lib");
+
+	free(out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_sysroot_dot_disables(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	// A sysroot of "." disables sysroot rewriting: ${pc_sysrootdir} expands to empty
+	pkgconf_client_set_sysroot_dir(client, ".");
+
+	char *out = pkgconf_bytecode_eval_str(client, &vars, "${pc_sysrootdir}/usr/lib", &saw_sysroot);
+	TEST_ASSERT_NONNULL(out);
+	TEST_ASSERT_STRCMP_EQ(out, "/usr/lib");
+
+	free(out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_sysroot_root_disables(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	// A sysroot of "/" (the root dir) disables rewriting.
+	pkgconf_client_set_sysroot_dir(client, "/");
+
+	char *out = pkgconf_bytecode_eval_str(client, &vars, "${pc_sysrootdir}/usr/lib", &saw_sysroot);
+	TEST_ASSERT_NONNULL(out);
+	TEST_ASSERT_STRCMP_EQ(out, "/usr/lib");
+
+	free(out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_sysroot_trailing_slash_trimmed(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	// Trailing slashes on the sysroot are normalized away, so the result doesn't get a doubled slash
+	pkgconf_client_set_sysroot_dir(client, "/sysroot///");
+
+	char *out = pkgconf_bytecode_eval_str(client, &vars, "${pc_sysrootdir}/usr/lib", &saw_sysroot);
+	TEST_ASSERT_NONNULL(out);
+	TEST_ASSERT_TRUE(saw_sysroot);
+	TEST_ASSERT_STRCMP_EQ(out, "/sysroot/usr/lib");
+
+	free(out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_sysroot_normalizes_to_root_disables(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	/* A sysroot of "//" survives the bare-"/" early check but normalizes down to "/" after
+	 * trailing-slash trimming, which then disables rewriting (empty sysroot) */
+	pkgconf_client_set_sysroot_dir(client, "//");
+
+	char *out = pkgconf_bytecode_eval_str(client, &vars, "${pc_sysrootdir}/usr/lib", &saw_sysroot);
+	TEST_ASSERT_NONNULL(out);
+	TEST_ASSERT_STRCMP_EQ(out, "/usr/lib");
+
+	free(out);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_circular_reference(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	// A variable that references itself must not infinite-loop: the `expanding` guard breaks the cycle
+	seed_variable(&vars, "loop", "${loop}");
+
+	char *out = pkgconf_bytecode_eval_str(client, &vars, "${loop}", &saw_sysroot);
+
+	/* The self-reference is broken; behavior is "expands to nothing further"
+	 * We mostly care that it returns rather than hanging or crashing */
+	if (out != NULL)
+		free(out);
+
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_references_var(void)
+{
+	pkgconf_buffer_t bcbuf = PKGCONF_BUFFER_INITIALIZER;
+
+	pkgconf_bytecode_compile(&bcbuf, "-I${includedir} -L${libdir}");
+
+	TEST_ASSERT_TRUE(pkgconf_bytecode_references_var(&bcbuf, "includedir"));
+	TEST_ASSERT_TRUE(pkgconf_bytecode_references_var(&bcbuf, "libdir"));
+	TEST_ASSERT_FALSE(pkgconf_bytecode_references_var(&bcbuf, "prefix"));
+
+	TEST_ASSERT_FALSE(pkgconf_bytecode_references_var(NULL, "x"));
+	TEST_ASSERT_FALSE(pkgconf_bytecode_references_var(&bcbuf, NULL));
+
+	pkgconf_buffer_finalize(&bcbuf);
+}
+
+static void
+test_references_var_text_only(void)
+{
+	pkgconf_buffer_t bcbuf = PKGCONF_BUFFER_INITIALIZER;
+
+	pkgconf_bytecode_compile(&bcbuf, "just plain text");
+
+	TEST_ASSERT_FALSE(pkgconf_bytecode_references_var(&bcbuf, "anything"));
+
+	pkgconf_buffer_finalize(&bcbuf);
+}
+
+static void
+test_rewrite_selfrefs(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	pkgconf_buffer_t prev = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_bytecode_compile(&prev, "old");
+
+	pkgconf_buffer_t rhs = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_bytecode_compile(&rhs, "${foo} new");
+
+	pkgconf_buffer_t rewritten = PKGCONF_BUFFER_INITIALIZER;
+	TEST_ASSERT_TRUE(pkgconf_bytecode_rewrite_selfrefs(&rewritten, &rhs, "foo", &prev));
+
+	pkgconf_bytecode_t bc;
+	pkgconf_bytecode_from_buffer(&bc, &rewritten);
+
+	pkgconf_buffer_t out = PKGCONF_BUFFER_INITIALIZER;
+	TEST_ASSERT_TRUE(pkgconf_bytecode_eval(client, &vars, &bc, &out, &saw_sysroot));
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str_or_empty(&out), "old new");
+
+	pkgconf_buffer_finalize(&out);
+	pkgconf_buffer_finalize(&rewritten);
+	pkgconf_buffer_finalize(&rhs);
+	pkgconf_buffer_finalize(&prev);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
+test_rewrite_selfrefs_no_match(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
+	bool saw_sysroot = false;
+
+	pkgconf_buffer_t prev = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_bytecode_compile(&prev, "PREV");
+
+	pkgconf_buffer_t rhs = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_bytecode_compile(&rhs, "${other} tail");
+
+	pkgconf_buffer_t rewritten = PKGCONF_BUFFER_INITIALIZER;
+	TEST_ASSERT_TRUE(pkgconf_bytecode_rewrite_selfrefs(&rewritten, &rhs, "foo", &prev));
+
+	// ${other} survives; seed it so eval can resolve it
+	seed_variable(&vars, "other", "OTHER");
+
+	pkgconf_bytecode_t bc;
+	pkgconf_bytecode_from_buffer(&bc, &rewritten);
+
+	pkgconf_buffer_t out = PKGCONF_BUFFER_INITIALIZER;
+	TEST_ASSERT_TRUE(pkgconf_bytecode_eval(client, &vars, &bc, &out, &saw_sysroot));
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str_or_empty(&out), "OTHER tail");
+
+	pkgconf_buffer_finalize(&out);
+	pkgconf_buffer_finalize(&rewritten);
+	pkgconf_buffer_finalize(&rhs);
+	pkgconf_buffer_finalize(&prev);
+	pkgconf_variable_list_free(&vars);
+	pkgconf_client_free(client);
+}
+
+static void
 test_eval_plain_text(void)
 {
 	pkgconf_client_t *client = test_client_new();
@@ -199,8 +580,7 @@ test_compile_eval_roundtrip(void)
 	pkgconf_list_t vars = PKGCONF_LIST_INITIALIZER;
 	bool saw_sysroot = false;
 
-	/* Compile directly, then evaluate via the bc field on a variable.
-	 * This is what the parser does internally for every .pc field. */
+	// Compile directly, then evaluate via the bc field on a variable
 	seed_variable(&vars, "name", "world");
 
 	pkgconf_variable_t *v = pkgconf_variable_get_or_create(&vars, "greeting");
@@ -222,17 +602,42 @@ int
 main(int argc, char *argv[])
 {
 	(void) argc;
-	const char *name = test_progname(argv[0]);
+	const char *basename = test_progname(argv[0]);
 
-	TEST_RUN(name, test_compile_produces_nonempty_buffer);
-	TEST_RUN(name, test_eval_plain_text);
-	TEST_RUN(name, test_eval_empty_input);
-	TEST_RUN(name, test_eval_variable_substitution);
-	TEST_RUN(name, test_eval_nested_variables);
-	TEST_RUN(name, test_eval_multiple_variables);
-	TEST_RUN(name, test_eval_undefined_variable);
-	TEST_RUN(name, test_eval_sysroot_detection);
-	TEST_RUN(name, test_compile_eval_roundtrip);
+	TEST_RUN(basename, test_eval_plain_text);
+	TEST_RUN(basename, test_eval_empty_input);
+	TEST_RUN(basename, test_eval_variable_substitution);
+	TEST_RUN(basename, test_eval_nested_variables);
+	TEST_RUN(basename, test_eval_multiple_variables);
+	TEST_RUN(basename, test_eval_undefined_variable);
+	TEST_RUN(basename, test_eval_sysroot_detection);
+	TEST_RUN(basename, test_eval_null_args);
+
+	TEST_RUN(basename, test_emit_guards);
+	TEST_RUN(basename, test_emit_text_and_eval);
+	TEST_RUN(basename, test_emit_var_and_eval);
+	TEST_RUN(basename, test_emit_sysroot_and_eval);
+
+	TEST_RUN(basename, test_dollar_escape);
+	TEST_RUN(basename, test_malformed_unclosed);
+	TEST_RUN(basename, test_empty_braces);
+
+	TEST_RUN(basename, test_circular_reference);
+	TEST_RUN(basename, test_references_var);
+	TEST_RUN(basename, test_references_var_text_only);
+
+	TEST_RUN(basename, test_compile_time_sysroot);
+	TEST_RUN(basename, test_sysroot_dot_disables);
+	TEST_RUN(basename, test_sysroot_root_disables);
+	TEST_RUN(basename, test_sysroot_trailing_slash_trimmed);
+	TEST_RUN(basename, test_sysroot_normalizes_to_root_disables);
+
+	TEST_RUN(basename, test_rewrite_selfrefs);
+	TEST_RUN(basename, test_rewrite_selfrefs_no_match);
+
+	TEST_RUN(basename, test_compile_eval_roundtrip);
+	TEST_RUN(basename, test_compile_produces_nonempty_buffer);
+	TEST_RUN(basename, test_compile_null_args);
 
 	return EXIT_SUCCESS;
 }

--- a/tests/api/test-client.c
+++ b/tests/api/test-client.c
@@ -17,6 +17,11 @@
 
 #include "test-api.h"
 
+#ifdef _WIN32
+#	define setenv(n, v, o) _putenv_s(n, v)
+#	define unsetenv(n) _putenv_s(n, "")
+#endif
+
 static void
 test_client_new_and_free(void)
 {

--- a/tests/api/test-client.c
+++ b/tests/api/test-client.c
@@ -210,6 +210,10 @@ canned_environ_handler(const pkgconf_client_t *client, const char *key)
 		return "the_value";
 	if (!strcmp(key, "EMPTY_VAR"))
 		return "";
+	if (!strcmp(key, "PKG_CONFIG_SYSTEM_INCLUDE_PATH"))
+		return "/custom/include";
+	if (!strcmp(key, "PKG_CONFIG_SYSTEM_LIBRARY_PATH"))
+		return "/custom/lib";
 
 	return NULL;
 }
@@ -253,6 +257,48 @@ test_client_dir_list_build_smoke(void)
 	pkgconf_client_free(client);
 }
 
+static void
+test_client_init_system_paths_from_environ(void)
+{
+	pkgconf_cross_personality_t *pers = pkgconf_cross_personality_default();
+	pkgconf_client_t *client = pkgconf_client_new(NULL, NULL, pers, NULL, canned_environ_handler);
+	TEST_ASSERT_NONNULL(client);
+
+	/* With PKG_CONFIG_SYSTEM_{INCLUDE,LIBRARY}_PATH set, init builds the filter dirs from the 
+	 * environment instead of copying the personality's defaults. */
+	TEST_ASSERT_TRUE(pkgconf_path_match_list("/custom/include", &client->filter_includedirs));
+	TEST_ASSERT_TRUE(pkgconf_path_match_list("/custom/lib", &client->filter_libdirs));
+
+	pkgconf_client_free(client);
+}
+
+static void
+test_client_preload_from_environ(void)
+{
+	pkgconf_cross_personality_t *pers = pkgconf_cross_personality_default();
+	pkgconf_client_t *client = pkgconf_client_new(NULL, NULL, pers, NULL, NULL);
+	TEST_ASSERT_NONNULL(client);
+
+	/* preload_from_environ reads the named var via getenv directly.
+	 * Point it at a dir; preload_path will try to load .pc files from there.
+	 * An empty/nonexistent dir is fine; we're exercising the split-and-iterate path, not asserting
+	 * loads. */
+	setenv("PKG_TEST_PRELOAD", "/nonexistent/dir", 1);
+
+	pkgconf_client_preload_from_environ(client, "PKG_TEST_PRELOAD");
+
+	unsetenv("PKG_TEST_PRELOAD");
+	pkgconf_client_free(client);
+}
+
+#ifndef PKGCONF_LITE
+static void
+test_client_trace_null_client(void)
+{
+	TEST_ASSERT_FALSE(pkgconf_trace(NULL, "test.c", 42, "func", "msg %d", 42));
+}
+#endif
+
 int
 main(int argc, char *argv[])
 {
@@ -261,6 +307,8 @@ main(int argc, char *argv[])
 
 	TEST_RUN(basename, test_client_new_and_free);
 	TEST_RUN(basename, test_client_init_and_deinit_stack);
+	TEST_RUN(basename, test_client_init_system_paths_from_environ);
+	TEST_RUN(basename, test_client_preload_from_environ);
 
 	TEST_RUN(basename, test_client_sysroot_dir);
 	TEST_RUN(basename, test_client_buildroot_dir);
@@ -277,6 +325,10 @@ main(int argc, char *argv[])
 	TEST_RUN(basename, test_client_getenv_via_handler);
 
 	TEST_RUN(basename, test_client_dir_list_build_smoke);
+
+#ifndef PKGCONF_LITE
+	TEST_RUN(basename, test_client_trace_null_client);
+#endif
 
 	return EXIT_SUCCESS;
 }

--- a/tests/api/test-dependency.c
+++ b/tests/api/test-dependency.c
@@ -416,6 +416,50 @@ test_version_trailing_zero_segments(void)
 	TEST_ASSERT_LT(pkgconf_compare_version("1", "1.0.0.0"), 0);
 }
 
+static void
+test_version_null_handling(void)
+{
+	TEST_ASSERT_LT(pkgconf_compare_version(NULL, "1.0"), 0);
+	TEST_ASSERT_GT(pkgconf_compare_version("1.0", NULL), 0);
+	TEST_ASSERT_LT(pkgconf_compare_version(NULL, NULL), 0);
+}
+
+static void
+test_version_tilde_both_sides(void)
+{
+	TEST_ASSERT_LT(pkgconf_compare_version("1.0~", "1.0a"), 0);
+	TEST_ASSERT_GT(pkgconf_compare_version("1.0a", "1.0~"), 0);
+
+	TEST_ASSERT_EQ(pkgconf_compare_version("1.0~rc", "1.0~rc"), 0);
+	TEST_ASSERT_LT(pkgconf_compare_version("1.0~a", "1.0~b"), 0);
+	TEST_ASSERT_LT(pkgconf_compare_version("1.0~1", "1.0~2"), 0);
+}
+
+static void
+test_version_separator_equivalence(void)
+{
+	TEST_ASSERT_EQ(pkgconf_compare_version("1.0", "1-0"), 0);
+	TEST_ASSERT_EQ(pkgconf_compare_version("1.2.3", "1_2_3"), 0);
+	TEST_ASSERT_EQ(pkgconf_compare_version("1..2", "1.2"), 0);
+}
+
+static void
+test_version_case_insensitive(void)
+{
+	TEST_ASSERT_EQ(pkgconf_compare_version("1.0RC1", "1.0rc1"), 0);
+	TEST_ASSERT_EQ(pkgconf_compare_version("1.0A", "1.0a"), 0);
+}
+
+static void
+test_version_alpha_prefix(void)
+{
+	TEST_ASSERT_LT(pkgconf_compare_version("1.0alpha", "1.0alphabeta"), 0);
+	TEST_ASSERT_GT(pkgconf_compare_version("1.0alphabeta", "1.0alpha"), 0);
+
+	TEST_ASSERT_LT(pkgconf_compare_version("1.0a", "1.0ab"), 0);
+	TEST_ASSERT_GT(pkgconf_compare_version("1.0ab", "1.0a"), 0);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -449,6 +493,11 @@ main(int argc, char *argv[])
 	TEST_RUN(basename, test_version_dotted_vs_hyphenated);
 	TEST_RUN(basename, test_version_leading_zeros);
 	TEST_RUN(basename, test_version_trailing_zero_segments);
+	TEST_RUN(basename, test_version_null_handling);
+	TEST_RUN(basename, test_version_tilde_both_sides);
+	TEST_RUN(basename, test_version_separator_equivalence);
+	TEST_RUN(basename, test_version_case_insensitive);
+	TEST_RUN(basename, test_version_alpha_prefix);
 
 	return EXIT_SUCCESS;
 }

--- a/tests/api/test-dependency.c
+++ b/tests/api/test-dependency.c
@@ -348,7 +348,8 @@ test_dependency_collision_drops_flagged_existing(void)
 	pkgconf_client_t *client = test_client_new();
 	pkgconf_list_t deps = PKGCONF_LIST_INITIALIZER;
 
-	pkgconf_dependency_add(client, &deps, "foo", "1.0", PKGCONF_CMP_EQUAL, PKGCONF_PKG_DEPF_INTERNAL);
+	pkgconf_dependency_t *first = pkgconf_dependency_add(client, &deps, "foo", "1.0", PKGCONF_CMP_EQUAL, PKGCONF_PKG_DEPF_INTERNAL);
+	TEST_ASSERT_NONNULL(first);
 	TEST_ASSERT_EQ(dependency_count(&deps), 1);
 
 	/* Adding the same dep UNFLAGGED collides; the existing flagged
@@ -359,6 +360,7 @@ test_dependency_collision_drops_flagged_existing(void)
 	TEST_ASSERT_EQ(dependency_count(&deps), 1);
 	TEST_ASSERT_EQ(second->flags, 0);
 
+	pkgconf_dependency_unref(client, first);
 	pkgconf_dependency_unref(client, second);
 	pkgconf_dependency_free(&deps);
 	pkgconf_client_free(client);

--- a/tests/api/test-dependency.c
+++ b/tests/api/test-dependency.c
@@ -321,6 +321,50 @@ test_dependency_add_multiple(void)
 }
 
 static void
+test_dependency_collision_drops_flagged_newcomer(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t deps = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_dependency_t *first = pkgconf_dependency_add(client, &deps, "foo", "1.0", PKGCONF_CMP_EQUAL, 0);
+	TEST_ASSERT_NONNULL(first);
+	TEST_ASSERT_EQ(dependency_count(&deps), 1);
+
+	/* Adding the same dep WITH flags collides; the flagged newcomer
+	 * is dropped in favour of the existing unflagged node, so _add
+	 * returns NULL and the count stays at 1 */
+	pkgconf_dependency_t *second = pkgconf_dependency_add(client, &deps, "foo", "1.0", PKGCONF_CMP_EQUAL, PKGCONF_PKG_DEPF_INTERNAL);
+	TEST_ASSERT_NULL(second);
+	TEST_ASSERT_EQ(dependency_count(&deps), 1);
+
+	pkgconf_dependency_unref(client, first);
+	pkgconf_dependency_free(&deps);
+	pkgconf_client_free(client);
+}
+
+static void
+test_dependency_collision_drops_flagged_existing(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t deps = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_dependency_add(client, &deps, "foo", "1.0", PKGCONF_CMP_EQUAL, PKGCONF_PKG_DEPF_INTERNAL);
+	TEST_ASSERT_EQ(dependency_count(&deps), 1);
+
+	/* Adding the same dep UNFLAGGED collides; the existing flagged
+	 * node is deleted and unref'd, the unflagged newcomer takes its
+	 * place; count stays at 1, but the node is now the new one */
+	pkgconf_dependency_t *second = pkgconf_dependency_add(client, &deps, "foo", "1.0", PKGCONF_CMP_EQUAL, 0);
+	TEST_ASSERT_NONNULL(second);
+	TEST_ASSERT_EQ(dependency_count(&deps), 1);
+	TEST_ASSERT_EQ(second->flags, 0);
+
+	pkgconf_dependency_unref(client, second);
+	pkgconf_dependency_free(&deps);
+	pkgconf_client_free(client);
+}
+
+static void
 test_version_equal(void)
 {
 	TEST_ASSERT_EQ(pkgconf_compare_version("1.0", "1.0"), 0);
@@ -481,6 +525,8 @@ main(int argc, char *argv[])
 	TEST_RUN(basename, test_dependency_add);
 	TEST_RUN(basename, test_dependency_add_no_version);
 	TEST_RUN(basename, test_dependency_add_multiple);
+	TEST_RUN(basename, test_dependency_collision_drops_flagged_newcomer);
+	TEST_RUN(basename, test_dependency_collision_drops_flagged_existing);
 
 	TEST_RUN(basename, test_version_equal);
 	TEST_RUN(basename, test_version_simple_numeric);

--- a/tests/api/test-license.c
+++ b/tests/api/test-license.c
@@ -1,0 +1,268 @@
+/*
+ * test-license.c
+ * Tests for the public libpkgconf license API.
+ *
+ * SPDX-License-Identifier: pkgconf
+ *
+ * Copyright (c) 2026 pkgconf authors (see AUTHORS).
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * This software is provided 'as is' and without any warranty, express or
+ * implied.  In no event shall the authors be liable for any damages arising
+ * from the use of this software.
+ */
+
+#include "test-api.h"
+
+static size_t
+license_count(const pkgconf_list_t *list)
+{
+	size_t n = 0;
+	const pkgconf_node_t *iter;
+
+	PKGCONF_FOREACH_LIST_ENTRY(list->head, iter)
+	{
+		n++;
+	}
+
+	return n;
+}
+
+static char *
+render_to_string(pkgconf_client_t *client, const pkgconf_list_t *list)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+	pkgconf_license_render(client, list, &buf);
+
+	char *out = strdup(pkgconf_buffer_str_or_empty(&buf));
+	pkgconf_buffer_finalize(&buf);
+	return out;
+}
+
+static void
+test_license_insert_and_free(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t licenses = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_license_insert(client, &licenses, PKGCONF_LICENSE_EXPRESSION, "BSD-3-Clause");
+	TEST_ASSERT_EQ(license_count(&licenses), 1);
+
+	const pkgconf_license_t *l = licenses.head->data;
+	TEST_ASSERT_NONNULL(l);
+	TEST_ASSERT_EQ(l->type, PKGCONF_LICENSE_EXPRESSION);
+	TEST_ASSERT_STRCMP_EQ(l->data, "BSD-3-Clause");
+
+	pkgconf_license_free(&licenses);
+	pkgconf_client_free(client);
+}
+
+static void
+test_license_free_empty(void)
+{
+	pkgconf_list_t licenses = PKGCONF_LIST_INITIALIZER;
+
+	// Freeing an empty list is a no-op. Smoke test.
+	pkgconf_license_free(&licenses);
+
+    // Smoke test
+	pkgconf_license_free(NULL);
+}
+
+static void
+test_license_evaluate_single(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t licenses = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_license_evaluate_str(client, &licenses, "BSD-3-Clause", 0);
+
+	TEST_ASSERT_EQ(license_count(&licenses), 1);
+	const pkgconf_license_t *l = licenses.head->data;
+	TEST_ASSERT_EQ(l->type, PKGCONF_LICENSE_EXPRESSION);
+	TEST_ASSERT_STRCMP_EQ(l->data, "BSD-3-Clause");
+
+	pkgconf_license_free(&licenses);
+	pkgconf_client_free(client);
+}
+
+static void
+test_license_evaluate_or(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t licenses = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_license_evaluate_str(client, &licenses, "MIT OR ISC", 0);
+
+	TEST_ASSERT_EQ(license_count(&licenses), 3);
+
+	char *rendered = render_to_string(client, &licenses);
+	TEST_ASSERT_STRCMP_EQ(rendered, "MIT OR ISC");
+	free(rendered);
+
+	pkgconf_license_free(&licenses);
+	pkgconf_client_free(client);
+}
+
+static void
+test_license_evaluate_and(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t licenses = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_license_evaluate_str(client, &licenses, "LGPL-2.1-only AND MIT", 0);
+
+	char *rendered = render_to_string(client, &licenses);
+	TEST_ASSERT_STRCMP_EQ(rendered, "LGPL-2.1-only AND MIT");
+	free(rendered);
+
+	pkgconf_license_free(&licenses);
+	pkgconf_client_free(client);
+}
+
+static void
+test_license_evaluate_multiple_keys_implicit_and(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t licenses = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_license_evaluate_str(client, &licenses, "BSD-3-Clause", 0);
+	pkgconf_license_evaluate_str(client, &licenses, "BSD-2-Clause", 0);
+
+	char *rendered = render_to_string(client, &licenses);
+	TEST_ASSERT_STRCMP_EQ(rendered, "BSD-3-Clause AND BSD-2-Clause");
+	free(rendered);
+
+	pkgconf_license_free(&licenses);
+	pkgconf_client_free(client);
+}
+
+static void
+test_license_evaluate_brackets(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t licenses = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_license_evaluate_str(client, &licenses, "ISC AND (BSD-3-Clause AND BSD-2-Clause)", 0);
+
+	char *rendered = render_to_string(client, &licenses);
+	TEST_ASSERT_STRCMP_EQ(rendered, "ISC AND (BSD-3-Clause AND BSD-2-Clause)");
+	free(rendered);
+
+	pkgconf_license_free(&licenses);
+	pkgconf_client_free(client);
+}
+
+static void
+test_license_evaluate_empty(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t licenses = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_license_evaluate_str(client, &licenses, "", 0);
+	TEST_ASSERT_EQ(license_count(&licenses), 0);
+
+	pkgconf_license_free(&licenses);
+	pkgconf_client_free(client);
+}
+
+static void
+test_license_evaluate_sanitizes(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t licenses = PKGCONF_LIST_INITIALIZER;
+
+	/* The sanitiser strips characters outside the allowed set
+	 * (alnum, '-', '+', '(', ')', '.', ':').  A token of pure
+	 * junk should sanitise to empty and be skipped. */
+	pkgconf_license_evaluate_str(client, &licenses, "BSD-3-Clause", 0);
+
+	const pkgconf_license_t *l = licenses.head->data;
+	TEST_ASSERT_STRCMP_EQ(l->data, "BSD-3-Clause");
+
+	pkgconf_license_free(&licenses);
+	pkgconf_client_free(client);
+}
+
+static void
+test_license_render_empty(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t licenses = PKGCONF_LIST_INITIALIZER;
+
+	char *rendered = render_to_string(client, &licenses);
+	TEST_ASSERT_EMPTY_STRING(rendered);
+	free(rendered);
+
+	pkgconf_license_free(&licenses);
+	pkgconf_client_free(client);
+}
+
+static void
+test_license_render_single(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t licenses = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_license_insert(client, &licenses, PKGCONF_LICENSE_EXPRESSION, "MIT");
+
+	char *rendered = render_to_string(client, &licenses);
+	TEST_ASSERT_STRCMP_EQ(rendered, "MIT");
+	free(rendered);
+
+	pkgconf_license_free(&licenses);
+	pkgconf_client_free(client);
+}
+
+static void
+test_license_copy_list(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t src = PKGCONF_LIST_INITIALIZER;
+	pkgconf_list_t dst = PKGCONF_LIST_INITIALIZER;
+
+	pkgconf_license_evaluate_str(client, &src, "MIT OR ISC", 0);
+	size_t src_count = license_count(&src);
+
+	pkgconf_license_copy_list(client, &dst, &src);
+	TEST_ASSERT_EQ(license_count(&dst), src_count);
+
+	/* The copy is independent: freeing the source must not affect
+	 * the destination's rendered output. */
+	pkgconf_license_free(&src);
+
+	char *rendered = render_to_string(client, &dst);
+	TEST_ASSERT_STRCMP_EQ(rendered, "MIT OR ISC");
+	free(rendered);
+
+	pkgconf_license_free(&dst);
+	pkgconf_client_free(client);
+}
+
+int
+main(int argc, char *argv[])
+{
+	(void) argc;
+	const char *basename = test_progname(argv[0]);
+
+	TEST_RUN(basename, test_license_insert_and_free);
+	TEST_RUN(basename, test_license_free_empty);
+
+	TEST_RUN(basename, test_license_evaluate_single);
+	TEST_RUN(basename, test_license_evaluate_or);
+	TEST_RUN(basename, test_license_evaluate_and);
+	TEST_RUN(basename, test_license_evaluate_multiple_keys_implicit_and);
+	TEST_RUN(basename, test_license_evaluate_brackets);
+	TEST_RUN(basename, test_license_evaluate_empty);
+	TEST_RUN(basename, test_license_evaluate_sanitizes);
+
+	TEST_RUN(basename, test_license_render_empty);
+	TEST_RUN(basename, test_license_render_single);
+
+	TEST_RUN(basename, test_license_copy_list);
+
+	return EXIT_SUCCESS;
+}

--- a/tests/api/test-tuple.c
+++ b/tests/api/test-tuple.c
@@ -216,6 +216,24 @@ test_tuple_define_variable_overrides_local(void)
 	pkgconf_client_free(client);
 }
 
+static void
+test_tuple_escaped_quote(void)
+{
+	pkgconf_client_t *client = test_client_new();
+	pkgconf_list_t tuples = PKGCONF_LIST_INITIALIZER;
+
+	// A double-quoted value containing an escaped double-quote
+	pkgconf_tuple_t *t = pkgconf_tuple_add(client, &tuples, "key", "\"a\\\"b\"", true, 0);
+	TEST_ASSERT_NONNULL(t);
+
+	const char *found = pkgconf_tuple_find(client, &tuples, "key");
+	TEST_ASSERT_NONNULL(found);
+	TEST_ASSERT_STRCMP_EQ(found, "a\"b");
+
+	pkgconf_tuple_free(&tuples);
+	pkgconf_client_free(client);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -234,6 +252,7 @@ main(int argc, char *argv[])
 	TEST_RUN(basename, test_tuple_global_free_resets);
 	TEST_RUN(basename, test_tuple_define_variable_end_to_end);
 	TEST_RUN(basename, test_tuple_define_variable_overrides_local);
+	TEST_RUN(basename, test_tuple_escaped_quote);
 
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
More test coverage added.

Coverage for the following APIs is added:
* Personality version checks (exercises more branches)
* A few dependency tests with corner cases
* Escaped quotes with tuples
* License API corner cases
* Audit tests (coverage is still low according to gcov but the remaining branches are mostly OOM corner cases difficult to test)
* Buffer tests (fputs, `pkgconf_buffer_subst` with empty patterns)
* More bytecode tests especially with evaluation
* A few more client tests

This was performed with the assistance of gcov to analyse coverage.