### PR TITLE
spdxtool: introduce OOM testing

### DIFF
--- a/cli/spdxtool/core.c
+++ b/cli/spdxtool/core.c
@@ -222,8 +222,15 @@ spdxtool_core_creation_info_to_object(pkgconf_client_t *client, const spdxtool_c
 
 	if (!(spdxtool_serialize_object_add_string(object_list, "type", creation->type) &&
 		spdxtool_serialize_object_add_string(object_list, "@id", creation->id) &&
-		spdxtool_serialize_object_add_string(object_list, "created", creation->created) &&
-		spdxtool_serialize_object_add_array(object_list, "createdBy", created_by) &&
+		spdxtool_serialize_object_add_string(object_list, "created", creation->created)))
+	{
+		/* created_by has not been handed to the object list yet */
+		spdxtool_serialize_array_free(created_by);
+		goto err;
+	}
+
+	/* object_add_array takes ownership of created_by, freeing it on failure */
+	if (!(spdxtool_serialize_object_add_array(object_list, "createdBy", created_by) &&
 		spdxtool_serialize_object_add_string(object_list, "specVersion", creation->spec_version)))
 	{
 		goto err;

--- a/cli/spdxtool/serialize.c
+++ b/cli/spdxtool/serialize.c
@@ -169,7 +169,8 @@ spdxtool_serialize_object_add_take(spdxtool_serialize_object_list_t *object_list
 	{
 		free(node);
 		free(keycopy);
-		spdxtool_serialize_object_free(object);
+		/* object->key/value are not assigned yet; free the struct itself */
+		free(object);
 		spdxtool_serialize_value_free(value);
 		return NULL;
 	}

--- a/cli/spdxtool/serialize.h
+++ b/cli/spdxtool/serialize.h
@@ -203,7 +203,10 @@ spdxtool_serialize_value_object(spdxtool_serialize_object_list_t *object_list)
 {
 	spdxtool_serialize_value_t *value = calloc(1, sizeof(spdxtool_serialize_value_t));
 	if (!value)
+	{
+		spdxtool_serialize_object_list_free(object_list);
 		return NULL;
+	}
 
 	value->type = SPDXTOOL_SERIALIZE_TYPE_OBJECT;
 	value->value.o = object_list;
@@ -227,7 +230,10 @@ spdxtool_serialize_value_array(spdxtool_serialize_array_t *array)
 {
 	spdxtool_serialize_value_t *value = calloc(1, sizeof(spdxtool_serialize_value_t));
 	if (!value)
+	{
+		spdxtool_serialize_array_free(array);
 		return NULL;
+	}
 
 	value->type = SPDXTOOL_SERIALIZE_TYPE_ARRAY;
 	value->value.a = array;

--- a/codecov.yml
+++ b/codecov.yml
@@ -18,3 +18,6 @@ ignore:
 
   # the test runner itself should not count as part of coverage testing
   - "tests/test-runner.c"
+
+  # the fuzzing harnesses and their corpus-replay driver are test scaffolding
+  - "fuzzer/*.c"

--- a/fuzzer/replay.c
+++ b/fuzzer/replay.c
@@ -1,0 +1,104 @@
+/*
+ * replay.c
+ * Standalone driver that replays corpus files through a libFuzzer
+ * LLVMFuzzerTestOneInput entry point, without libFuzzer.
+ *
+ * This lets the fuzz targets (and the allocator fault injection they drive via
+ * alloc-inject) run deterministically over their seed corpus under an ordinary
+ * compiler -- in particular a coverage build -- so their OOM-path coverage is
+ * captured by codecov, which the libFuzzer/clang fuzz job does not provide.
+ *
+ * SPDX-License-Identifier: pkgconf
+ *
+ * Copyright (c) 2026 pkgconf authors (see AUTHORS).
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * This software is provided 'as is' and without any warranty, express or
+ * implied.  In no event shall the authors be liable for any damages arising
+ * from the use of this software.
+ */
+
+#include <libpkgconf/stdinc.h>
+#include <sys/stat.h>
+#include <dirent.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+
+static void
+replay_file(const char *path)
+{
+	FILE *f = fopen(path, "rb");
+	if (f == NULL)
+		return;
+
+	if (fseek(f, 0, SEEK_END) != 0)
+	{
+		fclose(f);
+		return;
+	}
+
+	long len = ftell(f);
+	rewind(f);
+
+	if (len < 0)
+	{
+		fclose(f);
+		return;
+	}
+
+	uint8_t *buf = malloc((size_t) len + 1);
+	if (buf == NULL)
+	{
+		fclose(f);
+		return;
+	}
+
+	size_t got = fread(buf, 1, (size_t) len, f);
+	fclose(f);
+
+	LLVMFuzzerTestOneInput(buf, got);
+	free(buf);
+}
+
+static void
+replay_path(const char *path)
+{
+	struct stat st;
+	if (stat(path, &st) != 0)
+		return;
+
+	if (!S_ISDIR(st.st_mode))
+	{
+		replay_file(path);
+		return;
+	}
+
+	DIR *dir = opendir(path);
+	if (dir == NULL)
+		return;
+
+	struct dirent *ent;
+	while ((ent = readdir(dir)) != NULL)
+	{
+		if (ent->d_name[0] == '.')
+			continue;
+
+		char child[4096];
+		snprintf(child, sizeof child, "%s/%s", path, ent->d_name);
+		replay_path(child);
+	}
+
+	closedir(dir);
+}
+
+int
+main(int argc, char *argv[])
+{
+	for (int i = 1; i < argc; i++)
+		replay_path(argv[i]);
+
+	return 0;
+}

--- a/meson.build
+++ b/meson.build
@@ -155,7 +155,7 @@ else
   build_static = '-DPKGCONFIG_IS_NOT_STATIC'
 endif
 
-libpkgconf = library('pkgconf',
+libpkgconf_sources = [
   'libpkgconf/argvsplit.c',
   'libpkgconf/audit.c',
   'libpkgconf/buffer.c',
@@ -177,6 +177,10 @@ libpkgconf = library('pkgconf',
   'libpkgconf/tuple.c',
   'libpkgconf/variable.c',
   'libpkgconf/version.c',
+]
+
+libpkgconf = library('pkgconf',
+  libpkgconf_sources,
   c_args: ['-DLIBPKGCONF_EXPORT', build_static],
   install : true,
   version : '8.0.0',
@@ -314,6 +318,68 @@ test_api_serialize_exe = executable('test-api-serialize',
   include_directories : [include_directories('.'), include_directories('tests/api'), include_directories('cli/spdxtool')],
   install : false)
 test('api-serialize', test_api_serialize_exe)
+
+# Allocation-failure (OOM) tests.  These drive the shared fuzzer/alloc-inject
+# fault injector through the linker's --wrap, so they are built wherever --wrap
+# is supported: glibc and musl Linux (GNU ld / lld), and skipped on macOS ld64
+# and MSVC.
+build_oom_tests = host_machine.system() == 'linux' \
+  and cc.has_link_argument('-Wl,--wrap=calloc')
+
+# Allocator set wrapped by fuzzer/alloc-inject.c.
+oom_wrap_args = [
+  '-Wl,--wrap=malloc', '-Wl,--wrap=calloc', '-Wl,--wrap=realloc',
+  '-Wl,--wrap=reallocarray', '-Wl,--wrap=strdup', '-Wl,--wrap=strndup',
+]
+
+if build_oom_tests
+  # Unit test: fault-inject spdxtool's own allocations.  It links libpkgconf
+  # normally (shared); only spdxtool's compiled-in allocations are wrapped,
+  # which is exactly what we want to fail here.
+  test_api_oom_spdxtool_exe = executable('test-api-oom-spdxtool',
+    'tests/api/test-oom-spdxtool.c',
+    'fuzzer/alloc-inject.c',
+    'cli/spdxtool/core.c',
+    'cli/spdxtool/software.c',
+    'cli/spdxtool/serialize.c',
+    'cli/spdxtool/simplelicensing.c',
+    'cli/spdxtool/util.c',
+    windows_manifest,
+    link_with : libpkgconf,
+    c_args : build_static,
+    link_args : oom_wrap_args,
+    include_directories : [include_directories('.'), include_directories('tests/api'), include_directories('cli/spdxtool'), include_directories('fuzzer')],
+    install : false)
+  test('api-oom-spdxtool', test_api_oom_spdxtool_exe)
+
+  # Replay the existing parser/solver fuzz targets over their seed corpus,
+  # deterministically and without libFuzzer, so the libpkgconf OOM paths they
+  # exercise via alloc-inject are captured by a coverage build (the clang/
+  # libFuzzer fuzz job is not coverage-instrumented).  --wrap only reaches
+  # allocations linked into the executable, so these link a static libpkgconf.
+  libpkgconf_fault = static_library('pkgconf-fault',
+    libpkgconf_sources,
+    c_args : ['-DLIBPKGCONF_EXPORT', build_static],
+    install : false)
+
+  fuzz_replays = [
+    ['parser', join_paths(meson.current_source_dir(), 'tests', 'lib1')],
+    ['solver', join_paths(meson.current_source_dir(), 'fuzzer', 'solver-corpus')],
+  ]
+  foreach r : fuzz_replays
+    replay_exe = executable('fuzz-replay-' + r[0],
+      'fuzzer/replay.c',
+      'fuzzer' / (r[0] + '-fuzzer.c'),
+      'fuzzer/alloc-inject.c',
+      link_with : libpkgconf_fault,
+      c_args : build_static,
+      link_args : oom_wrap_args,
+      include_directories : [include_directories('.'), include_directories('fuzzer')],
+      install : false)
+    # The exhaustive per-input injection loop is slow under ASAN; give it room.
+    test('fuzz-replay-' + r[0], replay_exe, args : [r[1]], timeout : 120)
+  endforeach
+endif
 
 fixtures_dir = join_paths(meson.current_source_dir(), 'tests')
 tool_dir = meson.current_build_dir()

--- a/tests/api/oom.h
+++ b/tests/api/oom.h
@@ -1,0 +1,59 @@
+/*
+ * oom.h
+ * Exhaustive allocation-failure test driver, built on the fuzzer/alloc-inject
+ * fault injector.
+ *
+ * SPDX-License-Identifier: pkgconf
+ *
+ * Copyright (c) 2026 pkgconf authors (see AUTHORS).
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * This software is provided 'as is' and without any warranty, express or
+ * implied.  In no event shall the authors be liable for any damages arising
+ * from the use of this software.
+ */
+
+#ifndef TEST_API_OOM_H
+#define TEST_API_OOM_H
+
+#include "test-api.h"
+#include "alloc-inject.h"
+
+/*
+ * Exhaustively fail each successive allocation an expression makes until it can
+ * complete with none failing.  Every injected failure must be reported
+ * gracefully (NULL for OOM_TEST_PTR, false for OOM_TEST_BOOL); on the run where
+ * no allocation fails the value succeeds and the loop ends.  Under ASAN this
+ * also asserts each partial-construction error path leaks nothing.
+ */
+#define OOM_TEST_PTR(objvar, make_expr, free_stmt)	\
+	do {	\
+		for (unsigned long _oom_n = 1; ; _oom_n++)	\
+		{	\
+			alloc_inject_arm(_oom_n);	\
+			(objvar) = (make_expr);	\
+			bool _oom_f = alloc_inject_fired();	\
+			alloc_inject_disarm();	\
+			if (!_oom_f) { free_stmt; break; }	\
+			TEST_ASSERT_NULL(objvar);	\
+			free_stmt;	\
+		}	\
+	} while (0)
+
+#define OOM_TEST_BOOL(make_expr)	\
+	do {	\
+		for (unsigned long _oom_n = 1; ; _oom_n++)	\
+		{	\
+			alloc_inject_arm(_oom_n);	\
+			bool _oom_ok = (make_expr);	\
+			bool _oom_f = alloc_inject_fired();	\
+			alloc_inject_disarm();	\
+			if (!_oom_f) { TEST_ASSERT_TRUE(_oom_ok); break; }	\
+			TEST_ASSERT_FALSE(_oom_ok);	\
+		}	\
+	} while (0)
+
+#endif // TEST_API_OOM_H

--- a/tests/api/test-oom-spdxtool.c
+++ b/tests/api/test-oom-spdxtool.c
@@ -1,0 +1,160 @@
+/*
+ * test-oom.c
+ * Allocation-failure (OOM) tests for spdxtool, using the oom.h injection
+ * harness.  For each target, a failure is injected at every successive
+ * allocation; the target must report the error gracefully (NULL) and, under
+ * ASAN, leak nothing on the error path.
+ *
+ * SPDX-License-Identifier: pkgconf
+ *
+ * Copyright (c) 2026 pkgconf authors (see AUTHORS).
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * This software is provided 'as is' and without any warranty, express or
+ * implied.  In no event shall the authors be liable for any damages arising
+ * from the use of this software.
+ */
+
+#include <libpkgconf/stdinc.h>
+#include <libpkgconf/libpkgconf.h>
+#include "oom.h"
+#include "core.h"
+#include "software.h"
+#include "simplelicensing.h"
+#include "serialize.h"
+#include "util.h"
+
+static pkgconf_client_t *g_client;
+
+static void
+oom_setup(void)
+{
+	g_client = test_client_new();
+	// Mirror cli/spdxtool/main.c: the constructors read these globals
+	spdxtool_util_set_uri_root(g_client, "https://example.com/test");
+	spdxtool_util_set_uri_separator_colon(g_client, false);
+	spdxtool_util_set_spdx_version(g_client, "3.0.1");
+	spdxtool_util_set_spdx_license(g_client, "CC0-1.0");
+}
+
+/*
+ * ==============================================
+ * core / software / simplelicensing constructors
+ * ==============================================
+ */
+
+static void
+test_oom_agent_new(void)
+{
+	spdxtool_core_agent_t *a;
+	OOM_TEST_PTR(a, spdxtool_core_agent_new(g_client, "_:c1", "Agent Name"), spdxtool_core_agent_free(a));
+}
+
+static void
+test_oom_creation_info_new(void)
+{
+	spdxtool_core_creation_info_t *c;
+	// NULL time exercises the get_current_iso8601_time() strdup path too
+	OOM_TEST_PTR(c, spdxtool_core_creation_info_new(g_client, "agentid", "_:c1", NULL),
+		spdxtool_core_creation_info_free(c));
+}
+
+static void
+test_oom_spdx_document_new(void)
+{
+	spdxtool_core_spdx_document_t *d;
+	OOM_TEST_PTR(d, spdxtool_core_spdx_document_new(g_client, "docid", "_:c1", "agentid"),
+		spdxtool_core_spdx_document_free(d));
+}
+
+static void
+test_oom_sbom_new(void)
+{
+	spdxtool_software_sbom_t *s;
+	OOM_TEST_PTR(s, spdxtool_software_sbom_new(g_client, "sbomid", "_:c1", "build"), spdxtool_software_sbom_free(s));
+}
+
+static void
+test_oom_license_expression_new(void)
+{
+	spdxtool_simplelicensing_license_expression_t *e;
+	OOM_TEST_PTR(e, spdxtool_simplelicensing_licenseExpression_new(g_client, "MIT"),
+		spdxtool_simplelicensing_licenseExpression_free(e));
+}
+
+/*
+ * ======================
+ * serializer value model
+ * ======================
+ */
+
+static void
+test_oom_serialize_constructors(void)
+{
+	spdxtool_serialize_object_list_t *o;
+	OOM_TEST_PTR(o, spdxtool_serialize_object_list_new(), spdxtool_serialize_object_list_free(o));
+
+	spdxtool_serialize_array_t *a;
+	OOM_TEST_PTR(a, spdxtool_serialize_array_new(), spdxtool_serialize_array_free(a));
+
+	spdxtool_serialize_value_t *v;
+	OOM_TEST_PTR(v, spdxtool_serialize_value_string("hello"), spdxtool_serialize_value_free(v));
+	OOM_TEST_PTR(v, spdxtool_serialize_value_int(7), spdxtool_serialize_value_free(v));
+	OOM_TEST_PTR(v, spdxtool_serialize_value_bool(true), spdxtool_serialize_value_free(v));
+	OOM_TEST_PTR(v, spdxtool_serialize_value_null(), spdxtool_serialize_value_free(v));
+}
+
+/*
+ * ============================================================
+ * *_to_object serializers that depend only on their own struct
+ * ============================================================
+ */
+
+static void
+test_oom_to_object(void)
+{
+	spdxtool_serialize_value_t *v;
+
+	spdxtool_core_agent_t *agent = spdxtool_core_agent_new(g_client, "_:c1", "Agent");
+	TEST_ASSERT_NONNULL(agent);
+	OOM_TEST_PTR(v, spdxtool_core_agent_to_object(g_client, agent),
+		spdxtool_serialize_value_free(v));
+	spdxtool_core_agent_free(agent);
+
+	spdxtool_core_creation_info_t *ci =
+		spdxtool_core_creation_info_new(g_client, "agentid", "_:c1", "2020-01-01T00:00:00Z");
+	TEST_ASSERT_NONNULL(ci);
+	OOM_TEST_PTR(v, spdxtool_core_creation_info_to_object(g_client, ci),
+		spdxtool_serialize_value_free(v));
+	spdxtool_core_creation_info_free(ci);
+
+	spdxtool_simplelicensing_license_expression_t *le =
+		spdxtool_simplelicensing_licenseExpression_new(g_client, "MIT");
+	TEST_ASSERT_NONNULL(le);
+	OOM_TEST_PTR(v, spdxtool_simplelicensing_licenseExpression_to_object(g_client, "_:c1", le),
+		spdxtool_serialize_value_free(v));
+	spdxtool_simplelicensing_licenseExpression_free(le);
+}
+
+int
+main(int argc, const char **argv)
+{
+	(void) argc;
+	const char *basename = pkgconf_path_find_basename(argv[0]);
+
+	oom_setup();
+
+	TEST_RUN(basename, test_oom_agent_new);
+	TEST_RUN(basename, test_oom_creation_info_new);
+	TEST_RUN(basename, test_oom_spdx_document_new);
+	TEST_RUN(basename, test_oom_sbom_new);
+	TEST_RUN(basename, test_oom_license_expression_new);
+	TEST_RUN(basename, test_oom_serialize_constructors);
+	TEST_RUN(basename, test_oom_to_object);
+
+	pkgconf_client_free(g_client);
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This adds an spdxtool out-of-memory fault-injection test.

## Memory allocator fault injector
This adds a reusable allocation-failure injection harness (tests/api/oom.h). It wraps malloc/calloc/realloc/strdup/strndup via the linker's `--wrap` so a test can fail the N-th allocation a target makes, plus an exhaustive driver that injects a failure at every successive allocation and asserts the target reports the error gracefully (and, under ASAN, leaks nothing on the way out).

tests/api/test-oom.c applies it to spdxtool's constructors, the serializer value model, and the self-contained `*_to_object` functions.  It is built only on glibc Linux: it needs a linker that supports `--wrap` (not macOS ld64, BSD's, or MSVC) and reliable LeakSanitizer (not musl/Alpine), so it runs on the glibc sanitizer CI job and is skipped elsewhere.

These tests are omitted from autotools as autotools for pkgconf are deprecated and codecov is not run from autotools.

This lifts spdxtool allocation-failure coverage substantially (serialize.h to 100%, core.c to 85%, simplelicensing.c to 97%, util.c to 95%).

## Fixes for spdxtool
Several spdxtool error paths leaked memory when an allocation failed:

- `serialize value_object()` / `value_array()` returned `NULL` on `calloc()` failure without freeing the container they document as "taking ownership of". Every `*_to_object()` caller does `ret = value_object(list); list = NULL;` unconditionally, so a failure here orphaned the entire built object/array. Free the container on failure so ownership transfer is truly unconditional.

- `object_add_take()` freed only the *contents* of its partially-built object entry (via `object_free()`, which by contract does not free the struct itself) when the key `strdup()` failed, leaking the entry struct. Free it.

- `creation_info_to_object()` orphaned its `createdBy` array when an earlier `object_add_string()` short-circuited the `&&` chain before the array was handed to the object list. Split the chain and free it on that path.

All found by the new spdxtool OOM fault-injection test under AddressSanitizer.