### PR TITLE
codecov: treat partial hits as full hits

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,6 @@ coverage:
     patch:
       default:
         informational: true
+parsers:
+  cobertura:
+    partials_as_hits: true


### PR DESCRIPTION
gcovr's branch coverage marks a line "partial" whenever not every branch on it was exercised. Codecov's diff/PR view then flags these as not-fully-covered, adding noise unrelated to actual test gaps. Set partials_as_hits so Codecov counts any partially-covered line as a hit, matching the line-coverage-only signal we actually care about.

Due to that, the coverage goes from 65% to 80%.

For more information about this option, see: https://docs.codecov.com/docs/codecovyml-reference#parserscobertura