### PR TITLE
build: distribute `pkgconf.manifest.in` and `pkgconf.rc.in`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,8 @@ lib_LTLIBRARIES = libpkgconf.la
 EXTRA_DIST =	pkg.m4 \
 		meson.build \
 		meson_options.txt \
+		pkgconf.manifest.in \
+		pkgconf.rc.in \
 		pkgconf.wxs.in \
 		txt2rtf.py \
 		libpkgconf/meson.build \


### PR DESCRIPTION
Meson builds need these on Windows and they weren't being included in the dist tarball.