### PR TITLE
Only include the library in the msi installer when building as a shared library

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -300,6 +300,7 @@ if host_machine.system() == 'windows'
   conf_data.set('VERSION', meson.project_version())
   conf_data.set('EXE', pkgconf_exe.full_path())
   conf_data.set('DLL', libpkgconf.full_path())
+  conf_data.set('BUILD_TYPE', libtype)
 
   if host_machine.cpu_family() == 'x86'
     wix_arch = 'x86'

--- a/pkgconf.wxs.in
+++ b/pkgconf.wxs.in
@@ -41,11 +41,13 @@
                     Source="@EXE@"
                     KeyPath="yes" />
           </Component>
-          <Component Id="PkgconfDll" Guid="*">
-              <File Id="PkgconfDllFile"
-                    Source="@DLL@"
-                    KeyPath="yes" />
-          </Component>
+          <?if "@BUILD_TYPE@" = "shared" ?>
+            <Component Id="PkgconfDll" Guid="*">
+                <File Id="PkgconfDllFile"
+                        Source="@DLL@"
+                        KeyPath="yes" />
+            </Component>
+          <?endif?>
       </ComponentGroup>
 
       <ui:WixUI Id="WixUI_Minimal" InstallDirectory="INSTALLFOLDER" />


### PR DESCRIPTION
Previously, when building the project as a static library, the .lib (or .a) file was included in the installer, even though it serves no purpose there. Only include the library file when building the project as a shared library.

This should have been caught in https://github.com/pkgconf/pkgconf/pull/486, but i didnt realize it.