### PR TITLE
Add tests for fileio

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -276,6 +276,7 @@ EXTRA_DIST =	pkg.m4 \
 		tests/api/test-bytecode.c \
 		tests/api/test-client.c \
 		tests/api/test-dependency.c \
+		tests/api/test-fileio.c \
 		tests/api/test-fragment.c \
 		tests/api/test-license.c \
 		tests/api/test-path-utils.c \
@@ -502,6 +503,7 @@ API_TEST_PROGS =		\
 	test-api-bytecode	\
 	test-api-client		\
 	test-api-dependency	\
+	test-api-fileio		\
 	test-api-fragment	\
 	test-api-license	\
 	test-api-path-utils	\
@@ -540,6 +542,10 @@ test_api_dependency_LDADD = $(api_test_ldadd)
 test_api_dependency_SOURCES = tests/api/test-dependency.c
 test_api_dependency_CPPFLAGS = $(api_test_cppflags)
 
+test_api_fileio_LDADD = $(api_test_ldadd)
+test_api_fileio_SOURCES = tests/api/test-fileio.c
+test_api_fileio_CPPFLAGS = $(api_test_cppflags)
+
 test_api_fragment_LDADD = $(api_test_ldadd)
 test_api_fragment_SOURCES = tests/api/test-fragment.c
 test_api_fragment_CPPFLAGS = $(api_test_cppflags)
@@ -573,6 +579,7 @@ check: pkgconf test-runner $(API_TEST_PROGS)
 	$(builddir)/test-api-bytecode$(EXEEXT)
 	$(builddir)/test-api-client$(EXEEXT)
 	$(builddir)/test-api-dependency$(EXEEXT)
+	$(builddir)/test-api-fileio$(EXEEXT)
 	$(builddir)/test-api-fragment$(EXEEXT)
 	$(builddir)/test-api-license$(EXEEXT)
 	$(builddir)/test-api-path-utils$(EXEEXT)

--- a/libpkgconf/fileio.c
+++ b/libpkgconf/fileio.c
@@ -60,8 +60,6 @@ pkgconf_fgetline(pkgconf_buffer_t *buffer, FILE *stream)
 			}
 			else if (c == '\r')
 			{
-				push_or_return_fail(buffer, '\n');
-
 				if (*p == '\n')
 					p++;
 
@@ -71,6 +69,7 @@ pkgconf_fgetline(pkgconf_buffer_t *buffer, FILE *stream)
 					continue;
 				}
 
+				push_or_return_fail(buffer, '\n');
 				goto done;
 			}
 			else

--- a/libpkgconf/fileio.c
+++ b/libpkgconf/fileio.c
@@ -62,7 +62,22 @@ pkgconf_fgetline(pkgconf_buffer_t *buffer, FILE *stream)
 			else if (c == '\r')
 			{
 				if (*p == '\n')
+				{
 					p++;
+				}
+				else if (*p == '\0')
+				{
+					/*
+					 * The matching '\n' may not have been read into `in`
+					 * yet if '\r' landed exactly on the fgets() buffer
+					 * boundary. Peek the real stream so a split CRLF
+					 * isn't misparsed as two lines.
+					 */
+					int next = getc(stream);
+
+					if (next != '\n' && next != EOF && ungetc(next, stream) == EOF)
+						return false;
+				}
 
 				if (quoted)
 				{

--- a/libpkgconf/fileio.c
+++ b/libpkgconf/fileio.c
@@ -30,6 +30,7 @@ pkgconf_fgetline(pkgconf_buffer_t *buffer, FILE *stream)
 	bool quoted = false;
 	bool got_data = false;
 	char in[PKGCONF_ITEM_SIZE];
+	long unread = 0;
 
 	while (fgets(in, sizeof in, stream) != NULL)
 	{
@@ -70,6 +71,8 @@ pkgconf_fgetline(pkgconf_buffer_t *buffer, FILE *stream)
 				}
 
 				push_or_return_fail(buffer, '\n');
+				/* unlike '\n', a lone '\r' doesn't bound the fgets() call above */
+				unread = (long) strlen(p);
 				goto done;
 			}
 			else
@@ -86,6 +89,9 @@ pkgconf_fgetline(pkgconf_buffer_t *buffer, FILE *stream)
 	}
 
 done:
+	if (unread > 0 && fseek(stream, -unread, SEEK_CUR) != 0)
+		return false;
+
 	/* Remove newline character. */
 	if (pkgconf_buffer_lastc(buffer) == '\n')
 		trim_or_return_fail(buffer);

--- a/libpkgconf/personality.c
+++ b/libpkgconf/personality.c
@@ -291,7 +291,7 @@ load_personality_with_path(const char *path, const char *triplet, bool datadir)
 	if (triplet != NULL)
 		p->name = strdup(triplet);
 
-	f = fopen(pkgconf_buffer_str(&pathbuf), "r");
+	f = fopen(pkgconf_buffer_str(&pathbuf), "rb");
 	if (f == NULL)
 	{
 		pkgconf_buffer_finalize(&pathbuf);

--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -690,7 +690,7 @@ pkgconf_pkg_new_from_path(pkgconf_client_t *client, const char *filename, unsign
 	if (!str_has_suffix(filename, PKG_CONFIG_EXT))
 		return NULL;
 
-	f = fopen(filename, "r");
+	f = fopen(filename, "rb");
 	if (f == NULL)
 		return NULL;
 

--- a/meson.build
+++ b/meson.build
@@ -246,6 +246,7 @@ api_tests = [
   'bytecode',
   'client',
   'dependency',
+  'fileio',
   'fragment',
   'license',
   'path-utils',

--- a/tests/api/test-fileio.c
+++ b/tests/api/test-fileio.c
@@ -181,6 +181,40 @@ test_fgetline_backslash_not_continuation(void)
 	pkgconf_buffer_finalize(&buf);
 }
 
+// fgets() only stops on '\n', a full read buffer, or EOF. NOT on on a lone '\r'.
+// If a '\r' happens to be the very last byte fgets() manages to read
+// before the buffer fills up, the matching '\n' is still unread in the
+// stream and isn't visible to pkgconf_fgetline()'s lookahead, so the CRLF
+// pair gets split across two fgets() calls and is misparsed as two lines.
+static void
+test_fgetline_crlf_split_across_fgets_buffer(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+	size_t prefix_len = PKGCONF_ITEM_SIZE - 2;
+	char *content = malloc(prefix_len + strlen("\r\nworld\n") + 1);
+	FILE *f;
+
+	TEST_ASSERT_NONNULL(content);
+	memset(content, 'a', prefix_len);
+	strcpy(content + prefix_len, "\r\nworld\n");
+
+	f = fmemstream(content);
+	free(content);
+
+	TEST_ASSERT_TRUE(pkgconf_fgetline(&buf, f));
+	TEST_ASSERT_EQ(strlen(pkgconf_buffer_str(&buf)), prefix_len);
+
+	pkgconf_buffer_reset(&buf);
+	TEST_ASSERT_TRUE(pkgconf_fgetline(&buf, f));
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "world");
+
+	pkgconf_buffer_reset(&buf);
+	TEST_ASSERT_FALSE(pkgconf_fgetline(&buf, f));
+
+	fclose(f);
+	pkgconf_buffer_finalize(&buf);
+}
+
 int
 main(int argc, const char **argv)
 {
@@ -196,6 +230,7 @@ main(int argc, const char **argv)
 	TEST_RUN(basename, test_fgetline_backslash_continuation_crlf);
 	TEST_RUN(basename, test_fgetline_backslash_continuation_lone_cr);
 	TEST_RUN(basename, test_fgetline_backslash_not_continuation);
+	TEST_RUN(basename, test_fgetline_crlf_split_across_fgets_buffer);
 
 	return EXIT_SUCCESS;
 }

--- a/tests/api/test-fileio.c
+++ b/tests/api/test-fileio.c
@@ -1,0 +1,201 @@
+/*
+ * test-fileio.c
+ * Tests for the public libpkgconf file i/o API.
+ *
+ * SPDX-License-Identifier: pkgconf
+ *
+ * Copyright (c) 2026 pkgconf authors (see AUTHORS).
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * This software is provided 'as is' and without any warranty, express or
+ * implied.  In no event shall the authors be liable for any damages arising
+ * from the use of this software.
+ */
+
+#include "test-api.h"
+
+static FILE *
+fmemstream(const char *contents)
+{
+	FILE *f = tmpfile();
+
+	TEST_ASSERT_NONNULL(f);
+
+	fwrite(contents, 1, strlen(contents), f);
+	rewind(f);
+
+	return f;
+}
+
+static void
+test_fgetline_no_trailing_newline(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+	FILE *f = fmemstream("hello");
+
+	TEST_ASSERT_TRUE(pkgconf_fgetline(&buf, f));
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "hello");
+
+	pkgconf_buffer_reset(&buf);
+	TEST_ASSERT_FALSE(pkgconf_fgetline(&buf, f));
+
+	fclose(f);
+	pkgconf_buffer_finalize(&buf);
+}
+
+static void
+test_fgetline_empty_stream(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+	FILE *f = fmemstream("");
+
+	TEST_ASSERT_FALSE(pkgconf_fgetline(&buf, f));
+
+	fclose(f);
+	pkgconf_buffer_finalize(&buf);
+}
+
+static void
+test_fgetline_lf(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+	FILE *f = fmemstream("hello\nworld\n");
+
+	TEST_ASSERT_TRUE(pkgconf_fgetline(&buf, f));
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "hello");
+
+	pkgconf_buffer_reset(&buf);
+	TEST_ASSERT_TRUE(pkgconf_fgetline(&buf, f));
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "world");
+
+	pkgconf_buffer_reset(&buf);
+	TEST_ASSERT_FALSE(pkgconf_fgetline(&buf, f));
+
+	fclose(f);
+	pkgconf_buffer_finalize(&buf);
+}
+
+static void
+test_fgetline_crlf(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+	FILE *f = fmemstream("hello\r\nworld\r\n");
+
+	TEST_ASSERT_TRUE(pkgconf_fgetline(&buf, f));
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "hello");
+
+	pkgconf_buffer_reset(&buf);
+	TEST_ASSERT_TRUE(pkgconf_fgetline(&buf, f));
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "world");
+
+	pkgconf_buffer_reset(&buf);
+	TEST_ASSERT_FALSE(pkgconf_fgetline(&buf, f));
+
+	fclose(f);
+	pkgconf_buffer_finalize(&buf);
+}
+
+static void
+test_fgetline_lone_cr(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+	FILE *f = fmemstream("hello\rworld\r");
+
+	TEST_ASSERT_TRUE(pkgconf_fgetline(&buf, f));
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "hello");
+
+	pkgconf_buffer_reset(&buf);
+	TEST_ASSERT_TRUE(pkgconf_fgetline(&buf, f));
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "world");
+
+	pkgconf_buffer_reset(&buf);
+	TEST_ASSERT_FALSE(pkgconf_fgetline(&buf, f));
+
+	fclose(f);
+	pkgconf_buffer_finalize(&buf);
+}
+
+static void
+test_fgetline_backslash_continuation_lf(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+	FILE *f = fmemstream("foo\\\nbar\n");
+
+	TEST_ASSERT_TRUE(pkgconf_fgetline(&buf, f));
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "foobar");
+
+	fclose(f);
+	pkgconf_buffer_finalize(&buf);
+}
+
+static void
+test_fgetline_backslash_continuation_crlf(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+	FILE *f = fmemstream("foo\\\r\nbar\r\n");
+
+	TEST_ASSERT_TRUE(pkgconf_fgetline(&buf, f));
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "foobar");
+
+	pkgconf_buffer_reset(&buf);
+	TEST_ASSERT_FALSE(pkgconf_fgetline(&buf, f));
+
+	fclose(f);
+	pkgconf_buffer_finalize(&buf);
+}
+
+static void
+test_fgetline_backslash_continuation_lone_cr(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+	FILE *f = fmemstream("foo\\\rbar\r");
+
+	TEST_ASSERT_TRUE(pkgconf_fgetline(&buf, f));
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "foobar");
+
+	pkgconf_buffer_reset(&buf);
+	TEST_ASSERT_FALSE(pkgconf_fgetline(&buf, f));
+
+	fclose(f);
+	pkgconf_buffer_finalize(&buf);
+}
+
+// A backslash not immediately followed by a newline is not a continuation,
+// so it must be preserved literally in the output.
+static void
+test_fgetline_backslash_not_continuation(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+	FILE *f = fmemstream("foo\\bar\n");
+
+	TEST_ASSERT_TRUE(pkgconf_fgetline(&buf, f));
+	TEST_ASSERT_STRCMP_EQ(pkgconf_buffer_str(&buf), "foo\\bar");
+
+	pkgconf_buffer_reset(&buf);
+	TEST_ASSERT_FALSE(pkgconf_fgetline(&buf, f));
+
+	fclose(f);
+	pkgconf_buffer_finalize(&buf);
+}
+
+int
+main(int argc, const char **argv)
+{
+	(void) argc;
+	const char *basename = test_progname(argv[0]);
+
+	TEST_RUN(basename, test_fgetline_no_trailing_newline);
+	TEST_RUN(basename, test_fgetline_empty_stream);
+	TEST_RUN(basename, test_fgetline_lf);
+	TEST_RUN(basename, test_fgetline_crlf);
+	TEST_RUN(basename, test_fgetline_lone_cr);
+	TEST_RUN(basename, test_fgetline_backslash_continuation_lf);
+	TEST_RUN(basename, test_fgetline_backslash_continuation_crlf);
+	TEST_RUN(basename, test_fgetline_backslash_continuation_lone_cr);
+	TEST_RUN(basename, test_fgetline_backslash_not_continuation);
+
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
As said in the cygwin PR (https://github.com/pkgconf/pkgconf/pull/525), `pkgconf_fgetline` doesn't behave properly on a posix platform when it is reading a CRLF (\r\n) files.

I decided to fix this + adding many tests to try to catch as many issue as possible.

The commit (https://github.com/pkgconf/pkgconf/commit/83b4b2e2d65cb38d75146836850e46760c2a858d) fix the issue found in the cygwin PR.
The commit (https://github.com/pkgconf/pkgconf/commit/8430c0bd04964ee2c822bd0bf0c0ceae82b36ca0) fix another issue I found while writing the tests.

After I wrote the tests + fix the 2 above issue, I asked **claude** to find any leftover bugs and he found 2 problems that have been fixed in:
- https://github.com/pkgconf/pkgconf/commit/5264679e0bbab6b8e0bcd56fb2c8c1f35b5a0b7a
- https://github.com/pkgconf/pkgconf/commit/1b90227af6f2b33511c35a3556d9937ff0d06bc9

Both commits where written with the help of claude.
Note that I do understand the fix. It's just that claude is pretty good to find some bugs like those. 