### PR TITLE
Fix build when the project is used as a subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -181,13 +181,17 @@ cli_include = include_directories('cli')
 
 windows_manifest = []
 if host_machine.system() == 'windows'
-  conf_data = configuration_data()
+  manifest_conf_data = configuration_data()
   # The assemblyIdentity.version must always be in the format X.X.X.X.
-  conf_data.set('VERSION', meson.project_version() + '.0')
-  manifest_file = configure_file(input: 'pkgconf.manifest.in', output: 'pkgconf.manifest', configuration: conf_data)
+  manifest_conf_data.set('VERSION', meson.project_version() + '.0')
+  manifest_file = configure_file(input: 'pkgconf.manifest.in', output: 'pkgconf.manifest', configuration: manifest_conf_data)
+  
+  resource_file_conf_data = configuration_data()
+  resource_file_conf_data.set('MANIFEST_FILE', join_paths(meson.current_build_dir(), 'pkgconf.manifest'))
+  resources_file = configure_file(input: 'pkgconf.rc.in', output: 'pkgconf.rc', configuration: resource_file_conf_data)
 
   windows = import('windows')
-  windows_manifest += windows.compile_resources('pkgconf.rc', depend_files: manifest_file)
+  windows_manifest += windows.compile_resources(resources_file, depend_files: manifest_file)
 endif
 
 pkgconf_exe = executable('pkgconf',

--- a/pkgconf.rc
+++ b/pkgconf.rc
@@ -1,2 +1,0 @@
-#include <winuser.h>
-1 RT_MANIFEST "pkgconf.manifest"

--- a/pkgconf.rc.in
+++ b/pkgconf.rc.in
@@ -1,0 +1,2 @@
+#include <winuser.h>
+1 RT_MANIFEST "@MANIFEST_FILE@"


### PR DESCRIPTION
Fix build when the project is used as a subproject When the project is used as a subproject, I am getting this error:
```
../subprojects/pkgconf/pkgconf.rc(2) : error RC2135 : file not found: pkgconf.manifest
```

This is happening because when building subprojects, pkgconf.manifest isn't in the root path. It is in the subprojects folder, so RC.exe can't find the manifest file.

As a side note, the file path specified in ressource file (pkgconf.rc) must escape the "\". A simple solution is simply to use "/" to avoid having to escape anything. join_paths automatically convert the path to a posix path, so we won't have to worry about that.

Fix: https://github.com/pkgconf/pkgconf/issues/529