### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ By submitting a patch, you affirm that:
 * You can account for how the contribution was produced.
 
 Submitting contributions that you do not understand, cannot explain
-or cannot clearly attribute may be treated as harrassment per the
+or cannot clearly attribute may be treated as harassment per the
 pkgconf [Code of Conduct][coc].
 
 Contributions produced primarily by autonomous or agentic systems

--- a/NEWS
+++ b/NEWS
@@ -410,7 +410,7 @@ Changes from 2.0.0 to 2.0.1:
 
   The order of --modversion output is based on the dependency resolution
   queue which is passed to the solver, which itself generally maps to the
-  order of the constrants provided on the command line.
+  order of the constraints provided on the command line.
 
 * A new flag, --verbose, has been added.  When used with `--modversion`, it
   is possible to disambiguate which version belongs to which module:

--- a/cli/bomtool/main.c
+++ b/cli/bomtool/main.c
@@ -226,7 +226,7 @@ write_sbom_package(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *unused, u
 	OUTPUT_OR_RET(client, sbom_out, "PackageVersion: %s\n", pkg->version);
 	OUTPUT_OR_RET(client, sbom_out, "PackageDownloadLocation: NOASSERTION\n");
 
-	/* NOASSERTION is not a valide value for PackageVerificationCode. It
+	/* NOASSERTION is not a valid value for PackageVerificationCode. It
 	 * expect 40 lowercase hexadecimal digits.
 	 */
 #if 0

--- a/cli/spdxtool/software.c
+++ b/cli/spdxtool/software.c
@@ -45,7 +45,7 @@ out:
  *    :param pkgconf_client_t *client: The pkgconf client being accessed.
  *    :param const char *spdx_id: spdxId for this SBOM element
  *    :param const char *creation_id: id for CreationInfo
- *    :param const char *sbom_type: Sbom types can be found SPDX documention
+ *    :param const char *sbom_type: Sbom types can be found SPDX documentation
  *    :return: NULL if some problem occurs and Sbom struct if not
  */
 spdxtool_software_sbom_t *

--- a/cli/spdxtool/util.c
+++ b/cli/spdxtool/util.c
@@ -21,7 +21,7 @@
  *
  * .. c:function:: void spdxtool_util_set_key(pkgconf_client_t *client, const char *key, const char *key_value, const char *key_default)
  *
- *    Set key wit default value. Default value is used if key is NULL
+ *    Set key with default value. Default value is used if key is NULL
  *
  *    :param pkgconf_client_t* client: The pkgconf client being accessed.
  *    :param const char *key: Key to be preserved

--- a/libpkgconf/bsdstubs.c
+++ b/libpkgconf/bsdstubs.c
@@ -21,7 +21,7 @@
 #else
 /*
  * Creates a memory buffer and copies at most 'len' characters to it.
- * If 'len' is less than the length of the source string, truncation occured.
+ * If 'len' is less than the length of the source string, truncation occurred.
  */
 static inline char *
 pkgconf_strndup_impl(const char *src, size_t len)

--- a/libpkgconf/client.c
+++ b/libpkgconf/client.c
@@ -954,7 +954,7 @@ pkgconf_client_set_output(pkgconf_client_t *client, pkgconf_output_t *output)
  *    Looks up an environmental variable which may be mocked, otherwise fetches
  *    from the main environment.
  *
- *    :param pkgconf_client_t* client: yhe client object to use for looking up environmental variables.
+ *    :param pkgconf_client_t* client: the client object to use for looking up environmental variables.
  *    :param char* key: the environmental variable to look up.
  *    :return: the environmental variable contents else NULL
  *    :rtype: const char*

--- a/libpkgconf/pkg.c
+++ b/libpkgconf/pkg.c
@@ -1627,7 +1627,7 @@ pkgconf_pkg_walk_list(pkgconf_client_t *client,
 		if((pkgdep->flags & PKGCONF_PKG_PROPF_ANCESTOR) != 0)
 		{
 			/* In this case we have a circular reference.
-			 * We break that by deleteing the circular node from the
+			 * We break that by deleting the circular node from the
 			 * the list, so that we dont create a situation where
 			 * memory is leaked due to circular ownership.
 			 * i.e: A owns B owns A

--- a/man/spdxtool.1
+++ b/man/spdxtool.1
@@ -19,12 +19,12 @@
 .Ar module ...
 .Sh DESCRIPTION
 .Nm
-is a program which generates a JSON-LD formated SPDX Lite 3.0.1 software bill of
+is a program which generates a JSON-LD formatted SPDX Lite 3.0.1 software bill of
 materials (SBOM) for a given set of pkg-config modules.
 The output of this tool can then be translated into other SBOM
 formats as necessary.
 
-More documention about SDPX 3.0.1 can be found from:
+More documentation about SDPX 3.0.1 can be found from:
 .Lk https://spdx.github.io/spdx-spec/v3.0.1/
 .Pp
 The
@@ -46,7 +46,7 @@ Set agent name-property
 in /Core/Agent-class. Default is 'Default'
 .It Fl -creation-time
 Set create-property time in /Core/CreationInfo-class.
-SPDX documentation recomends using ISO 8601-formated time which is: YYYY-MM-DDThh:mm:ssZ.
+SPDX documentation recommends using ISO 8601-formatted time which is: YYYY-MM-DDThh:mm:ssZ.
 Default is document creation time.
 This takes precedence over the
 .Ev SOURCE_DATE_EPOCH

--- a/tests/lib1/depgraph-break.pc
+++ b/tests/lib1/depgraph-break.pc
@@ -9,4 +9,4 @@ Version: 1.2.3
 Libs: -L${libdir} -lfoo
 Cflags: -fPIC -I${includedir}/foo
 Cflags.private: -DFOO_STATIC
-Requires: nonexistant
+Requires: nonexistent


### PR DESCRIPTION
Fix typos discovered by codespell - https://pypi.org/project/codespell

% `codespell --ignore-words-list=atleast,nd,pard,shatow,siz`

% `codespell --ignore-words-list=atleast,nd,pard,shatow,siz --write-changes`