### PR TITLE
spdxtool: improve test coverage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -249,6 +249,7 @@ EXTRA_DIST =	pkg.m4 \
 		t/spdxtool/help.test \
 		t/spdxtool/meta-package.test \
 		t/spdxtool/meta-package-with-colon-spdx-base-id.test \
+		t/spdxtool/multi-copyright.test \
 		t/spdxtool/multiple-packages.test \
 		t/spdxtool/no-license.test \
 		t/spdxtool/output-file.test \
@@ -334,6 +335,7 @@ EXTRA_DIST =	pkg.m4 \
 		tests/api/test-fragment.c \
 		tests/api/test-license.c \
 		tests/api/test-path-utils.c \
+		tests/api/test-serialize.c \
 		tests/api/test-tuple.c \
 		tests/api/test-variable.c \
 		tests/lib-relocatable/lib/pkgconfig/foo.pc \
@@ -464,6 +466,7 @@ EXTRA_DIST =	pkg.m4 \
 		tests/lib-sbom/test4.pc \
 		tests/lib-sbom/test5.pc \
 		tests/lib-sbom/test6.pc \
+		tests/lib-sbom/multi-copyright.pc \
 		tests/lib-sbom/nolicense.pc \
 		tests/lib-sbom/special.pc \
 		tests/lib-sbom/variable-test1.pc \
@@ -478,6 +481,7 @@ EXTRA_DIST =	pkg.m4 \
 		tests/lib-sbom-files/define_variable_with_dependency.json \
 		tests/lib-sbom-files/meta_package.json \
 		tests/lib-sbom-files/meta_package-use-uri-spdx-base-id.json \
+		tests/lib-sbom-files/multi_copyright.json \
 		tests/lib-sbom-files/multiple_packages.json \
 		tests/lib-sbom-files/nolicense.json \
 		tests/lib-sbom-files/special.json \
@@ -584,6 +588,7 @@ API_TEST_PROGS =		\
 	test-api-fragment	\
 	test-api-license	\
 	test-api-path-utils	\
+	test-api-serialize	\
 	test-api-tuple		\
 	test-api-variable
 
@@ -636,6 +641,16 @@ test_api_path_utils_LDADD = $(api_test_ldadd)
 test_api_path_utils_SOURCES = tests/api/test-path-utils.c
 test_api_path_utils_CPPFLAGS = $(api_test_cppflags)
 
+test_api_serialize_LDADD = $(api_test_ldadd)
+test_api_serialize_SOURCES = \
+	tests/api/test-serialize.c \
+	cli/spdxtool/core.c \
+	cli/spdxtool/software.c \
+	cli/spdxtool/serialize.c \
+	cli/spdxtool/simplelicensing.c \
+	cli/spdxtool/util.c
+test_api_serialize_CPPFLAGS = $(api_test_cppflags) -I$(top_srcdir)/cli/spdxtool
+
 test_api_tuple_LDADD = $(api_test_ldadd)
 test_api_tuple_SOURCES = tests/api/test-tuple.c
 test_api_tuple_CPPFLAGS = $(api_test_cppflags)
@@ -661,6 +676,7 @@ check: pkgconf test-runner $(API_TEST_PROGS)
 	$(builddir)/test-api-fragment$(EXEEXT)
 	$(builddir)/test-api-license$(EXEEXT)
 	$(builddir)/test-api-path-utils$(EXEEXT)
+	$(builddir)/test-api-serialize$(EXEEXT)
 	$(builddir)/test-api-tuple$(EXEEXT)
 	$(builddir)/test-api-variable$(EXEEXT)
 	$(builddir)/test-runner$(EXEEXT) --test-fixtures=$(top_srcdir)/tests --tool-dir="$(PWD)" $(top_srcdir)/t/basic

--- a/cli/spdxtool/util.c
+++ b/cli/spdxtool/util.c
@@ -163,24 +163,6 @@ spdxtool_util_set_spdx_license(pkgconf_client_t *client, const char *spdx_licens
 /*
  * !doc
  *
- * .. c:function:: const char *spdxtool_util_get_spdx_license(pkgconf_client_t *client)
- *
- *    Get license which SBOM is release in
- *
- *    :param pkgconf_client_t* client: The pkgconf client being accessed.
- *    :return: SPDX license
- */
-const char *
-spdxtool_util_get_spdx_license(pkgconf_client_t *client)
-{
-	return pkgconf_tuple_find_global(client, "spdx_license");
-}
-
-static size_t last_id = 0;
-
-/*
- * !doc
- *
  * .. c:function:: char *spdxtool_util_get_spdx_id_int(pkgconf_client_t *client, char *part)
  *
  *    Get spdxId with current URI.
@@ -193,6 +175,7 @@ static size_t last_id = 0;
 char *
 spdxtool_util_get_spdx_id_int(pkgconf_client_t *client, const char *part)
 {
+	static size_t last_id = 0;
 	const char *global_xsd_any_uri = spdxtool_util_get_uri_root(client);
 	char sep = spdxtool_util_get_uri_separator(client);
 	pkgconf_buffer_t current_uri = PKGCONF_BUFFER_INITIALIZER;

--- a/cli/spdxtool/util.h
+++ b/cli/spdxtool/util.h
@@ -102,9 +102,6 @@ spdxtool_util_get_spdx_version(pkgconf_client_t *client);
 void
 spdxtool_util_set_spdx_license(pkgconf_client_t *client, const char *spdx_license);
 
-const char *
-spdxtool_util_get_spdx_license(pkgconf_client_t *client);
-
 char *
 spdxtool_util_get_spdx_id_int(pkgconf_client_t *client, const char *part);
 

--- a/meson.build
+++ b/meson.build
@@ -296,6 +296,22 @@ foreach t : api_tests
   test('api-' + t, exe)
 endforeach
 
+# Unit test for spdxtool's JSON serializer.  Unlike the api_tests above it must
+# also compile the spdxtool sources it exercises (everything but main.c).
+test_api_serialize_exe = executable('test-api-serialize',
+  'tests/api/test-serialize.c',
+  'cli/spdxtool/core.c',
+  'cli/spdxtool/software.c',
+  'cli/spdxtool/serialize.c',
+  'cli/spdxtool/simplelicensing.c',
+  'cli/spdxtool/util.c',
+  windows_manifest,
+  link_with : libpkgconf,
+  c_args : build_static,
+  include_directories : [include_directories('.'), include_directories('tests/api'), include_directories('cli/spdxtool')],
+  install : false)
+test('api-serialize', test_api_serialize_exe)
+
 fixtures_dir = join_paths(meson.current_source_dir(), 'tests')
 tool_dir = meson.current_build_dir()
 

--- a/t/spdxtool/multi-copyright.test
+++ b/t/spdxtool/multi-copyright.test
@@ -1,0 +1,5 @@
+Tool: spdxtool
+ToolArgs: --creation-time=test multi-copyright
+Environment: PKG_CONFIG_PATH=%TEST_FIXTURES_DIR%/lib-sbom
+ExpectedStdoutFile: ../../tests/lib-sbom-files/multi_copyright.json
+ExpectedExitCode: 0

--- a/tests/api/test-serialize.c
+++ b/tests/api/test-serialize.c
@@ -1,0 +1,203 @@
+/*
+ * test-serialize.c
+ * Tests for spdxtool's JSON serialization value model.
+ *
+ * SPDX-License-Identifier: pkgconf
+ *
+ * Copyright (c) 2026 pkgconf authors (see AUTHORS).
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * This software is provided 'as is' and without any warranty, express or
+ * implied.  In no event shall the authors be liable for any damages arising
+ * from the use of this software.
+ */
+
+#include <libpkgconf/stdinc.h>
+#include <libpkgconf/libpkgconf.h>
+#include "test-api.h"
+#include "serialize.h"
+
+// Render a value to a freshly-allocated C string (caller frees)
+static char *
+render(spdxtool_serialize_value_t *value)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+	TEST_ASSERT_TRUE(spdxtool_serialize_value_to_buf(&buf, value, 0));
+	char *s = strdup(pkgconf_buffer_str_or_empty(&buf));
+	pkgconf_buffer_finalize(&buf);
+	return s;
+}
+
+// Render a container without taking ownership of it
+static char *
+render_object(spdxtool_serialize_object_list_t *o)
+{
+	spdxtool_serialize_value_t wrap = { .type = SPDXTOOL_SERIALIZE_TYPE_OBJECT, .value = { .o = o } };
+	return render(&wrap);
+}
+
+static char *
+render_array(spdxtool_serialize_array_t *a)
+{
+	spdxtool_serialize_value_t wrap = { .type = SPDXTOOL_SERIALIZE_TYPE_ARRAY, .value = { .a = a } };
+	return render(&wrap);
+}
+
+// Scalar value types: string / int / bool / null
+static void
+test_serialize_value_string(void)
+{
+	spdxtool_serialize_value_t *v = spdxtool_serialize_value_string("hi");
+	TEST_ASSERT_NONNULL(v);
+	char *s = render(v);
+	TEST_ASSERT_STRCMP_EQ(s, "\"hi\"");
+	free(s);
+	spdxtool_serialize_value_free(v);
+}
+
+static void
+test_serialize_value_int(void)
+{
+	spdxtool_serialize_value_t *v = spdxtool_serialize_value_int(123);
+	TEST_ASSERT_NONNULL(v);
+	char *s = render(v);
+	TEST_ASSERT_STRCMP_EQ(s, "123");
+	free(s);
+	spdxtool_serialize_value_free(v);
+}
+
+static void
+test_serialize_value_bool(void)
+{
+	spdxtool_serialize_value_t *t = spdxtool_serialize_value_bool(true);
+	spdxtool_serialize_value_t *f = spdxtool_serialize_value_bool(false);
+	char *st = render(t);
+	char *sf = render(f);
+	TEST_ASSERT_STRCMP_EQ(st, "true");
+	TEST_ASSERT_STRCMP_EQ(sf, "false");
+	free(st);
+	free(sf);
+	spdxtool_serialize_value_free(t);
+	spdxtool_serialize_value_free(f);
+}
+
+static void
+test_serialize_value_null(void)
+{
+	spdxtool_serialize_value_t *v = spdxtool_serialize_value_null();
+	TEST_ASSERT_NONNULL(v);
+	char *s = render(v);
+	TEST_ASSERT_STRCMP_EQ(s, "null");
+	free(s);
+	spdxtool_serialize_value_free(v);
+}
+
+// All JSON string escape sequences, including control characters
+static void
+test_serialize_escape_sequences(void)
+{
+	spdxtool_serialize_value_t *v = spdxtool_serialize_value_string("\"\\\b\f\n\r\t\x01" "Z");
+	char *s = render(v);
+
+	TEST_ASSERT_STRSTR(s, "\\\"");     // quote
+	TEST_ASSERT_STRSTR(s, "\\\\");     // backslash
+	TEST_ASSERT_STRSTR(s, "\\b");      // backspace
+	TEST_ASSERT_STRSTR(s, "\\f");      // form feed
+	TEST_ASSERT_STRSTR(s, "\\n");      // newline
+	TEST_ASSERT_STRSTR(s, "\\r");      // carriage return
+	TEST_ASSERT_STRSTR(s, "\\t");      // tab
+	TEST_ASSERT_STRSTR(s, "\\u0001");  // other ctrl
+	TEST_ASSERT_STRSTR(s, "Z");        // printable passthrough
+
+	free(s);
+	spdxtool_serialize_value_free(v);
+}
+
+// Mixed-type object exercises the int/bool/null add helpers
+static void
+test_serialize_object_mixed_types(void)
+{
+	spdxtool_serialize_object_list_t *o = spdxtool_serialize_object_list_new();
+	TEST_ASSERT_NONNULL(o);
+
+	TEST_ASSERT_NONNULL(spdxtool_serialize_object_add_string(o, "s", "x"));
+	TEST_ASSERT_NONNULL(spdxtool_serialize_object_add_int(o, "i", 42));
+	TEST_ASSERT_NONNULL(spdxtool_serialize_object_add_bool(o, "b", true));
+	TEST_ASSERT_NONNULL(spdxtool_serialize_object_add_null(o, "n"));
+
+	char *s = render_object(o);
+	TEST_ASSERT_STRSTR(s, "\"s\": \"x\"");
+	TEST_ASSERT_STRSTR(s, "\"i\": 42");
+	TEST_ASSERT_STRSTR(s, "\"b\": true");
+	TEST_ASSERT_STRSTR(s, "\"n\": null");
+
+	free(s);
+	spdxtool_serialize_object_list_free(o);
+}
+
+// Mixed-type array exercises the int/bool/null array helpers
+static void
+test_serialize_array_mixed_types(void)
+{
+	spdxtool_serialize_array_t *a = spdxtool_serialize_array_new();
+	TEST_ASSERT_NONNULL(a);
+
+	TEST_ASSERT_NONNULL(spdxtool_serialize_array_add_int(a, 7));
+	TEST_ASSERT_NONNULL(spdxtool_serialize_array_add_bool(a, false));
+	TEST_ASSERT_NONNULL(spdxtool_serialize_array_add_null(a));
+
+	char *s = render_array(a);
+	TEST_ASSERT_STRSTR(s, "7");
+	TEST_ASSERT_STRSTR(s, "false");
+	TEST_ASSERT_STRSTR(s, "null");
+
+	free(s);
+	spdxtool_serialize_array_free(a);
+}
+
+// Defensive NULL handling that the CLI path never reaches
+static void
+test_serialize_null_guards(void)
+{
+	pkgconf_buffer_t buf = PKGCONF_BUFFER_INITIALIZER;
+	spdxtool_serialize_value_t *v = spdxtool_serialize_value_null();
+
+	// value_to_buf rejects NULL buffer or NULL value
+	TEST_ASSERT_FALSE(spdxtool_serialize_value_to_buf(NULL, v, 0));
+	TEST_ASSERT_FALSE(spdxtool_serialize_value_to_buf(&buf, NULL, 0));
+	pkgconf_buffer_finalize(&buf);
+
+	// value_string(NULL) yields NULL
+	TEST_ASSERT_NULL(spdxtool_serialize_value_string(NULL));
+
+	// add_take with a NULL container frees the value and returns NULL
+	TEST_ASSERT_NULL(spdxtool_serialize_object_add_take(NULL, "k", v));
+	TEST_ASSERT_NULL(spdxtool_serialize_array_add_take(NULL, spdxtool_serialize_value_null()));
+
+	// free routines are NULL-safe
+	spdxtool_serialize_value_free(NULL);
+	spdxtool_serialize_object_free(NULL);
+	spdxtool_serialize_object_list_free(NULL);
+	spdxtool_serialize_array_free(NULL);
+}
+
+int
+main(int argc, const char **argv)
+{
+	(void) argc;
+	const char *basename = pkgconf_path_find_basename(argv[0]);
+
+	TEST_RUN(basename, test_serialize_value_string);
+	TEST_RUN(basename, test_serialize_value_int);
+	TEST_RUN(basename, test_serialize_value_bool);
+	TEST_RUN(basename, test_serialize_value_null);
+	TEST_RUN(basename, test_serialize_escape_sequences);
+	TEST_RUN(basename, test_serialize_object_mixed_types);
+	TEST_RUN(basename, test_serialize_array_mixed_types);
+	TEST_RUN(basename, test_serialize_null_guards);
+
+	return EXIT_SUCCESS;
+}

--- a/tests/lib-sbom-files/multi_copyright.json
+++ b/tests/lib-sbom-files/multi_copyright.json
@@ -1,0 +1,90 @@
+{
+    "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+    "@graph": [
+        {
+            "type": "Agent",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/Agent/default",
+            "name": "Default"
+        },
+        {
+            "type": "CreationInfo",
+            "@id": "_:creationinfo_1",
+            "created": "test",
+            "createdBy": [
+                "https://github.com/pkgconf/pkgconf/Agent/default"
+            ],
+            "specVersion": "3.0.1"
+        },
+        {
+            "type": "simplelicensing_LicenseExpression",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/simplelicensing_LicenseExpression/MIT",
+            "simplelicensing_licenseExpression": "MIT"
+        },
+        {
+            "type": "software_Sbom",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/software_Sbom/multi-copyright",
+            "software_sbomType": [
+                "build"
+            ],
+            "rootElement": [
+                "https://github.com/pkgconf/pkgconf/Package/multi-copyright"
+            ],
+            "element": [
+                "https://github.com/pkgconf/pkgconf/Relationship/multi-copyright/hasDeclaredLicense",
+                "https://github.com/pkgconf/pkgconf/Relationship/multi-copyright/hasConcludedLicense"
+            ]
+        },
+        {
+            "type": "software_Package",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/Package/multi-copyright",
+            "name": "multi-copyright",
+            "originatedBy": [
+                "https://github.com/pkgconf/pkgconf/Agent/default"
+            ],
+            "software_copyrightText": "First copyright holder\nSecond copyright holder",
+            "software_homePage": "https://example.com/mc",
+            "software_downloadLocation": "",
+            "software_packageVersion": "1.0.0"
+        },
+        {
+            "type": "Relationship",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/Relationship/multi-copyright/hasDeclaredLicense",
+            "from": "https://github.com/pkgconf/pkgconf/Package/multi-copyright",
+            "to": [
+                "https://github.com/pkgconf/pkgconf/simplelicensing_LicenseExpression/MIT"
+            ],
+            "relationshipType": "hasDeclaredLicense"
+        },
+        {
+            "type": "Relationship",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/Relationship/multi-copyright/hasConcludedLicense",
+            "from": "https://github.com/pkgconf/pkgconf/Package/multi-copyright",
+            "to": [
+                "https://github.com/pkgconf/pkgconf/simplelicensing_LicenseExpression/MIT"
+            ],
+            "relationshipType": "hasConcludedLicense"
+        },
+        {
+            "type": "SpdxDocument",
+            "creationInfo": "_:creationinfo_1",
+            "spdxId": "https://github.com/pkgconf/pkgconf/spdxDocument/1",
+            "rootElement": [
+                "https://github.com/pkgconf/pkgconf/software_Sbom/multi-copyright"
+            ],
+            "element": [
+                "https://github.com/pkgconf/pkgconf/Agent/default",
+                "https://github.com/pkgconf/pkgconf/simplelicensing_LicenseExpression/MIT",
+                "https://github.com/pkgconf/pkgconf/Relationship/multi-copyright/hasDeclaredLicense",
+                "https://github.com/pkgconf/pkgconf/Relationship/multi-copyright/hasConcludedLicense",
+                "https://github.com/pkgconf/pkgconf/software_Sbom/multi-copyright",
+                "https://github.com/pkgconf/pkgconf/Package/multi-copyright"
+            ]
+        }
+    ]
+}

--- a/tests/lib-sbom/multi-copyright.pc
+++ b/tests/lib-sbom/multi-copyright.pc
@@ -1,0 +1,7 @@
+Name: multi-copyright
+Description: package with multiple copyright lines
+URL: https://example.com/mc
+Version: 1.0.0
+License: MIT
+Copyright: First copyright holder
+Copyright: Second copyright holder


### PR DESCRIPTION
This PR:

* Removes dead code from util.c in spdxtool not used anywhere.
* Adds a multi-line copyright test.
* Adds a serialize test to the API tests (covers the JSON parser; useful to cover weird character paths in quoting and serializer code we don't yet use but may in the future).