### PR TITLE
bomtool: do not emit PackageDownloadLocation twice

### DIFF
--- a/cli/bomtool/main.c
+++ b/cli/bomtool/main.c
@@ -224,7 +224,6 @@ write_sbom_package(pkgconf_client_t *client, pkgconf_pkg_t *pkg, void *unused, u
 	OUTPUT_OR_RET(client, sbom_out, "PackageName: %s\n", sbom_identity(pkg));
 	OUTPUT_OR_RET(client, sbom_out, "SPDXID: SPDXRef-Package-%s\n", sbom_spdx_identity(pkg));
 	OUTPUT_OR_RET(client, sbom_out, "PackageVersion: %s\n", pkg->version);
-	OUTPUT_OR_RET(client, sbom_out, "PackageDownloadLocation: NOASSERTION\n");
 
 	/* NOASSERTION is not a valid value for PackageVerificationCode. It
 	 * expect 40 lowercase hexadecimal digits.

--- a/tests/lib-sbom-files/bomtool-basic.txt
+++ b/tests/lib-sbom-files/bomtool-basic.txt
@@ -12,7 +12,6 @@ Created: test
 PackageName: test3@3.0.0
 SPDXID: SPDXRef-Package-test3C403.0.0
 PackageVersion: 3.0.0
-PackageDownloadLocation: NOASSERTION
 PackageSupplier: Person: Test3 Maintainer
 PackageHomePage: https://github.com/pkgconf/pkgconf/
 PackageLicenseDeclared: BSD-4-Clause

--- a/tests/lib-sbom-files/bomtool-define_variable.txt
+++ b/tests/lib-sbom-files/bomtool-define_variable.txt
@@ -12,7 +12,6 @@ Created: test
 PackageName: variable-test1@1.0-123
 SPDXID: SPDXRef-Package-variable-test1C401.0-123
 PackageVersion: 1.0-123
-PackageDownloadLocation: NOASSERTION
 PackageSupplier: Person: Variabletest1 Maintainer
 PackageHomePage: https://github.com/pkgconf/pkgconf/releases/
 PackageLicenseDeclared: BSD-2-Clause

--- a/tests/lib-sbom-files/bomtool-define_variable_with_dependency.txt
+++ b/tests/lib-sbom-files/bomtool-define_variable_with_dependency.txt
@@ -12,7 +12,6 @@ Created: test
 PackageName: variable-test2@2.0
 SPDXID: SPDXRef-Package-variable-test2C402.0
 PackageVersion: 2.0
-PackageDownloadLocation: NOASSERTION
 PackageSupplier: Person: Variabletest2 Maintainer
 PackageHomePage: https://github.com/pkgconf/pkgconf/releases/
 PackageLicenseDeclared: MIT
@@ -27,7 +26,6 @@ PackageDownloadLocation: https://github.com/pkgconf/pkgconf/archive/refs/tags/pk
 PackageName: variable-test1@1.0-123
 SPDXID: SPDXRef-Package-variable-test1C401.0-123
 PackageVersion: 1.0-123
-PackageDownloadLocation: NOASSERTION
 PackageSupplier: Person: Variabletest1 Maintainer
 PackageHomePage: https://github.com/pkgconf/pkgconf/releases/
 PackageLicenseDeclared: BSD-2-Clause

--- a/tests/lib-sbom-files/bomtool-meta_package.txt
+++ b/tests/lib-sbom-files/bomtool-meta_package.txt
@@ -12,7 +12,6 @@ Created: test
 PackageName: meta_package@1.0.0
 SPDXID: SPDXRef-Package-metaC5fpackageC401.0.0
 PackageVersion: 1.0.0
-PackageDownloadLocation: NOASSERTION
 PackageSupplier: Person: Meta Maintainer
 PackageHomePage: https://github.com/pkgconf/pkgconf
 PackageLicenseDeclared: BSD-2-Clause
@@ -27,7 +26,6 @@ PackageDownloadLocation: https://github.com/pkgconf/pkgconf/archive/refs/tags/pk
 PackageName: test1@1.0.0
 SPDXID: SPDXRef-Package-test1C401.0.0
 PackageVersion: 1.0.0
-PackageDownloadLocation: NOASSERTION
 PackageSupplier: Person: Test1 Maintainer
 PackageLicenseDeclared: BSD-1-Clause
 PackageLicenseConcluded: NOASSERTION
@@ -41,7 +39,6 @@ PackageDownloadLocation: NOASSERTION
 PackageName: test2@2.0.0
 SPDXID: SPDXRef-Package-test2C402.0.0
 PackageVersion: 2.0.0
-PackageDownloadLocation: NOASSERTION
 PackageSupplier: Person: Test2 Maintainer
 PackageHomePage: https://github.com/pkgconf/pkgconf/
 PackageLicenseDeclared: BSD-2-Clause
@@ -56,7 +53,6 @@ PackageDownloadLocation: https://github.com/pkgconf/pkgconf/archive/refs/tags/pk
 PackageName: test3@3.0.0
 SPDXID: SPDXRef-Package-test3C403.0.0
 PackageVersion: 3.0.0
-PackageDownloadLocation: NOASSERTION
 PackageSupplier: Person: Test3 Maintainer
 PackageHomePage: https://github.com/pkgconf/pkgconf/
 PackageLicenseDeclared: BSD-4-Clause
@@ -71,7 +67,6 @@ PackageDownloadLocation: https://github.com/pkgconf/pkgconf/archive/refs/tags/pk
 PackageName: test4@4.0.0
 SPDXID: SPDXRef-Package-test4C404.0.0
 PackageVersion: 4.0.0
-PackageDownloadLocation: NOASSERTION
 PackageSupplier: Person: Test4 Maintainer
 PackageHomePage: https://github.com/pkgconf/pkgconf/
 PackageLicenseDeclared: MIT
@@ -86,7 +81,6 @@ PackageDownloadLocation: https://github.com/pkgconf/pkgconf/archive/refs/tags/pk
 PackageName: test5@5.0.0
 SPDXID: SPDXRef-Package-test5C405.0.0
 PackageVersion: 5.0.0
-PackageDownloadLocation: NOASSERTION
 PackageSupplier: Person: Test5 Maintainer
 PackageHomePage: https://github.com/pkgconf/pkgconf/
 PackageLicenseDeclared: MIT
@@ -101,7 +95,6 @@ PackageDownloadLocation: https://github.com/pkgconf/pkgconf/archive/refs/tags/pk
 PackageName: test6@6.0.0
 SPDXID: SPDXRef-Package-test6C406.0.0
 PackageVersion: 6.0.0
-PackageDownloadLocation: NOASSERTION
 PackageSupplier: Person: Test6 Maintainer
 PackageHomePage: https://github.com/pkgconf/pkgconf/releases/
 PackageLicenseDeclared: Apache-2.0

--- a/tests/lib-sbom-files/bomtool-multiple_packages.txt
+++ b/tests/lib-sbom-files/bomtool-multiple_packages.txt
@@ -12,7 +12,6 @@ Created: test
 PackageName: test5@5.0.0
 SPDXID: SPDXRef-Package-test5C405.0.0
 PackageVersion: 5.0.0
-PackageDownloadLocation: NOASSERTION
 PackageSupplier: Person: Test5 Maintainer
 PackageHomePage: https://github.com/pkgconf/pkgconf/
 PackageLicenseDeclared: MIT
@@ -27,7 +26,6 @@ PackageDownloadLocation: https://github.com/pkgconf/pkgconf/archive/refs/tags/pk
 PackageName: test6@6.0.0
 SPDXID: SPDXRef-Package-test6C406.0.0
 PackageVersion: 6.0.0
-PackageDownloadLocation: NOASSERTION
 PackageSupplier: Person: Test6 Maintainer
 PackageHomePage: https://github.com/pkgconf/pkgconf/releases/
 PackageLicenseDeclared: Apache-2.0

--- a/tests/lib-sbom-files/bomtool-nolicense.txt
+++ b/tests/lib-sbom-files/bomtool-nolicense.txt
@@ -12,7 +12,6 @@ Created: test
 PackageName: nolicense@1.0.0
 SPDXID: SPDXRef-Package-nolicenseC401.0.0
 PackageVersion: 1.0.0
-PackageDownloadLocation: NOASSERTION
 PackageSupplier: Person: Nolicense Maintainer
 PackageHomePage: https://example.com/nolicense
 PackageLicenseDeclared: NOASSERTION

--- a/tests/lib-sbom-files/bomtool-private_dependency.txt
+++ b/tests/lib-sbom-files/bomtool-private_dependency.txt
@@ -12,7 +12,6 @@ Created: test
 PackageName: priv-parent@1.0.0
 SPDXID: SPDXRef-Package-priv-parentC401.0.0
 PackageVersion: 1.0.0
-PackageDownloadLocation: NOASSERTION
 PackageSupplier: Person: Privparent Maintainer
 PackageHomePage: https://example.com/priv-parent
 PackageLicenseDeclared: MIT
@@ -27,7 +26,6 @@ PackageDownloadLocation: NOASSERTION
 PackageName: priv-child@1.0.0
 SPDXID: SPDXRef-Package-priv-childC401.0.0
 PackageVersion: 1.0.0
-PackageDownloadLocation: NOASSERTION
 PackageSupplier: Person: Privchild Maintainer
 PackageHomePage: https://example.com/priv-child
 PackageLicenseDeclared: MIT

--- a/tests/lib-sbom-files/bomtool-special.txt
+++ b/tests/lib-sbom-files/bomtool-special.txt
@@ -12,7 +12,6 @@ Created: test
 PackageName: special@1.0.0
 SPDXID: SPDXRef-Package-specialC401.0.0
 PackageVersion: 1.0.0
-PackageDownloadLocation: NOASSERTION
 PackageSupplier: Person: Special Maintainer
 PackageHomePage: https://example.com/special
 PackageLicenseDeclared: MIT

--- a/tests/lib-sbom-files/bomtool-with_dependency.txt
+++ b/tests/lib-sbom-files/bomtool-with_dependency.txt
@@ -12,7 +12,6 @@ Created: test
 PackageName: test2@2.0.0
 SPDXID: SPDXRef-Package-test2C402.0.0
 PackageVersion: 2.0.0
-PackageDownloadLocation: NOASSERTION
 PackageSupplier: Person: Test2 Maintainer
 PackageHomePage: https://github.com/pkgconf/pkgconf/
 PackageLicenseDeclared: BSD-2-Clause
@@ -27,7 +26,6 @@ PackageDownloadLocation: https://github.com/pkgconf/pkgconf/archive/refs/tags/pk
 PackageName: test3@3.0.0
 SPDXID: SPDXRef-Package-test3C403.0.0
 PackageVersion: 3.0.0
-PackageDownloadLocation: NOASSERTION
 PackageSupplier: Person: Test3 Maintainer
 PackageHomePage: https://github.com/pkgconf/pkgconf/
 PackageLicenseDeclared: BSD-4-Clause


### PR DESCRIPTION
SPDX 2.2 section 7.7 gives PackageDownloadLocation a cardinality of 1..1, but `write_sbom_package()` emits it twice for every package.