### PR TITLE
CI: Run tests on cygwin

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 tests/lib1/dos-lineendings.pc eol=crlf
+tests/lib-sbom-files/*.json eol=lf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,6 +153,33 @@ jobs:
         run: |
           meson test -v -C _build
 
+  cygwin:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Cygwin
+        uses: cygwin/cygwin-install-action@v6
+        with:
+          packages: |
+            meson
+            ninja
+            gcc-core
+
+      - name: Build
+        shell: D:\cygwin\bin\bash.exe -o igncr '{0}'
+        run: |
+          export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
+          meson _build
+          meson compile -C _build
+
+      - name: Run tests
+        shell: D:\cygwin\bin\bash.exe -o igncr '{0}'
+        run: |
+          export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
+          meson test -v -C _build
+
   QEMU_VMs:
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
I believe it is a good idea to run the tests on cygwin because currently, the tests doesn't pass.
I fixed the problem with ``multiline-folding-cflags.test``, but I couldn't found the issue with the ``basic-with-colon.test`` test.