### PR TITLE
Move CI analyzer tests to use meson

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Update system and add dependencies
         run: |
           apt-get update
-          apt-get install -y kyua atf-sh build-essential meson
+          apt-get install -y build-essential meson
 
       - name: Build
         run: |
@@ -137,7 +137,7 @@ jobs:
       - name: Update system and add dependencies
         run: |
           apt-get update
-          apt-get install -y kyua atf-sh build-essential meson
+          apt-get install -y build-essential meson
 
       - name: Build
         run: |
@@ -161,7 +161,7 @@ jobs:
       - name: Update system and add dependencies
         run: |
           apt-get update
-          apt-get install -y kyua atf-sh build-essential autoconf libtool
+          apt-get install -y build-essential autoconf libtool
 
       - name: Build
         run: |
@@ -184,7 +184,7 @@ jobs:
       - name: Update system and add dependencies
         run: |
           apk update
-          apk add kyua atf build-base meson
+          apk add build-base meson
 
       - name: Build
         run: |
@@ -206,7 +206,7 @@ jobs:
       - name: Update system and add dependencies
         run: |
           apk update
-          apk add kyua atf build-base muon samurai
+          apk add build-base muon samurai
 
       - name: Build
         run: |
@@ -229,7 +229,7 @@ jobs:
       - name: Update system and add dependencies
         run: |
           apk update
-          apk add kyua atf build-base autoconf automake libtool xz gzip tar
+          apk add build-base autoconf automake libtool xz gzip tar
 
       - name: Build
         run: |
@@ -252,14 +252,12 @@ jobs:
       - name: Update system and add dependencies
         run: |
           apk update
-          apk add kyua atf build-base autoconf automake libtool xz gzip
+          apk add build-base meson libtool xz gzip
 
       - name: Build
         run: |
-          export CFLAGS="-Wall -Werror -O2 -ggdb3 -fanalyzer"
-          ./autogen.sh
-          ./configure
-          make -j9 CFLAGS="$CFLAGS"
+          CC=gcc meson setup _build -Danalyzer=true -Dwerror=true
+          meson compile -C _build
 
   llvm-sanitizers:
     runs-on: ubuntu-latest
@@ -272,7 +270,7 @@ jobs:
       - name: Update system and add dependencies
         run: |
           apk update
-          apk add kyua atf build-base meson clang cmd:llvm-symbolizer compiler-rt
+          apk add build-base meson clang cmd:llvm-symbolizer compiler-rt
 
       - name: Build
         run: |

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,12 @@ project('pkgconf', 'c',
 cc = meson.get_compiler('c')
 
 if cc.get_id() != 'msvc'
+  if get_option('analyzer')
+    add_project_arguments(
+      cc.get_supported_arguments('-fanalyzer'),
+      language : 'c',
+    )
+  endif
   add_project_arguments(
     '-D_BSD_SOURCE',
     '-D_DARWIN_C_SOURCE',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -18,3 +18,9 @@ option(
   value: false,
   description: 'Build libFuzzer targets'
 )
+
+option('analyzer',
+  type : 'boolean',
+  value : false,
+  description : 'enable GCC static analysis (-fanalyzer) on project targets'
+)

--- a/tests/api/test-api.h
+++ b/tests/api/test-api.h
@@ -24,6 +24,13 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if defined(__GNUC__) && !defined(__clang__)
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wpragmas" // older gcc may not know the next one
+	// Stop false-positive warnings for test cases
+#	pragma GCC diagnostic ignored "-Wanalyzer-tainted-assertion"
+#endif
+
 #define TEST_FAIL_(fmt, ...)	\
 	do {	\
 		fprintf(stderr, "FAIL: %s:%d: " fmt "\n",	\


### PR DESCRIPTION
This PR moves the analyzer step in the CI to use Meson in preparation for autotools deprecation. A minor test API harness change was required to remove spurious analyzer warnings (turning off `-Wanalyzer-tainted-assertion`).