### PR TITLE
ci: Build/test the project on macOS/NetBSD/FreeBSD/Haiku/Omnios

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,6 +153,79 @@ jobs:
         run: |
           meson test -v -C _build
 
+  QEMU_VMs:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: cpa.sh {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os_image: netbsd
+            version: '10.1'
+
+          - os_image: freebsd
+            version: '15.1'
+
+          - os_image: openbsd
+            version: '7.9'
+
+          - os_image: haiku
+            version: 'r1beta5'
+
+          - os_image: omnios
+            version: 'r151056'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Start VM on ${{ matrix.os_image }}
+        uses: cross-platform-actions/action@v1.3.0
+        with:
+          operating_system: ${{ matrix.os_image }}
+          version: ${{ matrix.version }}
+
+      - name: Install meson
+        run: |
+          case "${{ matrix.os_image }}" in
+            netbsd)
+              sudo pkgin -y install meson
+              ;;
+            freebsd)
+              # Using system compiler
+              sudo pkg -o ASSUME_ALWAYS_YES=yes install meson
+              ;;
+            openbsd)
+              sudo pkg_add meson
+              ;;
+            haiku)
+              pkgman install -y meson
+              ;;
+            omnios)
+              sudo pkg install --deny-new-be --no-backup-be \
+                pkg:/developer/gcc14 \
+                pkg:/library/python-3/meson-313 \
+                pkg:/ooce/developer/ninja
+              ;;
+          esac
+
+      - name: Build
+        run: |
+          if [[ "${{ matrix.os_image }}" == "omnios" ]]; then
+            export PATH=/usr/lib/python3.13/bin:$PATH
+          fi
+          meson _build -Dwerror=true
+          meson compile -C _build
+
+      - name: Run tests
+        run: |
+          if [[ "${{ matrix.os_image }}" == "omnios" ]]; then
+            export PATH=/usr/lib/python3.13/bin:$PATH
+          fi
+          meson test -v -C _build
+
   debian-meson:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,7 +198,7 @@ jobs:
               sudo pkg -o ASSUME_ALWAYS_YES=yes install meson
               ;;
             openbsd)
-              sudo pkg_add meson
+              sudo pkg_add https://cdn.openbsd.org/%m/meson
               ;;
             haiku)
               pkgman install -y meson

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,6 +133,26 @@ jobs:
         run: |
           meson test -v -C _build
 
+  macOS:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Update system and add dependencies
+        run: |
+          brew update
+          brew install meson
+
+      - name: Build
+        run: |
+          meson _build -Dwerror=true
+          meson compile -C _build
+
+      - name: Run tests
+        run: |
+          meson test -v -C _build
+
   debian-meson:
     runs-on: ubuntu-latest
     container:

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,12 @@ AC_CHECK_DECLS([strndup], [], [], [[#include <string.h>]])
 AC_CHECK_DECLS([pledge, unveil], [], [], [[#include <unistd.h>]])
 AC_CHECK_DECLS([readlinkat], [], [], [[#include <unistd.h>]])
 AC_CHECK_DECLS([reallocarray], [], [], [[#include <stdlib.h>]])
+AC_CHECK_DECLS([nl_langinfo_l], [], [], [[
+#ifdef __APPLE__
+#include <xlocale.h>
+#endif
+#include <locale.h>
+#include <langinfo.h>]])
 AC_CHECK_HEADERS([sys/stat.h])
 AM_INIT_AUTOMAKE([foreign dist-xz subdir-objects])
 AM_SILENT_RULES([yes])

--- a/libpkgconf/config.h.meson
+++ b/libpkgconf/config.h.meson
@@ -24,6 +24,9 @@
 /* Define to 1 if you have the `unveil' function. */
 #mesondefine HAVE_DECL_UNVEIL
 
+/* Define to 1 if you have the `nl_langinfo_l' function. */
+#mesondefine HAVE_DECL_NL_LANGINFO_L
+
 /* Name of package */
 #mesondefine PACKAGE
 

--- a/libpkgconf/fragment.c
+++ b/libpkgconf/fragment.c
@@ -23,6 +23,10 @@
 #include <langinfo.h>
 #endif
 
+#ifdef __APPLE__
+#include <xlocale.h>
+#endif
+
 /*
  * !doc
  *

--- a/libpkgconf/fragment.c
+++ b/libpkgconf/fragment.c
@@ -15,6 +15,7 @@
  * from the use of this software.
  */
 
+#include <libpkgconf/config.h>
 #include <libpkgconf/stdinc.h>
 #include <libpkgconf/libpkgconf.h>
 
@@ -674,7 +675,7 @@ pkgconf_is_locale_utf8(void)
 {
 #ifdef _WIN32
 	return GetACP() == CP_UTF8;
-#else
+#elif HAVE_DECL_NL_LANGINFO_L
 	static int cached = -1;
 
 	if (cached < 0)
@@ -689,6 +690,24 @@ pkgconf_is_locale_utf8(void)
 		}
 		else
 			cached = 0;
+	}
+
+	return cached;
+#else
+	static int cached = -1;
+
+	if (cached < 0)
+	{
+		const char *prev_locale = setlocale(LC_CTYPE, NULL);
+		char *saved_locale = prev_locale != NULL ? strdup(prev_locale) : NULL;
+
+		setlocale(LC_CTYPE, "");
+
+		const char *codeset = nl_langinfo(CODESET);
+		cached = codeset != NULL && (!strcasecmp(codeset, "UTF-8") || !strcasecmp(codeset, "UTF8"));
+
+		setlocale(LC_CTYPE, saved_locale != NULL ? saved_locale : "C");
+		free(saved_locale);
 	}
 
 	return cached;

--- a/meson.build
+++ b/meson.build
@@ -85,6 +85,14 @@ foreach f : check_functions
   endif
 endforeach
 
+# nl_langinfo_l() needs locale.h for locale_t in addition to langinfo.h (on macOS, it also need xlocale.h),
+# so it can't share the single-header check_functions loop above.
+if cc.has_function('nl_langinfo_l', prefix : '#define _BSD_SOURCE\n#define _DARWIN_C_SOURCE\n#define _DEFAULT_SOURCE\n#define _POSIX_C_SOURCE 200809L\n#ifdef __APPLE__\n#include <xlocale.h>\n#endif\n#include <locale.h>\n#include <langinfo.h>') and cc.has_header_symbol('langinfo.h', 'nl_langinfo_l', prefix : '#define _BSD_SOURCE\n#define _DARWIN_C_SOURCE\n#define _DEFAULT_SOURCE\n#define _POSIX_C_SOURCE 200809L\n#ifdef __APPLE__\n#include <xlocale.h>\n#endif\n#include <locale.h>')
+  cdata.set('HAVE_DECL_NL_LANGINFO_L', 1)
+else
+  cdata.set('HAVE_DECL_NL_LANGINFO_L', 0)
+endif
+
 default_path = []
 foreach f : ['libdir', 'datadir']
   default_path += [join_paths(get_option('prefix'), get_option(f), 'pkgconfig')]


### PR DESCRIPTION
The compilation on macOS was broken in this PR (https://github.com/pkgconf/pkgconf/pull/533).
I was getting this error:
```c
../libpkgconf/fragment.c:682:26: error: call to undeclared function 'nl_langinfo_l'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  682 |                         const char *codeset = nl_langinfo_l(CODESET, loc);
      |                                               ^
../libpkgconf/fragment.c:682:26: note: did you mean 'nl_langinfo'?
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_langinfo.h:116:20: note: 'nl_langinfo' declared here
  116 | char    *_LIBC_CSTR   nl_langinfo(nl_item);
      |                       ^
../libpkgconf/fragment.c:682:16: error: incompatible integer to pointer conversion initializing 'const char *' with an expression of type 'int' [-Wint-conversion]
  682 |                         const char *codeset = nl_langinfo_l(CODESET, loc);
      |                                     ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

For whatever reason, we need to include ``xlocale.h`` to be able to call ``nl_langinfo_l``.
See: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/nl_langinfo.3.html

Since there isn't any CI that use clang on a unix platform, let's use macOS to verify that we properly support clang.