### PR TITLE
cmake: ship a find_package(pkgconf CONFIG) package config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,9 +102,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: [
-          { msystem: MINGW64, arch: x86_64},
-        ]
+        include: [{ msystem: MINGW64, arch: x86_64 }]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -190,19 +188,19 @@ jobs:
       matrix:
         include:
           - os_image: netbsd
-            version: '10.1'
+            version: "10.1"
 
           - os_image: freebsd
-            version: '15.1'
+            version: "15.1"
 
           - os_image: openbsd
-            version: '7.9'
+            version: "7.9"
 
           - os_image: haiku
-            version: 'r1beta5'
+            version: "r1beta5"
 
           - os_image: omnios
-            version: 'r151056'
+            version: "r151056"
 
     steps:
       - name: Checkout code
@@ -540,6 +538,100 @@ jobs:
           export CC=clang
           export CFLAGS="-std=c99 -O2 -Wall -Wextra -ggdb3 -fsanitize=address,undefined"
           make -f Makefile.lite PKG_DEFAULT_PATH="/usr/lib/pkgconfig:/usr/share/pkgconfig" SYSTEM_LIBDIR="/usr/lib" SYSTEM_INCLUDEDIR="/usr/include" -j $(nproc) check
+
+  cmake-macros:
+    name: cmake-macros (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-static
+            runs_on: ubuntu-latest
+            default_library: static
+
+          - name: linux-shared
+            runs_on: ubuntu-latest
+            default_library: shared
+
+          - name: macos-static
+            runs_on: macos-latest
+            default_library: static
+    runs-on: ${{ matrix.runs_on }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install build tools (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential meson ninja-build cmake
+
+      - name: Install build tools (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install meson ninja cmake
+
+      - name: Build and install pkgconf
+        run: |
+          # Point with-system-libdir at a path that can't match the install
+          # prefix, so pkgconf keeps -L for its own libdir in --libs-only-L
+          # output. It otherwise drops -L when a module's libdir equals the
+          # compiled-in "system" libdir, which defaults to the install prefix's
+          # libdir.
+          meson setup _build_cmake_verify \
+            --prefix="${{ github.workspace }}/_install_cmake_verify" \
+            -Ddefault_library=${{ matrix.default_library }} \
+            -Dwith-system-libdir=/nonexistent-pkgconf-cmake-test-marker
+          meson compile -C _build_cmake_verify
+          meson install -C _build_cmake_verify
+
+      - name: Configure environment for the installed (possibly shared) library
+        run: |
+          prefix="${{ github.workspace }}/_install_cmake_verify"
+          # meson may install under lib/, lib64/ or a multiarch dir such as
+          # lib/x86_64-linux-gnu, so locate the shared library by name instead
+          # of guessing the directory. Empty on the static legs, which don't
+          # need it.
+          libdirs="$(find "$prefix" -type f \( -name 'libpkgconf*.so*' -o -name 'libpkgconf*.dylib' \) -exec dirname {} \; | sort -u | tr '\n' ':')"
+          echo "LD_LIBRARY_PATH=${libdirs}${LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
+          echo "DYLD_LIBRARY_PATH=${libdirs}${DYLD_LIBRARY_PATH}" >> "$GITHUB_ENV"
+          echo "CMAKE_PREFIX_PATH=${prefix}" >> "$GITHUB_ENV"
+
+      - name: Install a real pkg-config package (zlib)
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            sudo apt-get install -y zlib1g-dev
+          else
+            brew install zlib
+          fi
+          # The pkgconf we built has its own compiled-in search path under the
+          # test prefix, so tell it where the OS actually dropped zlib.pc.
+          zlibpc="$(find /usr /opt/homebrew /usr/local -name zlib.pc 2>/dev/null | head -n1)"
+          if [ -z "$zlibpc" ]; then
+            echo "could not locate an installed zlib.pc" >&2
+            exit 1
+          fi
+          echo "PKG_CONFIG_PATH=$(dirname "$zlibpc"):${PKG_CONFIG_PATH}" >> "$GITHUB_ENV"
+
+      - name: pkgconf_check_modules() / pkgconf_search_module() / query macros
+        run: |
+          cmake -S cmake/tests/basic -B _build_cmake_test
+          cmake --build _build_cmake_test
+          _build_cmake_test/consumer
+
+      - name: REQUIRED module must fail configure when not found
+        run: |
+          if cmake -S cmake/tests/required-fail -B _build_cmake_required_fail; then
+            echo "expected cmake configure to fail for a REQUIRED module that does not exist" >&2
+            exit 1
+          fi
+
+      - name: Consume a real package (zlib) through the imported target
+        run: |
+          cmake -S cmake/tests/zlib -B _build_cmake_zlib
+          cmake --build _build_cmake_zlib
+          _build_cmake_zlib/zlib-consumer
 
   fuzz:
     runs-on: ubuntu-latest

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,6 +22,13 @@ EXTRA_DIST =	pkg.m4 \
 		pkgconf.rc.in \
 		pkgconf.wxs.in \
 		txt2rtf.py \
+		cmake/pkgconf-config.cmake.in \
+		cmake/pkgconf-config-version.cmake.in \
+		cmake/tests/basic/CMakeLists.txt \
+		cmake/tests/basic/consumer.c \
+		cmake/tests/required-fail/CMakeLists.txt \
+		cmake/tests/zlib/CMakeLists.txt \
+		cmake/tests/zlib/consumer.c \
 		libpkgconf/meson.build \
 		libpkgconf/config.h.meson \
 		libpkgconf/win-dirent.h \

--- a/cmake/pkgconf-config-version.cmake.in
+++ b/cmake/pkgconf-config-version.cmake.in
@@ -1,0 +1,27 @@
+# pkgconf-config-version.cmake
+#
+# Version-compatibility file for find_package(pkgconf CONFIG). pkgconf isn't
+# built with CMake, so this is the hand-written equivalent of what
+# write_basic_package_version_file(... COMPATIBILITY SameMajorVersion) emits.
+
+set(PACKAGE_VERSION "@PKGCONF_VERSION@")
+
+if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
+  set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+  if(PACKAGE_VERSION MATCHES "^([0-9]+)")
+    set(CVF_VERSION_MAJOR "${CMAKE_MATCH_1}")
+  else()
+    set(CVF_VERSION_MAJOR "${PACKAGE_VERSION}")
+  endif()
+
+  if(PACKAGE_FIND_VERSION_MAJOR STREQUAL CVF_VERSION_MAJOR)
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+  else()
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  endif()
+
+  if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+    set(PACKAGE_VERSION_EXACT TRUE)
+  endif()
+endif()

--- a/cmake/pkgconf-config.cmake.in
+++ b/cmake/pkgconf-config.cmake.in
@@ -1,0 +1,400 @@
+# pkgconf-config.cmake
+#
+# CMake package config for the pkgconf(1) implementation of pkg-config.
+# Enables find_package(pkgconf CONFIG). See pkgconf(1) for the flag semantics.
+#
+# Defines:
+#
+#   PKGCONF_EXECUTABLE  - path to the pkgconf executable
+#   PkgConf::pkgconf    - imported executable target for pkgconf
+#
+# Module-set macros, modelled on CMake's FindPkgConfig.cmake
+# (pkg_check_modules()/pkg_search_module()), but always using this pkgconf
+# executable instead of whatever pkg-config is first on PATH:
+#
+#   pkgconf_check_modules(<prefix> [REQUIRED] [QUIET] [IMPORTED_TARGET]
+#                         [STATIC] [SHARED] [ENV_ONLY] [NO_UNINSTALLED]
+#                         [NO_PROVIDES] [IGNORE_CONFLICTS]
+#                         [MAXIMUM_TRAVERSE_DEPTH <depth>]
+#                         [DEFINE_VARIABLE <name=value>...]
+#                         [WITH_PATH <dir>...]
+#                         <modulespec>...)
+#     Queries pkgconf for all of the given module(s) (ANDed together, as with
+#     `pkgconf --exists <modulespec>...`), and on success sets:
+#       <prefix>_FOUND, <prefix>_VERSION, <prefix>_INCLUDE_DIRS, <prefix>_CFLAGS,
+#       <prefix>_CFLAGS_OTHER, <prefix>_LIBRARIES, <prefix>_LIBRARY_DIRS,
+#       <prefix>_LDFLAGS, <prefix>_LDFLAGS_OTHER
+#     IMPORTED_TARGET additionally defines an INTERFACE IMPORTED target
+#     PkgConf::<prefix>. The remaining keyword options map to the matching
+#     pkgconf(1) flags (--static/--shared, --env-only, --no-uninstalled,
+#     --no-provides, --ignore-conflicts, --maximum-traverse-depth,
+#     --define-variable, --with-path) and are passed to every pkgconf call
+#     this macro makes.
+#
+#   pkgconf_search_module(<prefix> ... <modulespec>...)
+#     Same options as pkgconf_check_modules(), but tries each <modulespec>
+#     individually and stops at the first one that is found, recording it in
+#     <prefix>_MODULE_NAME.
+#
+# Single-module query functions, wrapping the pkgconf(1) options that report
+# on one module at a time:
+#
+#   pkgconf_get_variable(<out-var> <module> <varname>)       --variable
+#   pkgconf_variable_names(<out-var> <module>)                --print-variables
+#   pkgconf_get_path(<out-var> <module>)                       --path
+#   pkgconf_check_version(<out-var> <module> <mode> <version>)
+#       mode is one of ATLEAST, EXACT, MAX, mapping to --atleast-version,
+#       --exact-version, --max-version; <out-var> is set to TRUE or FALSE.
+#   pkgconf_print_provides(<out-var> <module>)                 --print-provides
+#   pkgconf_print_requires(<out-var> <module> [PRIVATE])       --print-requires[-private]
+#   pkgconf_link_abi(<out-var> <module> [STATIC])               --link-abi
+#   pkgconf_list_all(<out-var>)                                 --list-all
+#
+# The diagnostic-only pkgconf options (--simulate, --digraph, --solution,
+# --fragment-tree, --dump-personality, --validate, --debug) aren't wrapped
+# here; they're for interactive troubleshooting, not for use inside a build.
+
+cmake_minimum_required(VERSION 3.13)
+
+find_program(PKGCONF_EXECUTABLE
+  NAMES pkgconf
+  HINTS "@PKGCONF_BINDIR@"
+  DOC "Path to the pkgconf executable"
+)
+mark_as_advanced(PKGCONF_EXECUTABLE)
+
+if(NOT PKGCONF_EXECUTABLE)
+  set(pkgconf_FOUND FALSE)
+  if(pkgconf_FIND_REQUIRED)
+    message(FATAL_ERROR "pkgconf: could not find the pkgconf executable")
+  endif()
+  return()
+endif()
+
+execute_process(
+  COMMAND "${PKGCONF_EXECUTABLE}" --version
+  OUTPUT_VARIABLE pkgconf_VERSION
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+set(pkgconf_FOUND TRUE)
+
+if(NOT TARGET PkgConf::pkgconf)
+  add_executable(PkgConf::pkgconf IMPORTED)
+  set_target_properties(PkgConf::pkgconf PROPERTIES IMPORTED_LOCATION "${PKGCONF_EXECUTABLE}")
+endif()
+
+# Build the list of global pkgconf flags shared by pkgconf_check_modules()
+# and pkgconf_search_module(), out of the variables that
+# cmake_parse_arguments(${_arg_prefix} ...) left in the caller's scope.
+function(_pkgconf_common_args _out_var _arg_prefix)
+  set(_args "")
+  if(${_arg_prefix}_STATIC)
+    list(APPEND _args "--static")
+  endif()
+  if(${_arg_prefix}_SHARED)
+    list(APPEND _args "--shared")
+  endif()
+  if(${_arg_prefix}_ENV_ONLY)
+    list(APPEND _args "--env-only")
+  endif()
+  if(${_arg_prefix}_NO_UNINSTALLED)
+    list(APPEND _args "--no-uninstalled")
+  endif()
+  if(${_arg_prefix}_NO_PROVIDES)
+    list(APPEND _args "--no-provides")
+  endif()
+  if(${_arg_prefix}_IGNORE_CONFLICTS)
+    list(APPEND _args "--ignore-conflicts")
+  endif()
+  if(DEFINED ${_arg_prefix}_MAXIMUM_TRAVERSE_DEPTH)
+    list(APPEND _args "--maximum-traverse-depth=${${_arg_prefix}_MAXIMUM_TRAVERSE_DEPTH}")
+  endif()
+  foreach(_def ${${_arg_prefix}_DEFINE_VARIABLE})
+    list(APPEND _args "--define-variable=${_def}")
+  endforeach()
+  foreach(_path ${${_arg_prefix}_WITH_PATH})
+    list(APPEND _args "--with-path=${_path}")
+  endforeach()
+  set(${_out_var} "${_args}" PARENT_SCOPE)
+endfunction()
+
+# _pkgconf_invoke(<prefix> <quiet> <modules-for-messages> <flags-and-modules>...)
+# Run the module-set queries and set <prefix>_FOUND/_VERSION/etc. in the
+# caller's scope. <flags-and-modules> is the full pkgconf argument list
+# (global flags from _pkgconf_common_args() plus the modules) used for every
+# call; <modules-for-messages> is the module list on its own, for diagnostics.
+function(_pkgconf_invoke _prefix _quiet _modules_for_msg)
+  execute_process(
+    COMMAND "${PKGCONF_EXECUTABLE}" --exists --print-errors ${ARGN}
+    RESULT_VARIABLE _pkgconf_result
+    ERROR_VARIABLE _pkgconf_error
+    OUTPUT_QUIET
+  )
+
+  if(NOT _pkgconf_result EQUAL 0)
+    set(${_prefix}_FOUND FALSE PARENT_SCOPE)
+    if(NOT _quiet)
+      message(STATUS "pkgconf: could not find module(s) \"${_modules_for_msg}\":\n${_pkgconf_error}")
+    endif()
+    return()
+  endif()
+
+  set(${_prefix}_FOUND TRUE PARENT_SCOPE)
+
+  execute_process(
+    COMMAND "${PKGCONF_EXECUTABLE}" --modversion ${ARGN}
+    OUTPUT_VARIABLE _pkgconf_version
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(${_prefix}_VERSION "${_pkgconf_version}" PARENT_SCOPE)
+
+  execute_process(
+    COMMAND "${PKGCONF_EXECUTABLE}" --cflags-only-I ${ARGN}
+    OUTPUT_VARIABLE _pkgconf_cflags_I
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  separate_arguments(_pkgconf_cflags_I_list UNIX_COMMAND "${_pkgconf_cflags_I}")
+  set(_pkgconf_include_dirs "")
+  foreach(_flag ${_pkgconf_cflags_I_list})
+    string(REGEX REPLACE "^-I" "" _dir "${_flag}")
+    list(APPEND _pkgconf_include_dirs "${_dir}")
+  endforeach()
+  set(${_prefix}_INCLUDE_DIRS "${_pkgconf_include_dirs}" PARENT_SCOPE)
+
+  execute_process(
+    COMMAND "${PKGCONF_EXECUTABLE}" --cflags-only-other ${ARGN}
+    OUTPUT_VARIABLE _pkgconf_cflags_other
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  separate_arguments(_pkgconf_cflags_other UNIX_COMMAND "${_pkgconf_cflags_other}")
+  set(${_prefix}_CFLAGS_OTHER "${_pkgconf_cflags_other}" PARENT_SCOPE)
+
+  execute_process(
+    COMMAND "${PKGCONF_EXECUTABLE}" --cflags ${ARGN}
+    OUTPUT_VARIABLE _pkgconf_cflags
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  separate_arguments(_pkgconf_cflags UNIX_COMMAND "${_pkgconf_cflags}")
+  set(${_prefix}_CFLAGS "${_pkgconf_cflags}" PARENT_SCOPE)
+
+  execute_process(
+    COMMAND "${PKGCONF_EXECUTABLE}" --libs-only-L ${ARGN}
+    OUTPUT_VARIABLE _pkgconf_libs_L
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  separate_arguments(_pkgconf_libs_L_list UNIX_COMMAND "${_pkgconf_libs_L}")
+  set(_pkgconf_library_dirs "")
+  foreach(_flag ${_pkgconf_libs_L_list})
+    string(REGEX REPLACE "^-L" "" _dir "${_flag}")
+    list(APPEND _pkgconf_library_dirs "${_dir}")
+  endforeach()
+  set(${_prefix}_LIBRARY_DIRS "${_pkgconf_library_dirs}" PARENT_SCOPE)
+
+  execute_process(
+    COMMAND "${PKGCONF_EXECUTABLE}" --libs-only-l ${ARGN}
+    OUTPUT_VARIABLE _pkgconf_libs_l
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  separate_arguments(_pkgconf_libs_l_list UNIX_COMMAND "${_pkgconf_libs_l}")
+  set(_pkgconf_libraries "")
+  foreach(_flag ${_pkgconf_libs_l_list})
+    string(REGEX REPLACE "^-l" "" _lib "${_flag}")
+    list(APPEND _pkgconf_libraries "${_lib}")
+  endforeach()
+  set(${_prefix}_LIBRARIES "${_pkgconf_libraries}" PARENT_SCOPE)
+
+  execute_process(
+    COMMAND "${PKGCONF_EXECUTABLE}" --libs-only-other ${ARGN}
+    OUTPUT_VARIABLE _pkgconf_ldflags_other
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  separate_arguments(_pkgconf_ldflags_other UNIX_COMMAND "${_pkgconf_ldflags_other}")
+  set(${_prefix}_LDFLAGS_OTHER "${_pkgconf_ldflags_other}" PARENT_SCOPE)
+
+  execute_process(
+    COMMAND "${PKGCONF_EXECUTABLE}" --libs ${ARGN}
+    OUTPUT_VARIABLE _pkgconf_ldflags
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  separate_arguments(_pkgconf_ldflags UNIX_COMMAND "${_pkgconf_ldflags}")
+  set(${_prefix}_LDFLAGS "${_pkgconf_ldflags}" PARENT_SCOPE)
+endfunction()
+
+function(_pkgconf_define_imported_target _prefix)
+  if(NOT TARGET PkgConf::${_prefix})
+    add_library(PkgConf::${_prefix} INTERFACE IMPORTED)
+    set_target_properties(PkgConf::${_prefix} PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${${_prefix}_INCLUDE_DIRS}"
+      INTERFACE_COMPILE_OPTIONS "${${_prefix}_CFLAGS_OTHER}"
+      INTERFACE_LINK_DIRECTORIES "${${_prefix}_LIBRARY_DIRS}"
+      INTERFACE_LINK_LIBRARIES "${${_prefix}_LIBRARIES}"
+      INTERFACE_LINK_OPTIONS "${${_prefix}_LDFLAGS_OTHER}")
+  endif()
+endfunction()
+
+set(_pkgconf_module_set_options
+  REQUIRED QUIET IMPORTED_TARGET
+  STATIC SHARED ENV_ONLY NO_UNINSTALLED NO_PROVIDES IGNORE_CONFLICTS)
+set(_pkgconf_module_set_one_value_args MAXIMUM_TRAVERSE_DEPTH)
+set(_pkgconf_module_set_multi_value_args DEFINE_VARIABLE WITH_PATH)
+
+macro(pkgconf_check_modules _prefix)
+  cmake_parse_arguments("${_prefix}_ARG"
+    "${_pkgconf_module_set_options}"
+    "${_pkgconf_module_set_one_value_args}"
+    "${_pkgconf_module_set_multi_value_args}"
+    ${ARGN})
+
+  _pkgconf_common_args(_pkgconf_extra_args "${_prefix}_ARG")
+  _pkgconf_invoke("${_prefix}" "${${_prefix}_ARG_QUIET}" "${${_prefix}_ARG_UNPARSED_ARGUMENTS}"
+    ${_pkgconf_extra_args} ${${_prefix}_ARG_UNPARSED_ARGUMENTS})
+
+  if(NOT ${_prefix}_FOUND)
+    if(${_prefix}_ARG_REQUIRED)
+      message(FATAL_ERROR "pkgconf: required module(s) \"${${_prefix}_ARG_UNPARSED_ARGUMENTS}\" were not found")
+    endif()
+  elseif(${_prefix}_ARG_IMPORTED_TARGET)
+    _pkgconf_define_imported_target("${_prefix}")
+  endif()
+
+  unset(_pkgconf_extra_args)
+  foreach(_pkgconf_opt ${_pkgconf_module_set_options})
+    unset(${_prefix}_ARG_${_pkgconf_opt})
+  endforeach()
+  foreach(_pkgconf_opt ${_pkgconf_module_set_one_value_args} ${_pkgconf_module_set_multi_value_args})
+    unset(${_prefix}_ARG_${_pkgconf_opt})
+  endforeach()
+  unset(${_prefix}_ARG_UNPARSED_ARGUMENTS)
+  unset(_pkgconf_opt)
+endmacro()
+
+macro(pkgconf_search_module _prefix)
+  cmake_parse_arguments("${_prefix}_ARG"
+    "${_pkgconf_module_set_options}"
+    "${_pkgconf_module_set_one_value_args}"
+    "${_pkgconf_module_set_multi_value_args}"
+    ${ARGN})
+
+  _pkgconf_common_args(_pkgconf_extra_args "${_prefix}_ARG")
+
+  set(${_prefix}_FOUND FALSE)
+  set(${_prefix}_MODULE_NAME "")
+
+  foreach(_pkgconf_candidate ${${_prefix}_ARG_UNPARSED_ARGUMENTS})
+    if(NOT ${_prefix}_FOUND)
+      _pkgconf_invoke("${_prefix}" TRUE "${_pkgconf_candidate}" ${_pkgconf_extra_args} "${_pkgconf_candidate}")
+      if(${_prefix}_FOUND)
+        set(${_prefix}_MODULE_NAME "${_pkgconf_candidate}")
+      endif()
+    endif()
+  endforeach()
+  unset(_pkgconf_candidate)
+
+  if(NOT ${_prefix}_FOUND)
+    if(${_prefix}_ARG_REQUIRED)
+      message(FATAL_ERROR "pkgconf: none of the required module alternatives \"${${_prefix}_ARG_UNPARSED_ARGUMENTS}\" were found")
+    elseif(NOT ${_prefix}_ARG_QUIET)
+      message(STATUS "pkgconf: none of the module alternatives \"${${_prefix}_ARG_UNPARSED_ARGUMENTS}\" were found")
+    endif()
+  elseif(${_prefix}_ARG_IMPORTED_TARGET)
+    _pkgconf_define_imported_target("${_prefix}")
+  endif()
+
+  unset(_pkgconf_extra_args)
+  foreach(_pkgconf_opt ${_pkgconf_module_set_options})
+    unset(${_prefix}_ARG_${_pkgconf_opt})
+  endforeach()
+  foreach(_pkgconf_opt ${_pkgconf_module_set_one_value_args} ${_pkgconf_module_set_multi_value_args})
+    unset(${_prefix}_ARG_${_pkgconf_opt})
+  endforeach()
+  unset(${_prefix}_ARG_UNPARSED_ARGUMENTS)
+  unset(_pkgconf_opt)
+endmacro()
+
+function(pkgconf_get_variable _out_var _module _varname)
+  execute_process(
+    COMMAND "${PKGCONF_EXECUTABLE}" "--variable=${_varname}" "${_module}"
+    OUTPUT_VARIABLE _pkgconf_out
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(${_out_var} "${_pkgconf_out}" PARENT_SCOPE)
+endfunction()
+
+function(pkgconf_variable_names _out_var _module)
+  execute_process(
+    COMMAND "${PKGCONF_EXECUTABLE}" --print-variables "${_module}"
+    OUTPUT_VARIABLE _pkgconf_out
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string(REPLACE "\n" ";" _pkgconf_out "${_pkgconf_out}")
+  set(${_out_var} "${_pkgconf_out}" PARENT_SCOPE)
+endfunction()
+
+function(pkgconf_get_path _out_var _module)
+  execute_process(
+    COMMAND "${PKGCONF_EXECUTABLE}" --path "${_module}"
+    OUTPUT_VARIABLE _pkgconf_out
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(${_out_var} "${_pkgconf_out}" PARENT_SCOPE)
+endfunction()
+
+function(pkgconf_check_version _out_var _module _mode _version)
+  if(_mode STREQUAL "ATLEAST")
+    set(_flag "--atleast-version=${_version}")
+  elseif(_mode STREQUAL "EXACT")
+    set(_flag "--exact-version=${_version}")
+  elseif(_mode STREQUAL "MAX")
+    set(_flag "--max-version=${_version}")
+  else()
+    message(FATAL_ERROR "pkgconf_check_version: mode must be one of ATLEAST, EXACT, MAX (got \"${_mode}\")")
+  endif()
+
+  execute_process(
+    COMMAND "${PKGCONF_EXECUTABLE}" "${_flag}" "${_module}"
+    RESULT_VARIABLE _pkgconf_result
+    OUTPUT_QUIET ERROR_QUIET)
+
+  if(_pkgconf_result EQUAL 0)
+    set(${_out_var} TRUE PARENT_SCOPE)
+  else()
+    set(${_out_var} FALSE PARENT_SCOPE)
+  endif()
+endfunction()
+
+function(pkgconf_print_provides _out_var _module)
+  execute_process(
+    COMMAND "${PKGCONF_EXECUTABLE}" --print-provides "${_module}"
+    OUTPUT_VARIABLE _pkgconf_out
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string(REPLACE "\n" ";" _pkgconf_out "${_pkgconf_out}")
+  set(${_out_var} "${_pkgconf_out}" PARENT_SCOPE)
+endfunction()
+
+function(pkgconf_print_requires _out_var _module)
+  cmake_parse_arguments(_pkgconf_req "PRIVATE" "" "" ${ARGN})
+  if(_pkgconf_req_PRIVATE)
+    set(_flag "--print-requires-private")
+  else()
+    set(_flag "--print-requires")
+  endif()
+  execute_process(
+    COMMAND "${PKGCONF_EXECUTABLE}" "${_flag}" "${_module}"
+    OUTPUT_VARIABLE _pkgconf_out
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string(REPLACE "\n" ";" _pkgconf_out "${_pkgconf_out}")
+  set(${_out_var} "${_pkgconf_out}" PARENT_SCOPE)
+endfunction()
+
+function(pkgconf_link_abi _out_var _module)
+  cmake_parse_arguments(_pkgconf_abi "STATIC" "" "" ${ARGN})
+  set(_flag_args --link-abi)
+  if(_pkgconf_abi_STATIC)
+    list(APPEND _flag_args --static)
+  endif()
+  execute_process(
+    COMMAND "${PKGCONF_EXECUTABLE}" ${_flag_args} "${_module}"
+    OUTPUT_VARIABLE _pkgconf_out
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string(REPLACE "\n" ";" _pkgconf_out "${_pkgconf_out}")
+  set(${_out_var} "${_pkgconf_out}" PARENT_SCOPE)
+endfunction()
+
+function(pkgconf_list_all _out_var)
+  execute_process(
+    COMMAND "${PKGCONF_EXECUTABLE}" --list-all
+    OUTPUT_VARIABLE _pkgconf_out
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string(REPLACE "\n" ";" _pkgconf_out "${_pkgconf_out}")
+  set(${_out_var} "${_pkgconf_out}" PARENT_SCOPE)
+endfunction()

--- a/cmake/tests/basic/CMakeLists.txt
+++ b/cmake/tests/basic/CMakeLists.txt
@@ -1,0 +1,63 @@
+# Tests pkgconf-config.cmake against pkgconf's own installed libpkgconf.pc, so
+# it doesn't depend on any third-party .pc file being present.
+#
+# CI configures pkgconf with -Dwith-system-libdir=/some-marker-that-cannot-exist
+# so libpkgconf's own libdir stays in --libs-only-L output. pkgconf otherwise
+# drops -L for dirs matching its compiled-in SYSTEM_LIBDIR, which defaults to
+# the install prefix's libdir -- where this test installs libpkgconf.
+
+cmake_minimum_required(VERSION 3.13)
+project(pkgconf_cmake_macros_test C)
+
+find_package(pkgconf REQUIRED CONFIG)
+message(STATUS "pkgconf_VERSION = ${pkgconf_VERSION}")
+if(NOT pkgconf_VERSION)
+  message(FATAL_ERROR "pkgconf_VERSION was not set by find_package(pkgconf CONFIG)")
+endif()
+
+pkgconf_check_modules(LIBPKGCONF REQUIRED IMPORTED_TARGET libpkgconf)
+if(NOT LIBPKGCONF_FOUND)
+  message(FATAL_ERROR "pkgconf_check_modules() failed to find libpkgconf")
+endif()
+if(NOT LIBPKGCONF_INCLUDE_DIRS)
+  message(FATAL_ERROR "LIBPKGCONF_INCLUDE_DIRS was not populated")
+endif()
+if(NOT LIBPKGCONF_LIBRARIES)
+  message(FATAL_ERROR "LIBPKGCONF_LIBRARIES was not populated")
+endif()
+
+add_executable(consumer consumer.c)
+target_link_libraries(consumer PRIVATE PkgConf::LIBPKGCONF)
+
+# pkgconf_search_module() should skip the nonexistent alternative and pick the real one.
+pkgconf_search_module(LIBPKGCONF2 REQUIRED this-module-does-not-exist-xyz libpkgconf)
+if(NOT LIBPKGCONF2_MODULE_NAME STREQUAL "libpkgconf")
+  message(FATAL_ERROR "pkgconf_search_module() picked the wrong module: \"${LIBPKGCONF2_MODULE_NAME}\"")
+endif()
+
+# Without REQUIRED, a missing module should not fail configure.
+pkgconf_check_modules(MISSING QUIET this-module-does-not-exist-xyz)
+if(MISSING_FOUND)
+  message(FATAL_ERROR "pkgconf_check_modules() reported FOUND for a module that does not exist")
+endif()
+
+pkgconf_get_variable(LIBPKGCONF_PCFILEDIR libpkgconf pcfiledir)
+if(NOT LIBPKGCONF_PCFILEDIR)
+  message(FATAL_ERROR "pkgconf_get_variable() returned an empty value")
+endif()
+
+pkgconf_check_version(LIBPKGCONF_ATLEAST_0 libpkgconf ATLEAST 0)
+if(NOT LIBPKGCONF_ATLEAST_0)
+  message(FATAL_ERROR "pkgconf_check_version(ATLEAST 0) should be TRUE")
+endif()
+
+pkgconf_check_version(LIBPKGCONF_ATLEAST_999 libpkgconf ATLEAST 999.0)
+if(LIBPKGCONF_ATLEAST_999)
+  message(FATAL_ERROR "pkgconf_check_version(ATLEAST 999.0) should be FALSE")
+endif()
+
+pkgconf_variable_names(LIBPKGCONF_VARNAMES libpkgconf)
+list(FIND LIBPKGCONF_VARNAMES "includedir" _libpkgconf_varnames_idx)
+if(_libpkgconf_varnames_idx EQUAL -1)
+  message(FATAL_ERROR "pkgconf_variable_names() did not include \"includedir\"")
+endif()

--- a/cmake/tests/basic/consumer.c
+++ b/cmake/tests/basic/consumer.c
@@ -1,0 +1,10 @@
+#include <libpkgconf/libpkgconf.h>
+#include <stdio.h>
+
+int
+main(void)
+{
+    int cmp = pkgconf_compare_version("1.0", "1.0");
+	  printf("pkgconf_compare_version(\"1.0\", \"1.0\") = %d\n", cmp);
+	  return cmp == 0 ? 0 : 1;
+}

--- a/cmake/tests/required-fail/CMakeLists.txt
+++ b/cmake/tests/required-fail/CMakeLists.txt
@@ -1,0 +1,8 @@
+# pkgconf_check_modules(... REQUIRED ...) should fail configure (nonzero exit)
+# for a module that does not exist. CI runs this and expects it to fail.
+
+cmake_minimum_required(VERSION 3.13)
+project(pkgconf_cmake_macros_required_fail_test C)
+
+find_package(pkgconf REQUIRED CONFIG)
+pkgconf_check_modules(MISSING REQUIRED this-module-does-not-exist-xyz)

--- a/cmake/tests/zlib/CMakeLists.txt
+++ b/cmake/tests/zlib/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Tests the pkgconf cmake macros against a real third-party package, zlib,
+# found through its installed zlib.pc. The basic test only queries pkgconf's
+# own libpkgconf.pc, so this covers the more usual case of consuming a .pc
+# file that ships with some other library.
+
+cmake_minimum_required(VERSION 3.13)
+project(pkgconf_cmake_macros_zlib_test C)
+
+find_package(pkgconf REQUIRED CONFIG)
+
+pkgconf_check_modules(ZLIB REQUIRED IMPORTED_TARGET zlib)
+if(NOT ZLIB_FOUND)
+  message(FATAL_ERROR "pkgconf_check_modules() failed to find zlib")
+endif()
+if(NOT ZLIB_VERSION)
+  message(FATAL_ERROR "ZLIB_VERSION was not set for a found module")
+endif()
+message(STATUS "ZLIB_VERSION = ${ZLIB_VERSION}")
+
+# Rely entirely on the imported target so the include dirs, link dirs and
+# -lz coming out of the macros all have to be correct for this to build/run.
+add_executable(zlib-consumer consumer.c)
+target_link_libraries(zlib-consumer PRIVATE PkgConf::ZLIB)

--- a/cmake/tests/zlib/consumer.c
+++ b/cmake/tests/zlib/consumer.c
@@ -1,0 +1,25 @@
+#include <zlib.h>
+#include <stdio.h>
+#include <string.h>
+
+int
+main(void)
+{
+	const char *input = "the quick brown fox jumps over the lazy dog";
+	unsigned char compressed[128];
+	unsigned char restored[128];
+	uLong compressed_len = sizeof(compressed);
+	uLong restored_len = sizeof(restored);
+
+	printf("zlib version %s\n", zlibVersion());
+
+	/* Round-trip a buffer so a broken -I/-L/-l from the macros shows up as a
+	   link or runtime failure rather than passing silently. */
+	if (compress(compressed, &compressed_len,
+	    (const unsigned char *) input, strlen(input) + 1) != Z_OK)
+		return 1;
+	if (uncompress(restored, &restored_len, compressed, compressed_len) != Z_OK)
+		return 1;
+
+	return strcmp(input, (const char *) restored) == 0 ? 0 : 1;
+}

--- a/meson.build
+++ b/meson.build
@@ -443,6 +443,23 @@ foreach t : test_suites
     depends : [pkgconf_exe, spdxtool_exe, bomtool_exe, pccritic_exe])
 endforeach
 
+cmake_conf_data = configuration_data()
+cmake_conf_data.set('PKGCONF_BINDIR', join_paths(get_option('prefix'), get_option('bindir')))
+cmake_conf_data.set('PKGCONF_VERSION', meson.project_version())
+
+pkgconf_cmake_config = configure_file(
+  input : 'cmake/pkgconf-config.cmake.in',
+  output : 'pkgconf-config.cmake',
+  configuration : cmake_conf_data,
+)
+pkgconf_cmake_config_version = configure_file(
+  input : 'cmake/pkgconf-config-version.cmake.in',
+  output : 'pkgconf-config-version.cmake',
+  configuration : cmake_conf_data,
+)
+install_data(pkgconf_cmake_config, pkgconf_cmake_config_version,
+  install_dir : join_paths(get_option('libdir'), 'cmake', 'pkgconf'))
+
 install_man('man/bomtool.1')
 install_man('man/pkgconf.1')
 install_man('man/pkg.m4.7')


### PR DESCRIPTION
Add `cmake`/`pkgconf-config.cmake(.in)`, installed by meson to `$libdir/cmake/pkgconf`, so projects can locate pkgconf with `find_package(pkgconf CONFIG)` and query modules through it.

This CMake module provides `pkgconf_check_modules()` and `pkgconf_search_module()`, modelled on CMake's ownFindPkgConfig.cmake. However, it always uses pkgconf instead of whatever pkg-config is first on $PATH. This also provides thin wrappers over the single-module pkgconf options (`--variable``, `--print-variables`, `--path`, version checks, `--print-provides`, `--print-requires`, `--link-abi`, `--list-all`). `IMPORTED_TARGET` builds a `PkgConf::<prefix>` interface target from the resulting flags.

A cmake-macros CI job builds and installs pkgconf, then exercises the macros against pkgconf's own `libpkgconf.pc` and a real third-party package (zlib), and checks that a `REQUIRED` nonexistent module fails configure. The CI job runs on Linux (static and shared) and macOS.