### PR TITLE
ci: add tests on Debian 7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -401,6 +401,54 @@ jobs:
         run: |
           make distcheck
 
+  debian-7:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          path: pkgconf
+
+      - name: Checkout muon
+        uses: actions/checkout@v6
+        with:
+          repository: muon-build/muon
+          path: muon
+
+      - name: Build inside Debian 7
+        run: |
+          cat > build.sh << 'EOF'
+          #!/bin/bash
+          set -e
+
+          # See: https://www.howtoforge.com/using-old-debian-versions-in-your-sources.list
+          cat > /etc/apt/sources.list << 'SOURCES'
+          deb http://archive.debian.org/debian/ wheezy main non-free contrib
+          deb-src http://archive.debian.org/debian/ wheezy main non-free contrib
+
+          deb http://archive.debian.org/debian-security/ wheezy/updates main non-free contrib
+          deb-src http://archive.debian.org/debian-security/ wheezy/updates main non-free contrib
+          SOURCES
+
+          # Install gcc
+          apt-get update || true
+          apt-get install -y --force-yes gcc
+
+          # Build muon
+          cd /home/muon
+          # To know why "-lrt" is needed, see: https://github.com/muon-build/muon/issues/268
+          LDFLAGS="-lrt" ./bootstrap.sh build
+          LDFLAGS="-lrt" build/muon-bootstrap setup -Dmeson-docs=disabled build
+          build/muon-bootstrap -C build samu
+          build/muon -C build install
+
+          # Build pkgconf + run tests
+          cd /home/pkgconf
+          muon build builddir
+          muon -C builddir test -v -v
+          EOF
+          docker run --rm --volume "$PWD":/home debian:7 /bin/bash /home/build.sh
+
   analysis:
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Debian 7 is fairly old. It ships with gcc 4.7.2 and glibc 2.13. glibc 2.13 was released on 1 February 2011 (https://sourceware.org/glibc/wiki/Glibc%20Timeline).
This CI job should catch any glibc compatibility issues.
It should help to catch issues like: https://github.com/pkgconf/pkgconf/issues/553

This is just an idea. I know we already have a lot of CI, so this might be overkill.