### PR TITLE
Avoid space in MSI INSTALLFOLDER

### DIFF
--- a/pkgconf.wxs.in
+++ b/pkgconf.wxs.in
@@ -19,7 +19,7 @@
       </Feature>
 
       <StandardDirectory Id="ProgramFiles6432Folder">
-          <Directory Id="INSTALLFOLDER" Name="pkgconf @VERSION@" />
+          <Directory Id="INSTALLFOLDER" Name="pkgconf-@VERSION@" />
       </StandardDirectory>
 
       <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">


### PR DESCRIPTION
Probably a debatable improvement:

I try to use the official MSI package for vcpkg.
The package is not installed, but extracted with `msiexec` as "administrative" installation.
This gives a runnable `pkgconf.exe` and `pccritic.exe`, but...
The filepath always contain a space due to the `pkgconf 3.0.x` directory.
When the filepath is passed literally into autotools builds via the `PKG_CONFIG` environment variable, at least some builds will not be able to invoke pkgconf because their scripts expand space into multiple words.

Among various ways to resolve the issue, there is one simple mitigation:
Avoid the space.
