### PR TITLE
bomtool: Adjust charset for SPDX IDs and add some missing mandatory properties

### DIFF
--- a/cli/bomtool/main.c
+++ b/cli/bomtool/main.c
@@ -16,6 +16,7 @@
  * from the use of this software.
  */
 
+#include <ctype.h>
 #include <time.h>
 
 #include "libpkgconf/config.h"
@@ -77,9 +78,21 @@ static const char *
 sbom_spdx_identity(pkgconf_pkg_t *pkg)
 {
 	static char buf[PKGCONF_ITEM_SIZE];
+	size_t i, o;
 
-	snprintf(buf, sizeof buf, "%sC64%s", pkg->id, pkg->version);
-
+	/* Sanitize the package ID: only letters, numbers, dot (.) and dash (-)
+	 * are allowed.
+	 */
+	for (i = 0, o = 0; i < strlen(pkg->id) && o < sizeof(buf); i++, o++) {
+		char c = pkg->id[i];
+		if (c == '-' || c == '.' || isalnum(c))
+			buf[o] = c;
+		else {
+			snprintf(buf + o, sizeof(buf) - o, "C%02x", c);
+			o += 2;
+		}
+	}
+	snprintf(buf + o, sizeof(buf) - o, "C64%s", pkg->version);
 	return buf;
 }
 
@@ -252,7 +265,7 @@ write_sbom_relationships(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *unu
 	if (pkg->flags & PKGCONF_PKG_PROPF_VIRTUAL)
 		return;
 
-	snprintf(baseref, sizeof baseref, "SPDXRef-Package-%sC64%s", pkg->id, pkg->version);
+	snprintf(baseref, sizeof baseref, "SPDXRef-Package-%s", sbom_spdx_identity(pkg));
 
 	PKGCONF_FOREACH_LIST_ENTRY(pkg->required.head, node)
 	{

--- a/cli/bomtool/main.c
+++ b/cli/bomtool/main.c
@@ -162,8 +162,10 @@ write_copyright_lines(pkgconf_client_t *client, const pkgconf_list_t *copyright_
 {
 	const pkgconf_node_t *node;
 
-	if (copyright_lines->head == NULL)
+	if (copyright_lines->head == NULL) {
+		OUTPUT_OR_RET_FALSE(client, sbom_out, "PackageCopyrightText: NOASSERTION\n");
 		return true;
+	}
 
 	OUTPUT_OR_RET_FALSE(client, sbom_out, "PackageCopyrightText: <text>");
 

--- a/cli/bomtool/main.c
+++ b/cli/bomtool/main.c
@@ -177,10 +177,17 @@ write_sbom_package(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *unused)
 		return;
 
 	OUTPUT_OR_RET(client, sbom_out, "##### Package: %s\n\n", sbom_identity(pkg));
-	OUTPUT_OR_RET(client, sbom_out, "PackageName: %s\n", pkg->id);
+	OUTPUT_OR_RET(client, sbom_out, "PackageName: %s\n", sbom_identity(pkg));
 	OUTPUT_OR_RET(client, sbom_out, "SPDXID: SPDXRef-Package-%s\n", sbom_spdx_identity(pkg));
 	OUTPUT_OR_RET(client, sbom_out, "PackageVersion: %s\n", pkg->version);
+	OUTPUT_OR_RET(client, sbom_out, "PackageDownloadLocation: NOASSERTION\n");
+
+	/* NOASSERTION is not a valide value for PackageVerificationCode. It
+	 * expect 40 lowercase hexadecimal digits.
+	 */
+#if 0
 	OUTPUT_OR_RET(client, sbom_out, "PackageVerificationCode: NOASSERTION\n");
+#endif
 
 	/* XXX: What about projects? */
 	if (pkg->maintainer != NULL)

--- a/cli/bomtool/main.c
+++ b/cli/bomtool/main.c
@@ -222,6 +222,7 @@ write_sbom_package(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *unused)
 	}
 	else
 		OUTPUT_OR_RET(client, sbom_out, "PackageLicenseDeclared: NOASSERTION\n");
+	OUTPUT_OR_RET(client, sbom_out, "PackageLicenseConcluded: NOASSERTION\n");
 
 	if (!write_copyright_lines(client, &pkg->copyright))
 		return;

--- a/cli/bomtool/main.c
+++ b/cli/bomtool/main.c
@@ -16,6 +16,8 @@
  * from the use of this software.
  */
 
+#include <time.h>
+
 #include "libpkgconf/config.h"
 #include <libpkgconf/stdinc.h>
 #include <libpkgconf/libpkgconf.h>
@@ -109,6 +111,10 @@ sbom_name(pkgconf_pkg_t *world)
 static bool
 write_sbom_header(pkgconf_client_t *client, pkgconf_pkg_t *world)
 {
+	time_t t;
+	struct tm *tm;
+	char buf[21];
+
 	OUTPUT_OR_RET_FALSE(client, sbom_out, "SPDXVersion: %s\n", spdx_version);
 	OUTPUT_OR_RET_FALSE(client, sbom_out, "DataLicense: %s\n", bom_license);
 	OUTPUT_OR_RET_FALSE(client, sbom_out, "SPDXID: %s\n", document_ref);
@@ -130,6 +136,12 @@ write_sbom_header(pkgconf_client_t *client, pkgconf_pkg_t *world)
 
 	OUTPUT_OR_RET_FALSE(client, sbom_out, "DocumentNamespace: https://spdx.org/spdxdocs/bomtool-%s\n", PACKAGE_VERSION);
 	OUTPUT_OR_RET_FALSE(client, sbom_out, "Creator: Tool: bomtool %s\n", PACKAGE_VERSION);
+
+	t = time(NULL);
+	tm = gmtime(&t);
+	strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", tm);
+	OUTPUT_OR_RET_FALSE(client, sbom_out, "Created: %s\n", buf);
+
 	OUTPUT_OR_RET_FALSE(client, sbom_out, "\n\n");
 
 	return true;


### PR DESCRIPTION
I recently played with `pkgconf`s BOM/SPDX capabilities on FreeBSD (which embed 2.5.1).

Using the [SPDX's Python Tools](https://github.com/spdx/tools-python) and the [Online Validation Tool](https://tools.spdx.org/app/validate/) I found a few issues:
- the charset for identifiers is limited to letters, numbers, dot (`.`) and dash (`-`) while we currently allow things like underscore (`_`) and plus sign (`+`)
- the `PackageVerificationCode` property expect an hexadecimal string, `NOASSERTION` is invalid
- `PackageLicenseConcluded`, `PackageCopyrightText` and `Created` are mandatory

The following commits hope to fix this issues:
- for identifiers, use the `C%02x` notation
- for missing properties, add them with `NOASSERTION` when possible
- for the `PackageVerificationCode`, just omit it (I don't know yet how to implement it properly :/)
- add `Created` with the current time in UTC

Running the tests on Ubuntu 24.04 as follow [looks OK](https://github.com/user-attachments/files/28394488/tests.log):

    find . -name '*.test' -exec ./test-runner --test-fixtures ./tests --test-case {} --debug \; > tests.log 2>&1