### PR TITLE
Run coverage in the CI and upload it to codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -306,16 +306,27 @@ jobs:
       - name: Update system and add dependencies
         run: |
           apk update
-          apk add build-base meson
+          apk add build-base meson gcovr bash git curl gpg
 
       - name: Build
         run: |
-          meson _build -Dwerror=true
+          meson _build -Dwerror=true -Db_coverage=true
           meson compile -C _build
 
       - name: Run tests
         run: |
           meson test -v -C _build
+
+      - name: Run coverage
+        run: |
+          ninja -C _build coverage-xml
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          fail_ci_if_error: true
+          files: ./_build/meson-logs/coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   alpine-muon:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pkgconf [![test](https://github.com/pkgconf/pkgconf/actions/workflows/test.yml/badge.svg)](https://github.com/pkgconf/pkgconf/actions/workflows/test.yml)
+# pkgconf [![test](https://github.com/pkgconf/pkgconf/actions/workflows/test.yml/badge.svg)](https://github.com/pkgconf/pkgconf/actions/workflows/test.yml) [![Coverage](https://img.shields.io/codecov/c/github/pkgconf/pkgconf)](https://app.codecov.io/github/pkgconf/pkgconf)
 
 `pkgconf` is a program which helps to configure compiler and linker flags for
 development libraries.  It is a superset of the functionality provided by

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
I think it would be beneficial to use meson [coverage](https://mesonbuild.com/Unit-tests.html#coverage) feature to track which part of pkgconf is covered by tests.
Knowing the coverage help to know what tests we should add.

In brief, this PR use meson coverage feature to generate a report that is uploaded to https://app.codecov.io/.
This is how the report looks: https://app.codecov.io/github/pkgconf/pkgconf/tree/moi15moi:Add-coverage

If you are interested in this PR, note that you will need to properly config https://app.codecov.io and add the ``CODECOV_TOKEN`` to the secret (note that you can not require to use a token like written here https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token but it would main anyone could upload a coverage to codecov, so it's a pretty bad idea)