### PR TITLE
autotools: loudly announce deprecation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -701,7 +701,7 @@ pkgconf-final-stamp:
 	@echo
 	@echo "============================================================================"
 	@echo "WARNING: Autotools support is deprecated and will be removed in pkgconf 3.1."
-	@echo "Please migrate to Meson."
+	@echo "Please migrate to Meson or Muon."
 	@echo "See README.md for instructions on building with Meson."
 	@echo "============================================================================"
 	@echo

--- a/Makefile.am
+++ b/Makefile.am
@@ -696,3 +696,15 @@ check: pkgconf test-runner $(API_TEST_PROGS)
 	$(builddir)/test-runner$(EXEEXT) --test-fixtures=$(top_srcdir)/tests --tool-dir="$(PWD)" $(top_srcdir)/t/symlink
 	$(builddir)/test-runner$(EXEEXT) --test-fixtures=$(top_srcdir)/tests --tool-dir="$(PWD)" $(top_srcdir)/t/sysroot
 	$(builddir)/test-runner$(EXEEXT) --test-fixtures=$(top_srcdir)/tests --tool-dir="$(PWD)" $(top_srcdir)/t/tuple
+
+pkgconf-final-stamp:
+	@echo
+	@echo "============================================================================"
+	@echo "WARNING: Autotools support is deprecated and will be removed in pkgconf 3.1."
+	@echo "Please migrate to Meson."
+	@echo "See README.md for instructions on building with Meson."
+	@echo "============================================================================"
+	@echo
+
+all: pkgconf-final-stamp
+install-exec-hook: pkgconf-final-stamp

--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,12 @@ dnl from the use of this software.
 
 AC_PREREQ([2.71])
 AC_INIT([pkgconf],[2.9.91],[https://github.com/pkgconf/pkgconf/issues/new])
+AC_MSG_WARN([
+===================================================================
+Autotools support is deprecated and will be removed in pkgconf 3.1.
+Please migrate to meson.
+===================================================================
+])
 AC_CONFIG_SRCDIR([cli/main.c])
 AC_CONFIG_MACRO_DIR([m4])
 AX_CHECK_COMPILE_FLAG([-Wall], [CFLAGS="$CFLAGS -Wall"])
@@ -80,6 +86,14 @@ AC_CONFIG_FILES([Makefile libpkgconf.pc])
 AC_OUTPUT
 
 cat << EOF
+
+===================================================================
+*** WARNING ***
+Autotools support is deprecated and will be removed in pkgconf 3.1.
+Please migrate to Meson.
+See README.md for instructions on building with Meson.
+===================================================================
+
 Build configuration:
 
 	Default personality search paths:	${PERSONALITY_PATH}

--- a/configure.ac
+++ b/configure.ac
@@ -90,8 +90,8 @@ cat << EOF
 ===================================================================
 *** WARNING ***
 Autotools support is deprecated and will be removed in pkgconf 3.1.
-Please migrate to Meson.
-See README.md for instructions on building with Meson.
+Please migrate to Meson or Muon.
+See README.md for instructions on building with Meson or Muon.
 ===================================================================
 
 Build configuration:

--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ AC_INIT([pkgconf],[2.9.91],[https://github.com/pkgconf/pkgconf/issues/new])
 AC_MSG_WARN([
 ===================================================================
 Autotools support is deprecated and will be removed in pkgconf 3.1.
-Please migrate to meson.
+Please migrate to Meson or Muon.
 ===================================================================
 ])
 AC_CONFIG_SRCDIR([cli/main.c])


### PR DESCRIPTION
This adds announcements to `configure` and `make` about impending autotools deprecation. Useful for people who failed to read the README / NEWS or just assumed 3.0 is like previous releases.