### PR TITLE
man page: adjust text for recent --variable changes

### DIFF
--- a/man/pkgconf.1
+++ b/man/pkgconf.1
@@ -7,7 +7,7 @@
 .\" This software is provided 'as is' and without any warranty, express or
 .\" implied.  In no event shall the authors be liable for any damages arising
 .\" from the use of this software.
-.Dd July 2, 2026
+.Dd September 8, 2026
 .Dt PKGCONF 1
 .Os
 .Sh NAME
@@ -117,8 +117,7 @@ options:
 .It
 Single-module output options:
 .Fl -path ,
-.Fl -print-variables ,
-.Fl -variable :
+.Fl -print-variables :
 If any of these options is specified, only the first
 .Ar module
 argument is used, all other arguments are silently ignored,
@@ -128,8 +127,9 @@ Depth-one output options:
 .Fl -print-provides ,
 .Fl -modversion ,
 .Fl -print-requires ,
+.Fl -print-requires-private ,
 and
-.Fl -print-requires-private :
+.Fl -variable :
 If any of these options is specified, only modules
 explicitly specified on the command line are inspected
 and no dependency resolution is attempted.
@@ -589,12 +589,11 @@ This option implies
 and
 .Fl -errors-to-stdout .
 .It Fl -variable Ns = Ns Ar varname
-For the first
-.Ar module
-given on the command line, print the value of the variable with the name
+For each specified
+.Ar module ,
+print the value of the variable with the name
 .Ar varname
-to standard output.
-Any subsequent arguments are silently ignored.
+to standard output in command-line order.
 This option implies
 .Fl -maximum-traverse-depth Ns =1
 and overrides and disables all


### PR DESCRIPTION
It now prints the variables of all passed modules, not just the first one.

See https://github.com/pkgconf/pkgconf/issues/576#issuecomment-5391344806

----

As a draft since the new behaviour is weird. There is no way to map the output to the input modules if spaces are involved, so I'm having a hard time documenting the form of the output as passing more than one module will result in ambiguous output.