### PR TITLE
Support clang-cl

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,35 @@ jobs:
             _build/*.dll
             _build/*.msi
 
+  clang-cl:
+    name: ${{ matrix.name }}
+    runs-on: windows-2025
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install Meson and Ninja
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install meson ninja
+
+      - name: Build
+        run: |
+          meson _build --vsenv
+          meson compile -C _build
+        env:
+          CC: clang-cl
+
+      - name: Run tests
+        run: |
+          meson test -v -C _build
+
   msys2:
     runs-on: windows-latest
     strategy:

--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -120,7 +120,7 @@ struct pkgconf_bufferset_ {
 	pkgconf_buffer_t buffer;
 };
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 # define PKGCONF_PACKED_STRUCT(name) __pragma(pack(push, 1)) struct name __pragma(pack(pop))
 #else
 # define PKGCONF_PACKED_STRUCT(name) struct __attribute__((__packed__)) name

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ project('pkgconf', 'c',
 
 cc = meson.get_compiler('c')
 
-if cc.get_id() != 'msvc'
+if cc.get_argument_syntax() != 'msvc'
   if get_option('analyzer')
     add_project_arguments(
       cc.get_supported_arguments('-fanalyzer'),


### PR DESCRIPTION
Before this PR, clang-cl wasn't properly supported. I was getting many compilation errors. See: https://github.com/moi15moi/pkgconf/actions/runs/27799579152/job/82266780491

I haven't investigated why, but the msvc version of ``PKGCONF_PACKED_STRUCT`` doesn't seems to be handled properly with clang-cl. I just avoided the problem by using the gnuc version.

To be sure we always support clang-cl, I simply added it to the CI.