### PR TITLE
pkgconf.manifest.in: Set longPathAware to true

### DIFF
--- a/pkgconf.manifest.in
+++ b/pkgconf.manifest.in
@@ -4,6 +4,7 @@
   <application>
     <windowsSettings>
       <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+      <longPathAware  xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </windowsSettings>
   </application>
 </assembly>


### PR DESCRIPTION
Since Windows Version 1607, if we specify longPathAware in the manifest, it remove the limitation of MAX_PATH (when using fopen or any other API that is manipulating file/directory, the path could be maximum 260 characters).

For more information, see: https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation