### PR TITLE
fixup! bomtool: Fix package ID charset

### DIFF
--- a/cli/bomtool/main.c
+++ b/cli/bomtool/main.c
@@ -92,7 +92,8 @@ sbom_spdx_identity(pkgconf_pkg_t *pkg)
 			o += 2;
 		}
 	}
-	snprintf(buf + o, sizeof(buf) - o, "C64%s", pkg->version);
+	snprintf(buf + o, sizeof(buf) - o, "C40%s", pkg->version);
+	/*                                  ^^^ 0x40 is the at sign (@) */
 	return buf;
 }
 


### PR DESCRIPTION
Well, it's embarrassing… when submitting #516 I overlooked the way exotic characters are encoded. I though the syntax was `C` followed by the hexadecimal value of the character but it was the decimal one.

Also using decimal is problematic I think. For example `@7` is encoded as `C647` which is ambiguous to decode as both `C6` and `C64` are valid encoded exotic characters, i.e., ACK (`^F`) and at sign (`@`) respectively.

Using fixed-length hexadecimal should fix the problem (`C%02x`) and is shorter than fixed-length decimal (`C%03d`).

Note that this encoding don't seems to be part of the [SPDX 2.2 specification](https://spdx.github.io/spdx-spec/v2.2.2/), did I miss it? Or does it means it's somewhat FreeBSD-specific?