### PR TITLE
codecov: exempt API tests from coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -19,5 +19,8 @@ ignore:
   # the test runner itself should not count as part of coverage testing
   - "tests/test-runner.c"
 
+  # the API tests should not count as part of coverage testing
+  - "tests/api/*.c"
+
   # the fuzzing harnesses and their corpus-replay driver are test scaffolding
   - "fuzzer/*.c"


### PR DESCRIPTION
These are test programs that should not count towards overall coverage.

No functional changes.