### PR TITLE
libpkgconf: deprecate reading pkg-config path from Windows registry

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,11 @@ Changes from 2.5.1 to 3.0.0:
   Continuous integration now exercises both the muon and pkgconf-lite builds.
   See https://github.com/pkgconf/pkgconf/issues/481 for rationale and discussion.
 
+* DEPRECATION: Support for setting `PKG_CONFIG_PATH` from the Windows registry
+  is slated for removal in 3.1.  It is recommended `PKG_CONFIG_PATH` be set from
+  the environment on Windows.
+  See https://github.com/pkgconf/pkgconf/issues/546 for rationale and discussion.
+
 * SPDX Software Bill of Materials (SBOM) generation:
   - New spdxtool(1) utility which generates SPDX Lite 3.0.1 SBOM files.  Initial
     implementation by Tuukka Pasanen, sponsored by The FreeBSD Foundation, and

--- a/libpkgconf/client.c
+++ b/libpkgconf/client.c
@@ -70,8 +70,12 @@ pkgconf_client_dir_list_build(pkgconf_client_t *client, const pkgconf_cross_pers
 		const pkgconf_list_t *prepend_list = &personality->dir_list;
 
 #ifdef _WIN32
-		(void) pkgconf_path_build_from_registry(HKEY_CURRENT_USER, &client->dir_list, true);
-		(void) pkgconf_path_build_from_registry(HKEY_LOCAL_MACHINE, &client->dir_list, true);
+		/*
+		 * NOTE: setting the pkgconf path from the registry is deprecated
+		 * and will be removed in pkgconf 3.1.
+		 */
+		(void) pkgconf_path_build_from_registry(client, HKEY_CURRENT_USER, &client->dir_list, true);
+		(void) pkgconf_path_build_from_registry(client, HKEY_LOCAL_MACHINE, &client->dir_list, true);
 #endif
 
 		if (pkgconf_client_getenv(client, "PKG_CONFIG_LIBDIR") != NULL)

--- a/libpkgconf/libpkgconf.h
+++ b/libpkgconf/libpkgconf.h
@@ -569,7 +569,7 @@ PKGCONF_API void pkgconf_path_prepend(const char *text, pkgconf_list_t *dirlist,
 PKGCONF_API size_t pkgconf_path_split(const char *text, pkgconf_list_t *dirlist, bool filter);
 PKGCONF_API size_t pkgconf_path_build_from_environ(const pkgconf_client_t *client, const char *envvarname, const char *fallback, pkgconf_list_t *dirlist, bool filter);
 #ifdef _WIN32
-PKGCONF_API size_t pkgconf_path_build_from_registry(/* HKEY -> HANDLE -> PVOID */ void *hKey, pkgconf_list_t *dirlist, bool filter);
+PKGCONF_API size_t pkgconf_path_build_from_registry(pkgconf_client_t *client, /* HKEY -> HANDLE -> PVOID */ void *hKey, pkgconf_list_t *dirlist, bool filter);
 #endif
 PKGCONF_API bool pkgconf_path_match_list(const char *path, const pkgconf_list_t *dirlist);
 PKGCONF_API void pkgconf_path_free(pkgconf_list_t *dirlist);

--- a/libpkgconf/path.c
+++ b/libpkgconf/path.c
@@ -528,6 +528,13 @@ pkgconf_path_find_basename(const char *path)
  *
  *    Adds paths to a directory list discovered from a given registry key.
  *
+ *    .. warning::
+ *       The Windows registry search path mechanism is deprecated and will be
+ *       removed in pkgconf 3.1.  Use ``PKG_CONFIG_PATH`` or configure search
+ *       paths explicitly instead.  Avoid using this function directly in new
+ *       code.
+ *
+ *    :param pkgconf_client_t* client: pkgconf client
  *    :param HKEY hKey: The registry key to enumerate.
  *    :param pkgconf_list_t* dir_list: The directory list to append enumerated paths to.
  *    :param bool filter: Whether duplicate paths should be filtered.
@@ -535,7 +542,7 @@ pkgconf_path_find_basename(const char *path)
  *    :rtype: size_t
  */
 size_t
-pkgconf_path_build_from_registry(void *hKey, pkgconf_list_t *dir_list, bool filter)
+pkgconf_path_build_from_registry(pkgconf_client_t *client, void *hKey, pkgconf_list_t *dir_list, bool filter)
 {
 	HKEY key;
 	int i = 0;
@@ -546,6 +553,10 @@ pkgconf_path_build_from_registry(void *hKey, pkgconf_list_t *dir_list, bool filt
 	if (RegOpenKeyEx(hKey, PKG_CONFIG_REG_KEY,
 				0, KEY_READ, &key) != ERROR_SUCCESS)
 		return 0;
+
+	pkgconf_warn(client,
+		"WARNING: support for reading PKG_CONFIG_PATH from the Windows registry "
+		"is deprecated and will be removed in pkgconf 3.1\n");
 
 	while (RegEnumValue(key, i++, buf, &bufsize, NULL, NULL, NULL, NULL)
 			== ERROR_SUCCESS)


### PR DESCRIPTION
There is no evidence of this feature being used in the wild. Environmental variables work just fine on Windows. The primary impetus for this feature was a documented (but probably never implemented) feature in pkg-config of reading `PKG_CONFIG_PATH` from the Windows registry.

Deprecate for now, remove in 3.1. A warning will be emitted if this feature is used.

Closes #546