### PR TITLE
AUTHORS: update mailmap and authors list

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,1 +1,5 @@
-Ariadne Conill <ariadne@dereferenced.org> <nenolod@dereferenced.org>
+Ariadne Conill <ariadne@ariadne.space> <nenolod@dereferenced.org>
+Ariadne Conill <ariadne@ariadne.space> <ariadne@dereferenced.org>
+Dan Kegel <dank@kegel.com> <dank@oblong.com>
+Baptiste Daroussin <bapt@FreeBSD.org> <bapt@gandi.net>
+orbea <orbea@fredslev.dk> <orbea@riseup.net>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,41 +1,97 @@
+✈ Graham ✈ <plicease@cpan.org>
 A. Wilcox <AWilcox@Wilcox-Tech.com>
 Alexander Tsoy <alexander@tsoy.me>
 Alexpux <alexey.pawlow@gmail.com>
 Alon Bar-Lev <alon.barlev@gmail.com>
 Alyx <alyx@malkier.net>
-Ariadne Conill <ariadne@dereferenced.org>
+Andrea Pappacoda <andrea@pappacoda.it>
+Andrej Shadura <andrew.shadura@collabora.co.uk>
+Antonin Décimo <antonin.decimo@gmail.com>
+Ariadne Conill <ariadne@ariadne.space>
 Baptiste Daroussin <bapt@FreeBSD.org>
-Baptiste Daroussin <bapt@gandi.net>
+Ben <bhipple@protonmail.com>
 Bryan Drewery <bryan@shatow.net>
+Christoph Reiter <reiter.christoph@gmail.com>
+Colin Gillespie <colin@cgillespie.xyz>
 Dag-Erling Smørgrav <des@des.no>
 Dan Kegel <dank@kegel.com>
-Dan Kegel <dank@oblong.com>
 Dan Nicholson <dbn.lists@gmail.com>
+data-man <dataman@tutanota.com>
 David Michael <fedora.dm0@gmail.com>
+David Seifert <soap@gentoo.org>
+Doug Freed <dwfreed@mtu.edu>
+Dylan Baker <dylan@pnwbakers.com>
+Eli Schwartz <eschwartz93@gmail.com>
+Elizabeth Kiara Regina Ashford <elizabeth.jennifer.myers@gmail.com>
 Emil Renner Berthing <esmil@mailme.dk>
 Fabian Groffen <grobian@gentoo.org>
+Filipe Laíns <lains@riseup.net>
 Graham Ollis <plicease@cpan.org>
 Gregor Richards <Richards@codu.org>
+h30032433 <huyubiao@huawei.com>
+Harmen Stoppels <harmenstoppels@gmail.com>
+huyubiao <h13958451065@163.com>
 Ignacio Casal Quinteiro <qignacio@amazon.com>
 Igor Gnatenko <ignatenko@redhat.com>
+Ingo Schwarze <schwarze@openbsd.org>
+Ismael Luceno <ismael@iodev.co.uk>
 Issam Maghni <concatime@users.noreply.github.com>
-JD Horelick <jdhore1@gmail.com>
 Jason Dusek <jason.dusek@gmail.com>
 Javier Viguera <javier.viguera@digi.com>
+JD Horelick <jdhore1@gmail.com>
 Jean-Sébastien Pédron <dumbbell@FreeBSD.org>
+Jeff Moguillansky <jmoguillansky@gopro.com>
 John Hein <jhgit@users.github.com>
+Jonathan Gray <jsg@jsg.id.au>
+Joshua Watt <JPEWhacker@gmail.com>
 Jussi Pakkanen <jpakkane@gmail.com>
+Kai Pastor <dg0yt@darc.de>
+L. E. Segovia <amy@amyspark.me>
 Leorize <alaviss@users.noreply.github.com>
 Luca Barbato <lu_zero@gentoo.org>
+Marc-André Lureau <marcandre.lureau@redhat.com>
 Marcin Wojdyr <wojdyr@gmail.com>
+Mattias Hansson <mattias.hansson@assaabloy.com>
 Maxin B. John <maxinbjohn@users.noreply.github.com>
 Michał Górny <mgorny@gentoo.org>
+midipix <writeonce@midipix.org>
 Mike Frysinger <vapier@gentoo.org>
+Mike L <cl.jeremy@qq.com>
+moi15moi <moi15moismokerlolilol@gmail.com>
+mrgrouse <bdmfegys@duck.com>
+Neal Gompa <ngompa13@gmail.com>
+Nicolas Braud-Santoni <nicoo@debian.org>
+Olaf Hering <olaf@aepfle.de>
+olf <Olf0@users.noreply.github.com>
+orbea <orbea@fredslev.dk>
+Peter Kokot <peterkokot@gmail.com>
+Petr Písař <ppisar@redhat.com>
+Pierce <contact@mokou.io>
+Pierre Pronchery <pierre@defora.net>
+psykose <alice@ayaya.dev>
+rentianyue-jk <rentianyue-jk@360shuke.com>
+Ross Burton <ross.burton@arm.com>
+Ryan Scott <ryan.gl.scott@gmail.com>
+Sam James <sam@gentoo.org>
+Sandro Mani <manisandro@gmail.com>
 Seungha Yang <seungha.yang@navercorp.com>
+Shubham Chakraborty <chakrabortyshubham66@gmail.com>
+Simon Josefsson <simon@josefsson.org>
+Stefan Weil <sw@weilnetz.de>
+Stéphane Rochoy <stephane.rochoy@stormshield.eu>
+Stone Tickle <lattis@mochiro.moe>
+Taylor R Campbell <campbell+pkgconf@mumble.net>
+Timo Röhling <roehling@debian.org>
 TingPing <tingping@tingping.se>
 Tobias Kortkamp <t6@users.noreply.github.com>
+Tobias Stoeckmann <tobias@stoeckmann.org>
 Tony Theodore <tonyt@logyst.com>
+Tuukka Pasanen <tuukka.pasanen@ilmi.fi>
+Undefine <undefine@undefine.pl>
+Victor Westerhuis <victor@westerhu.is>
+Vincent Torri <vincent.torri@gmail.com>
 Volker Braun <vbraun.name@gmail.com>
+wi24rd <14029004+wi24rd@users.noreply.github.com>
+Xi Ruoyao <xry111@xry111.site>
 Yu Kobayashi <yukoba@accelart.jp>
-orbea <orbea@fredslev.dk>
-✈ Graham ✈ <plicease@cpan.org>
+Ziemowit Łąski <15880281+zlaski@users.noreply.github.com>


### PR DESCRIPTION
This deduplicates some authors in the mailmap and also regenerates the long out of date AUTHORS list.

Performed with:
`git shortlog -sne HEAD | awk '{$1=""; print $0}' | sed 's/^ //' | sort > AUTHORS`