### PR TITLE
libpkgconf: fragment: don't split UTF-8 sequences when quoting fragments

### DIFF
--- a/libpkgconf/fragment.c
+++ b/libpkgconf/fragment.c
@@ -18,6 +18,11 @@
 #include <libpkgconf/stdinc.h>
 #include <libpkgconf/libpkgconf.h>
 
+#ifndef _WIN32
+#include <locale.h>
+#include <langinfo.h>
+#endif
+
 /*
  * !doc
  *
@@ -651,6 +656,41 @@ pkgconf_fragment_filter(const pkgconf_client_t *client, pkgconf_list_t *dest, pk
 	}
 }
 
+/*
+ * !doc
+ *
+ * .. c:function:: bool pkgconf_is_locale_utf8(void)
+ *
+ *    Check whether text is expected to be UTF-8 encoded in the current environment.
+ *
+ *    :return: :code:`true` if text is expected to be UTF-8 encoded, :code:`false` otherwise.
+ */
+bool
+pkgconf_is_locale_utf8(void)
+{
+#ifdef _WIN32
+	return GetACP() == CP_UTF8;
+#else
+	static int cached = -1;
+
+	if (cached < 0)
+	{
+		locale_t loc = newlocale(LC_CTYPE_MASK, "", (locale_t)0);
+
+		if (loc != (locale_t)0)
+		{
+			const char *codeset = nl_langinfo_l(CODESET, loc);
+			cached = codeset != NULL && (!strcasecmp(codeset, "UTF-8") || !strcasecmp(codeset, "UTF8"));
+			freelocale(loc);
+		}
+		else
+			cached = 0;
+	}
+
+	return cached;
+#endif
+}
+
 static void
 fragment_quote(pkgconf_buffer_t *out, const pkgconf_fragment_t *frag)
 {
@@ -671,7 +711,25 @@ fragment_quote(pkgconf_buffer_t *out, const pkgconf_fragment_t *frag)
 		{ 0x7f, 0xff },
 	};
 
-	pkgconf_buffer_escape(out, src, quote_spans, PKGCONF_ARRAY_SIZE(quote_spans));
+	/* If the local is UTF-8 we must not split character over 0x7f because it would add "\" between each bytes.
+	   So only DEL (0x7f) needs escaping */
+	const pkgconf_span_t quote_spans_utf8[] = {
+		{ 0x00, 0x1f },
+		{ (unsigned char)' ', (unsigned char)'#' },
+		{ (unsigned char)'%', (unsigned char)'\'' },
+		{ (unsigned char)'*', (unsigned char)'*' },
+		{ (unsigned char)';', (unsigned char)'<' },
+		{ (unsigned char)'>', (unsigned char)'?' },
+		{ (unsigned char)'[', (unsigned char)']' },
+		{ (unsigned char)'`', (unsigned char)'`' },
+		{ (unsigned char)'{', (unsigned char)'}' },
+		{ 0x7f, 0x7f },
+	};
+
+	if (pkgconf_is_locale_utf8())
+		pkgconf_buffer_escape(out, src, quote_spans_utf8, PKGCONF_ARRAY_SIZE(quote_spans_utf8));
+	else
+		pkgconf_buffer_escape(out, src, quote_spans, PKGCONF_ARRAY_SIZE(quote_spans));
 }
 
 static void

--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -519,6 +519,7 @@ PKGCONF_API void pkgconf_fragment_free(pkgconf_list_t *list);
 PKGCONF_API void pkgconf_fragment_filter(const pkgconf_client_t *client, pkgconf_list_t *dest, pkgconf_list_t *src, pkgconf_fragment_filter_func_t filter_func, void *data);
 PKGCONF_API void pkgconf_fragment_render_buf(const pkgconf_list_t *list, pkgconf_buffer_t *buf, bool escape, const pkgconf_fragment_render_ops_t *ops, char delim);
 PKGCONF_API bool pkgconf_fragment_has_system_dir(const pkgconf_client_t *client, const pkgconf_fragment_t *frag);
+PKGCONF_API bool pkgconf_is_locale_utf8(void);
 
 /* license.c */
 PKGCONF_API void pkgconf_license_copy_list(const pkgconf_client_t *client, pkgconf_list_t *list, const pkgconf_list_t *base);

--- a/t/basic/utf8-pkg-config-path.test
+++ b/t/basic/utf8-pkg-config-path.test
@@ -1,4 +1,5 @@
 Environment: PKG_CONFIG_PATH=%TEST_FIXTURES_DIR%/lib1/tÃ«ðŸ˜‹st/lib/pkgconfig
 WantedFlags: cflags define-prefix
 Query: utf8
-ExpectedStdout: -I%TEST_FIXTURES_DIR%/lib1/t\Ã\«\ð\Ÿ\˜\‹st/include
+ExpectedStdout: -I%TEST_FIXTURES_DIR%/lib1/tÃ«ðŸ˜‹st/include
+RequireUtf8Locale: true

--- a/tests/test-runner.c
+++ b/tests/test-runner.c
@@ -110,6 +110,7 @@ typedef struct test_case_
 	pkgconf_buffer_t fragment_filter;
 
 	pkgconf_buffer_t skip_platforms;
+	bool require_utf8_locale;
 
 	pkgconf_list_t define_variables;
 
@@ -335,6 +336,16 @@ test_keyword_set_int(pkgconf_test_case_t *testcase, const char *keyword, const c
 }
 
 static void
+test_keyword_set_bool(pkgconf_test_case_t *testcase, const char *keyword, const char *warnprefix, const ptrdiff_t offset, const char *value)
+{
+	(void) keyword;
+	(void) warnprefix;
+
+	bool *dest = (bool *)((char *) testcase + offset);
+	*dest = !strcasecmp(value, "true");
+}
+
+static void
 test_keyword_set_buffer(pkgconf_test_case_t *testcase, const char *keyword, const char *warnprefix, const ptrdiff_t offset, const char *value)
 {
 	(void) keyword;
@@ -546,6 +557,7 @@ static const pkgconf_test_keyword_pair_t test_keyword_pairs[] =
 	{"MaxVersion",		test_keyword_set_buffer,		offsetof(pkgconf_test_case_t, max_version)},
 	{"PackageSearchPath",	test_keyword_set_path_list,		offsetof(pkgconf_test_case_t, search_path)},
 	{"Query",		test_keyword_set_buffer,		offsetof(pkgconf_test_case_t, query)},
+	{"RequireUtf8Locale",	test_keyword_set_bool,			offsetof(pkgconf_test_case_t, require_utf8_locale)},
 	{"SetupCopy",		test_keyword_extend_bufferset,		offsetof(pkgconf_test_case_t, copies)},
 	{"SetupMkdir",		test_keyword_extend_bufferset,		offsetof(pkgconf_test_case_t, mkdirs)},
 #ifdef _WIN32
@@ -1196,6 +1208,12 @@ run_test_case(const pkgconf_test_case_t *testcase)
 	{
 		printf("# test skipped on %s\nSKIP: %s\n",
 			pkgconf_buffer_str(our_platform), testcase->name);
+		return true;
+	}
+
+	if (testcase->require_utf8_locale && !pkgconf_is_locale_utf8())
+	{
+		printf("# test skipped: requires a UTF-8 locale\nSKIP: %s\n", testcase->name);
 		return true;
 	}
 


### PR DESCRIPTION
fragment_quote() escapes every byte in the range [0x7f, 0xff] with a backslash. For a fragment containing a UTF-8 multibyte sequence (ex: "😋" which is \xF0\x9F\x98\x8B in UTF-8), this inserts a backslash before each byte of the sequence individually (ex: \\\xf0\\\x9f\\\x98\\\x8b for "😋"), producing mangled output instead of the original UTF-8 text.

To detect if the text if UTF-8, let's simply check the LC_CTYPE codeset on POSIX and the ANSI code page on Windows. When it does, narrow the escaped range to DEL (0x7f) only, so bytes 0x80-0xff pass through untouched and multibyte sequences stay intact.

Note: This is not compatible with upstream pkg-config's strdup_escape_shell() (https://gitlab.freedesktop.org/pkg-config/pkg-config/-/blob/d97db4fae4c1cd099b506970b285dc2afd818ea2/parse.c#L591-618). As a result, pkgconf and pkg-config now produce different quoted output for non-ASCII fragments in a UTF-8 locale (but they will still produce the same result if the locale is not UTF-8).

This PR try to fix this comment: https://github.com/mesonbuild/meson/issues/15903#issuecomment-4686542184

PS: This PR was partially created with the assistance of an LLM.