### PR TITLE
spdxtool: serialize suppliedBy as a scalar Agent reference

### DIFF
--- a/cli/spdxtool/software.c
+++ b/cli/spdxtool/software.c
@@ -330,7 +330,6 @@ spdxtool_software_package_to_object(pkgconf_client_t *client, pkgconf_pkg_t *pkg
 	spdxtool_serialize_value_t *ret = NULL;
 	spdxtool_serialize_object_list_t *object_list = NULL;
 	spdxtool_serialize_array_t *originated_by = NULL;
-	spdxtool_serialize_array_t *supplied_by = NULL;
 	char *creation_info = NULL;
 	char *spdx_id = NULL;
 	char *agent = NULL;
@@ -377,20 +376,8 @@ spdxtool_software_package_to_object(pkgconf_client_t *client, pkgconf_pkg_t *pkg
 		goto err;
 
 	supplier = spdxtool_util_tuple_lookup(client, &pkg->vars, "suppliedBy");
-	if (supplier)
-	{
-		supplied_by = spdxtool_serialize_array_new();
-		if (!supplied_by)
-			goto err;
-
-		if (!spdxtool_serialize_array_add_string(supplied_by, supplier))
-			goto err;
-
-		ok = spdxtool_serialize_object_add_array(object_list, "suppliedBy", supplied_by);
-		supplied_by = NULL;
-		if (!ok)
-			goto err;
-	}
+	if (supplier && !spdxtool_serialize_object_add_string(object_list, "suppliedBy", supplier))
+		goto err;
 
 	if (!serialize_copyright_lines_to_object(object_list, &pkg->copyright))
 		goto err;
@@ -600,6 +587,5 @@ err:
 	}
 	spdxtool_serialize_object_list_free(object_list);
 	spdxtool_serialize_array_free(originated_by);
-	spdxtool_serialize_array_free(supplied_by);
 	return ret;
 }

--- a/tests/lib-sbom-files/agent_name.json
+++ b/tests/lib-sbom-files/agent_name.json
@@ -60,9 +60,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/myagent"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/test3_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/test3_maintainer",
             "software_copyrightText": "Test3 copyright text",
             "software_homePage": "https://github.com/pkgconf/pkgconf/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",

--- a/tests/lib-sbom-files/agent_name_space.json
+++ b/tests/lib-sbom-files/agent_name_space.json
@@ -60,9 +60,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/my_agent"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/test3_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/test3_maintainer",
             "software_copyrightText": "Test3 copyright text",
             "software_homePage": "https://github.com/pkgconf/pkgconf/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",

--- a/tests/lib-sbom-files/basic-spdx-base-id.json
+++ b/tests/lib-sbom-files/basic-spdx-base-id.json
@@ -60,9 +60,7 @@
             "originatedBy": [
                 "https://distfiles.ariadne.space/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://distfiles.ariadne.space/pkgconf/Agent/test3_maintainer"
-            ],
+            "suppliedBy": "https://distfiles.ariadne.space/pkgconf/Agent/test3_maintainer",
             "software_copyrightText": "Test3 copyright text",
             "software_homePage": "https://github.com/pkgconf/pkgconf/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",

--- a/tests/lib-sbom-files/basic-use-uri.json
+++ b/tests/lib-sbom-files/basic-use-uri.json
@@ -60,9 +60,7 @@
             "originatedBy": [
                 "github.com:pkgconf:pkgconf:Agent:default"
             ],
-            "suppliedBy": [
-                "github.com:pkgconf:pkgconf:Agent:test3_maintainer"
-            ],
+            "suppliedBy": "github.com:pkgconf:pkgconf:Agent:test3_maintainer",
             "software_copyrightText": "Test3 copyright text",
             "software_homePage": "https://github.com/pkgconf/pkgconf/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",

--- a/tests/lib-sbom-files/basic.json
+++ b/tests/lib-sbom-files/basic.json
@@ -60,9 +60,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/test3_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/test3_maintainer",
             "software_copyrightText": "Test3 copyright text",
             "software_homePage": "https://github.com/pkgconf/pkgconf/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",

--- a/tests/lib-sbom-files/creation_id.json
+++ b/tests/lib-sbom-files/creation_id.json
@@ -60,9 +60,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/test3_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/test3_maintainer",
             "software_copyrightText": "Test3 copyright text",
             "software_homePage": "https://github.com/pkgconf/pkgconf/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",

--- a/tests/lib-sbom-files/define_variable.json
+++ b/tests/lib-sbom-files/define_variable.json
@@ -60,9 +60,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/variabletest1_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/variabletest1_maintainer",
             "software_copyrightText": "NOASSERTION",
             "software_homePage": "https://github.com/pkgconf/pkgconf/releases/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",

--- a/tests/lib-sbom-files/define_variable_with_dependency.json
+++ b/tests/lib-sbom-files/define_variable_with_dependency.json
@@ -88,9 +88,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/variabletest2_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/variabletest2_maintainer",
             "software_copyrightText": "NOASSERTION",
             "software_homePage": "https://github.com/pkgconf/pkgconf/releases/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",
@@ -104,9 +102,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/variabletest1_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/variabletest1_maintainer",
             "software_copyrightText": "NOASSERTION",
             "software_homePage": "https://github.com/pkgconf/pkgconf/releases/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",

--- a/tests/lib-sbom-files/meta_package-use-uri-spdx-base-id.json
+++ b/tests/lib-sbom-files/meta_package-use-uri-spdx-base-id.json
@@ -219,9 +219,7 @@
             "originatedBy": [
                 "distfiles.ariadne.space:pkgconf:Agent:default"
             ],
-            "suppliedBy": [
-                "distfiles.ariadne.space:pkgconf:Agent:meta_maintainer"
-            ],
+            "suppliedBy": "distfiles.ariadne.space:pkgconf:Agent:meta_maintainer",
             "software_copyrightText": "NOASSERTION",
             "software_homePage": "https://github.com/pkgconf/pkgconf",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",
@@ -235,9 +233,7 @@
             "originatedBy": [
                 "distfiles.ariadne.space:pkgconf:Agent:default"
             ],
-            "suppliedBy": [
-                "distfiles.ariadne.space:pkgconf:Agent:test1_maintainer"
-            ],
+            "suppliedBy": "distfiles.ariadne.space:pkgconf:Agent:test1_maintainer",
             "software_copyrightText": "Test1 copyright text",
             "software_homePage": "",
             "software_downloadLocation": "",
@@ -251,9 +247,7 @@
             "originatedBy": [
                 "distfiles.ariadne.space:pkgconf:Agent:default"
             ],
-            "suppliedBy": [
-                "distfiles.ariadne.space:pkgconf:Agent:test2_maintainer"
-            ],
+            "suppliedBy": "distfiles.ariadne.space:pkgconf:Agent:test2_maintainer",
             "software_copyrightText": "NOASSERTION",
             "software_homePage": "https://github.com/pkgconf/pkgconf/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",
@@ -267,9 +261,7 @@
             "originatedBy": [
                 "distfiles.ariadne.space:pkgconf:Agent:default"
             ],
-            "suppliedBy": [
-                "distfiles.ariadne.space:pkgconf:Agent:test3_maintainer"
-            ],
+            "suppliedBy": "distfiles.ariadne.space:pkgconf:Agent:test3_maintainer",
             "software_copyrightText": "Test3 copyright text",
             "software_homePage": "https://github.com/pkgconf/pkgconf/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",
@@ -283,9 +275,7 @@
             "originatedBy": [
                 "distfiles.ariadne.space:pkgconf:Agent:default"
             ],
-            "suppliedBy": [
-                "distfiles.ariadne.space:pkgconf:Agent:test4_maintainer"
-            ],
+            "suppliedBy": "distfiles.ariadne.space:pkgconf:Agent:test4_maintainer",
             "software_copyrightText": "NOASSERTION",
             "software_homePage": "https://github.com/pkgconf/pkgconf/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",
@@ -299,9 +289,7 @@
             "originatedBy": [
                 "distfiles.ariadne.space:pkgconf:Agent:default"
             ],
-            "suppliedBy": [
-                "distfiles.ariadne.space:pkgconf:Agent:test5_maintainer"
-            ],
+            "suppliedBy": "distfiles.ariadne.space:pkgconf:Agent:test5_maintainer",
             "software_copyrightText": "NOASSERTION",
             "software_homePage": "https://github.com/pkgconf/pkgconf/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",
@@ -315,9 +303,7 @@
             "originatedBy": [
                 "distfiles.ariadne.space:pkgconf:Agent:default"
             ],
-            "suppliedBy": [
-                "distfiles.ariadne.space:pkgconf:Agent:test6_maintainer"
-            ],
+            "suppliedBy": "distfiles.ariadne.space:pkgconf:Agent:test6_maintainer",
             "software_copyrightText": "NOASSERTION",
             "software_homePage": "https://github.com/pkgconf/pkgconf/releases/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",

--- a/tests/lib-sbom-files/meta_package.json
+++ b/tests/lib-sbom-files/meta_package.json
@@ -219,9 +219,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/meta_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/meta_maintainer",
             "software_copyrightText": "NOASSERTION",
             "software_homePage": "https://github.com/pkgconf/pkgconf",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",
@@ -235,9 +233,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/test1_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/test1_maintainer",
             "software_copyrightText": "Test1 copyright text",
             "software_homePage": "",
             "software_downloadLocation": "",
@@ -251,9 +247,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/test2_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/test2_maintainer",
             "software_copyrightText": "NOASSERTION",
             "software_homePage": "https://github.com/pkgconf/pkgconf/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",
@@ -267,9 +261,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/test3_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/test3_maintainer",
             "software_copyrightText": "Test3 copyright text",
             "software_homePage": "https://github.com/pkgconf/pkgconf/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",
@@ -283,9 +275,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/test4_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/test4_maintainer",
             "software_copyrightText": "NOASSERTION",
             "software_homePage": "https://github.com/pkgconf/pkgconf/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",
@@ -299,9 +289,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/test5_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/test5_maintainer",
             "software_copyrightText": "NOASSERTION",
             "software_homePage": "https://github.com/pkgconf/pkgconf/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",
@@ -315,9 +303,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/test6_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/test6_maintainer",
             "software_copyrightText": "NOASSERTION",
             "software_homePage": "https://github.com/pkgconf/pkgconf/releases/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",

--- a/tests/lib-sbom-files/multi_copyright.json
+++ b/tests/lib-sbom-files/multi_copyright.json
@@ -60,9 +60,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/mc_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/mc_maintainer",
             "software_copyrightText": "First copyright holder\nSecond copyright holder",
             "software_homePage": "https://example.com/mc",
             "software_downloadLocation": "",

--- a/tests/lib-sbom-files/multiple_packages.json
+++ b/tests/lib-sbom-files/multiple_packages.json
@@ -87,9 +87,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/test5_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/test5_maintainer",
             "software_copyrightText": "NOASSERTION",
             "software_homePage": "https://github.com/pkgconf/pkgconf/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",
@@ -103,9 +101,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/test6_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/test6_maintainer",
             "software_copyrightText": "NOASSERTION",
             "software_homePage": "https://github.com/pkgconf/pkgconf/releases/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",

--- a/tests/lib-sbom-files/nolicense.json
+++ b/tests/lib-sbom-files/nolicense.json
@@ -52,9 +52,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/nolicense_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/nolicense_maintainer",
             "software_copyrightText": "Nolicense copyright text",
             "software_homePage": "https://example.com/nolicense",
             "software_downloadLocation": "https://example.com/nolicense/nolicense-1.0.0.tar.gz",

--- a/tests/lib-sbom-files/private_dependency.json
+++ b/tests/lib-sbom-files/private_dependency.json
@@ -82,9 +82,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/privparent_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/privparent_maintainer",
             "software_copyrightText": "NOASSERTION",
             "software_homePage": "https://example.com/priv-parent",
             "software_downloadLocation": "",
@@ -98,9 +96,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/privchild_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/privchild_maintainer",
             "software_copyrightText": "NOASSERTION",
             "software_homePage": "https://example.com/priv-child",
             "software_downloadLocation": "",

--- a/tests/lib-sbom-files/special.json
+++ b/tests/lib-sbom-files/special.json
@@ -60,9 +60,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/special_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/special_maintainer",
             "software_copyrightText": "Quote \" backslash \\ and\ttab",
             "software_homePage": "https://example.com/special",
             "software_downloadLocation": "",

--- a/tests/lib-sbom-files/with_dependency.json
+++ b/tests/lib-sbom-files/with_dependency.json
@@ -88,9 +88,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/test2_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/test2_maintainer",
             "software_copyrightText": "NOASSERTION",
             "software_homePage": "https://github.com/pkgconf/pkgconf/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",
@@ -104,9 +102,7 @@
             "originatedBy": [
                 "https://github.com/pkgconf/pkgconf/Agent/default"
             ],
-            "suppliedBy": [
-                "https://github.com/pkgconf/pkgconf/Agent/test3_maintainer"
-            ],
+            "suppliedBy": "https://github.com/pkgconf/pkgconf/Agent/test3_maintainer",
             "software_copyrightText": "Test3 copyright text",
             "software_homePage": "https://github.com/pkgconf/pkgconf/",
             "software_downloadLocation": "https://github.com/pkgconf/pkgconf/archive/refs/tags/pkgconf-2.5.1.tar.gz",


### PR DESCRIPTION
SPDX 3.0.1 defines [Artifact.suppliedBy](https://spdx.github.io/spdx-spec/v3.0.1/model/Core/Classes/Artifact/) with a maximum cardinality of one. Accordingly, the official JSON schema expects a single Agent reference rather than an array.

Serialize suppliedBy directly as a string instead of wrapping it in a one-element array. This makes the generated JSON-LD structurally conformant for this property and removes the unnecessary array allocation and cleanup.

Update the expected SBOM output fixtures to reflect the corrected representation.